### PR TITLE
SFDCENG-748 : Generate RC1 for SalesForce 2.1.0 compatible with ACS 6.0

### DIFF
--- a/distribution/src/main/resources/VERSIONS.md
+++ b/distribution/src/main/resources/VERSIONS.md
@@ -25,7 +25,7 @@ This file lists the recommended components for this Service Pack. Use it along w
 | Alfresco Media Management | 1.0.3.3 |
 | Alfresco Office Services | @alfresco.aos-module.version@ |
 | SAML Single Sign-On (SSO) for Alfresco Content Services | 1.0.3 |
-| Alfresco Content Connector for Salesforce | 2.0.2.5 |
+| Alfresco Content Connector for Salesforce | 2.1.0-RC1 |
 | Alfresco Kofax Integration | 2.0 |
 | Alfresco S3 Connector | 2.1.0 | 1.3.x |
 | Alfresco EMC Centera Connector | 2.1.1 |


### PR DESCRIPTION
This PR updates the SalesForce Connector version to 2.1.0-RC1 in the VERSIONS.md file.

JIRA issue: https://issues.alfresco.com/jira/browse/SFDCENG-748 
