### PR TITLE
SFDCENG-756 : Generate RC2 for Salesforce 2.1.0 compatible with ACS 6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
         <alfresco.centera-connector.version>2.2.0-RC1</alfresco.centera-connector.version>
 
         <!-- Alfresco Salesforce Connector version -->
-        <alfresco.salesforce-connector.version>2.1.0-RC1</alfresco.salesforce-connector.version>
+        <alfresco.salesforce-connector.version>2.1.0-RC2</alfresco.salesforce-connector.version>
 
         <!-- Alfresco Kofax Connector version -->
         <alfresco.kofax.version>2.0.0</alfresco.kofax.version>


### PR DESCRIPTION
    - update the SF connector version to 2.1.0-RC2