### PR TITLE
GOOGLEDOCS-437 : Generate Final Build for GoogleDocs 3.1.0 compatible…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         <alfresco.alfresco-share-services.version>6.0.0-rc5</alfresco.alfresco-share-services.version>
 
         <!-- Alfresco GoogleDocs integration version -->
-        <alfresco.googledocs.version>3.1.0-RC2</alfresco.googledocs.version>
+        <alfresco.googledocs.version>3.1.0</alfresco.googledocs.version>
 
         <!-- Alfresco S3 Connector integration version -->
         <alfresco.s3connector.version>2.2.0-RC2</alfresco.s3connector.version>


### PR DESCRIPTION
… with ACS Ent 6.0

   - updated googledocs version

Green build on branch: https://bamboo.alfresco.com/bamboo/browse/PLAT-ACS44