### PR TITLE
REPO-3590: 6.0: Include Document Transformation Engine amp into "all amps" test

### DIFF
--- a/docker-alfresco/test/docker-alfresco-all-amps-test/pom.xml
+++ b/docker-alfresco/test/docker-alfresco-all-amps-test/pom.xml
@@ -262,6 +262,22 @@
                                     <overWrite>false</overWrite>
                                     <outputDirectory>${project.build.directory}/amps_share</outputDirectory>
                                 </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.alfresco</groupId>
+                                    <artifactId>alfresco-document-transformation-engine-repo</artifactId>
+                                    <version>${alfresco.transformation-engine.version}</version>
+                                    <type>amp</type>
+                                    <overWrite>false</overWrite>
+                                    <outputDirectory>${project.build.directory}/amps</outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.alfresco</groupId>
+                                    <artifactId>alfresco-document-transformation-engine-share</artifactId>
+                                    <version>${alfresco.transformation-engine.version}</version>
+                                    <type>amp</type>
+                                    <overWrite>false</overWrite>
+                                    <outputDirectory>${project.build.directory}/amps_share</outputDirectory>
+                                </artifactItem>
                             </artifactItems>
                         </configuration>
                     </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
         <alfresco.outlook.version>2.4.2</alfresco.outlook.version>
 
         <!-- Document Transformation Engine -->
-        <alfresco.transformation-engine.version>2.1.1</alfresco.transformation-engine.version>
+        <alfresco.transformation-engine.version>2.2.0</alfresco.transformation-engine.version>
 
         <!-- Alfresco Records Management -->
         <alfresco.records-management.version>2.5.2</alfresco.records-management.version>
@@ -592,6 +592,18 @@
                 <groupId>org.alfresco.mediamanagement</groupId>
                 <artifactId>alfresco-mm-share</artifactId>
                 <version>${alfresco.mm.version}</version>
+                <type>amp</type>
+            </dependency>
+            <dependency>
+                <groupId>org.alfresco</groupId>
+                <artifactId>alfresco-document-transformation-engine-repo</artifactId>
+                <version>${alfresco.transformation-engine.version}</version>
+                <type>amp</type>
+            </dependency>
+            <dependency>
+                <groupId>org.alfresco</groupId>
+                <artifactId>alfresco-document-transformation-engine-share</artifactId>
+                <version>${alfresco.transformation-engine.version}</version>
                 <type>amp</type>
             </dependency>
         </dependencies>


### PR DESCRIPTION
- added Document Transformation Engine amp to the list of applied amps. Updated version to 2.2.0