### PR TITLE
REPO-3590: 6.0: Include Document Transformation Engine amp into "all amps" test

### DIFF
--- a/docker-alfresco/test/docker-alfresco-all-amps-test/Dockerfile
+++ b/docker-alfresco/test/docker-alfresco-all-amps-test/Dockerfile
@@ -49,4 +49,4 @@ RUN mkdir /usr/local/tomcat/webapps/ROOT && cd /usr/local/tomcat/webapps/ROOT &&
 # Add catalina.policy to ROOT.war and alfresco.war
 # Grant all security permissions to alfresco webapp because of numerous permissions required in order to work properly.
 # Grant only deployXmlPermission to ROOT webapp.
-    sed -i -e "\$a\grant\ codeBase\ \"file:\$\{catalina.base\}\/webapps\/alfresco\/-\" \{\n\    permission\ java.security.AllPermission\;\n\};\ngrant\ codeBase\ \"file:\$\{catalina.base\}\/webapps\/ROOT\/-\" \{\n\    permission org.apache.catalina.security.DeployXmlPermission \"ROOT\";\n\};" /usr/local/tomcat/conf/catalina.policy
+    sed -i -e "\$a\grant\ codeBase\ \"file:\$\{catalina.base\}\/webapps\/alfresco\/-\" \{\n\    permission\ java.security.AllPermission\;\n\};\ngrant\ codeBase\ \"file:\$\{catalina.base\}\/webapps\/ROOT\/-\" \{\n\    permission org.apache.catalina.security.DeployXmlPermission \"ROOT\";\n\};\ngrant\ codeBase\ \"file:\$\{catalina.base\}\/webapps\/share\/-\" \{\n\    permission\ java.security.AllPermission\;\n\};" /usr/local/tomcat/conf/catalina.policy

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
         <alfresco.outlook.version>2.4.2</alfresco.outlook.version>
 
         <!-- Document Transformation Engine -->
-        <alfresco.transformation-engine.version>2.2.0</alfresco.transformation-engine.version>
+        <alfresco.transformation-engine.version>2.2.1</alfresco.transformation-engine.version>
 
         <!-- Alfresco Records Management -->
         <alfresco.records-management.version>2.5.2</alfresco.records-management.version>


### PR DESCRIPTION
- fixed share on all amps test image (share was not starting)
- update DTS version because 2.2.0 is not available on nexus