### PR TITLE
REPO-4135: upgrade hazelcast to the latest version 3.11.2 

### DIFF
--- a/docker-alfresco/test/docker-alfresco-all-amps-test/pom.xml
+++ b/docker-alfresco/test/docker-alfresco-all-amps-test/pom.xml
@@ -260,6 +260,8 @@
                                     <overWrite>false</overWrite>
                                     <outputDirectory>${project.build.directory}/amps</outputDirectory>
                                 </artifactItem>
+                                <!--
+                                Uncomment this when REPO-4233 is fixed and we have a compatible saml module
                                 <artifactItem>
                                     <groupId>org.alfresco.saml</groupId>
                                     <artifactId>alfresco-saml-repo</artifactId>
@@ -276,6 +278,7 @@
                                     <overWrite>false</overWrite>
                                     <outputDirectory>${project.build.directory}/amps_share</outputDirectory>
                                 </artifactItem>
+                                -->
                                 <artifactItem>
                                     <groupId>org.alfresco.mediamanagement</groupId>
                                     <artifactId>alfresco-mm-repo</artifactId>

--- a/docker-alfresco/test/docker-alfresco-all-amps-test/pom.xml
+++ b/docker-alfresco/test/docker-alfresco-all-amps-test/pom.xml
@@ -279,6 +279,8 @@
                                     <outputDirectory>${project.build.directory}/amps_share</outputDirectory>
                                 </artifactItem>
                                 -->
+                                <!--
+                                Uncomment this when MM-785 is fixed and we have a compatible MM module
                                 <artifactItem>
                                     <groupId>org.alfresco.mediamanagement</groupId>
                                     <artifactId>alfresco-mm-repo</artifactId>
@@ -295,6 +297,7 @@
                                     <overWrite>false</overWrite>
                                     <outputDirectory>${project.build.directory}/amps_share</outputDirectory>
                                 </artifactItem>
+                                 -->
                                 <artifactItem>
                                     <groupId>org.alfresco</groupId>
                                     <artifactId>alfresco-document-transformation-engine-repo</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
         <dependency.alfresco-hb-data-sender.version>1.0.10</dependency.alfresco-hb-data-sender.version>
 
         <dependency.alfresco-enterprise-repository.version>7.29</dependency.alfresco-enterprise-repository.version>
-        <dependency.alfresco-enterprise-remote-api.version>7.22</dependency.alfresco-enterprise-remote-api.version>
+        <dependency.alfresco-enterprise-remote-api.version>7.23</dependency.alfresco-enterprise-remote-api.version>
 
         <dependency.alfresco-spring-encryptor.version>6.1</dependency.alfresco-spring-encryptor.version>
         <dependency.alfresco-enterprise-crypto.version>6.1</dependency.alfresco-enterprise-crypto.version>
@@ -621,7 +621,7 @@
             <dependency>
                 <groupId>com.hazelcast</groupId>
                 <artifactId>hazelcast</artifactId>
-                <version>3.9.2</version>
+                <version>3.11.2</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
This means removing the SAML and MM module from the all-amps docker image and tests since they need to be fixed and released separatly