### PR TITLE
APPSREPO-651 : [Security] MNT-20533: activemq-client MitM vulnerability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <dependency.alfresco-trashcan-cleaner.version>2.3</dependency.alfresco-trashcan-cleaner.version>
         <dependency.alfresco-jlan.version>7.1</dependency.alfresco-jlan.version>
         <dependency.alfresco-server-root.version>6.0.1</dependency.alfresco-server-root.version>
-        <dependency.alfresco-messaging-repo.version>1.2.9</dependency.alfresco-messaging-repo.version>
+        <dependency.alfresco-messaging-repo.version>1.2.13</dependency.alfresco-messaging-repo.version>
 
         <dependency.spring.version>5.1.0.RELEASE</dependency.spring.version>
         <dependency.fabric8.version>3.5.37</dependency.fabric8.version>


### PR DESCRIPTION
    - updated alfresco-messaging-repo to version 1.2.13 which brings camel libs 2.23.2 and activemq libs 5.15.9