### PR TITLE
REPO-4369: Add org.apache.camel dependencies, version 2.23.2

### DIFF
--- a/docker-alfresco/test/docker-alfresco-all-amps-test/scripts/checkLibraryDuplicates.sh
+++ b/docker-alfresco/test/docker-alfresco-all-amps-test/scripts/checkLibraryDuplicates.sh
@@ -2,24 +2,44 @@
 
 # Script used to check for duplicated libraries after applying all amps
 
-Libdir=$1
-lib_list=""
-echo "Scanning libraries from $Libdir"
+# List of library names (separated by space) for which the version is not easy to identify with simple pattern matching,
+# usually libraries with versions that don't follow naming/versioning standards.
+# e.g. geronimo-jms_2.0_spec-1.0-alpha-2.jar
+#      geronimo-jms_1.1_spec-1.1.1.jar
+WHITELIST="geronimo-jms"
 
-for lib1 in $(ls "$Libdir"); do
-    if [[ "$lib1" =~ [0-9]+.[0-9] ]]; then
-        noversion="${lib1%%"$BASH_REMATCH"*}"
-        for lib2 in $(ls -I "$lib1" "$Libdir"); do
-            if [[ "$lib2" = "$noversion"[0-9].* ]]; then
-                lib_list="$lib_list $lib1"
-            fi
-        done
-    fi
+lib_dir=$1
+multiple_version_lib_list=""
+
+echo "Scanning libraries from $lib_dir"
+echo "Skipping libraries which match the whitelist, check for false positives:"
+
+for current_lib in $(ls "$lib_dir"); do
+   if [[ "$current_lib" =~ [0-9]+.[0-9] ]]; then
+       noversion_lib="${current_lib%%"$BASH_REMATCH"*}"
+
+       skip=false
+       for exclude_lib in $WHITELIST; do
+           if [[ "$noversion_lib" =~ "$exclude_lib" ]]; then
+               skip=true
+               break
+           fi
+       done
+       if [[ "$skip" = true ]]; then
+           echo "Skip $current_lib"
+           continue
+       fi
+       for other_lib in $(ls --ignore="$current_lib" "$lib_dir"); do
+           if [[ "$other_lib" = "$noversion_lib"[0-9].* ]]; then
+               multiple_version_lib_list="$multiple_version_lib_list $current_lib"
+           fi
+       done
+   fi
 done
 
-if [ -n "$lib_list" ]; then
-    >&2 echo "The following libraries have more than one version: $lib_list"
-    exit 1
+if [[ -n "$multiple_version_lib_list" ]]; then
+   >&2 echo "[ERROR] The following libraries have more than one version: $multiple_version_lib_list"
+   exit 1
 else
-    echo "There are no duplicated libraries"
+   echo "[INFO] There are no duplicated libraries."
 fi

--- a/docker-alfresco/test/docker-alfresco-all-amps-test/scripts/checkLibraryDuplicates.sh
+++ b/docker-alfresco/test/docker-alfresco-all-amps-test/scripts/checkLibraryDuplicates.sh
@@ -12,7 +12,9 @@ lib_dir=$1
 multiple_version_lib_list=""
 
 echo "Scanning libraries from $lib_dir"
-echo "Skipping libraries which match the whitelist, check for false positives:"
+if [[ -n "$WHITELIST" ]]; then
+    echo "Skipping libraries which match the whitelist, check for false positives:"
+fi
 
 for current_lib in $(ls "$lib_dir"); do
    if [[ "$current_lib" =~ [0-9]+.[0-9] ]]; then
@@ -29,7 +31,8 @@ for current_lib in $(ls "$lib_dir"); do
            echo "Skip $current_lib"
            continue
        fi
-       for other_lib in $(ls --ignore="$current_lib" "$lib_dir"); do
+       
+       for other_lib in $(gls --ignore="$current_lib" "$lib_dir"); do
            if [[ "$other_lib" = "$noversion_lib"[0-9].* ]]; then
                multiple_version_lib_list="$multiple_version_lib_list $current_lib"
            fi

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,7 @@
         <dependency.spring.version>5.1.0.RELEASE</dependency.spring.version>
         <dependency.fabric8.version>3.5.37</dependency.fabric8.version>
         <dependency.jackson.version>2.9.8</dependency.jackson.version>
+        <dependency.camel.version>2.23.2</dependency.camel.version>
 
         <!-- Alfresco Share version -->
         <alfresco.share.version>6.0.1.1</alfresco.share.version>
@@ -432,6 +433,27 @@
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-email</artifactId>
                 <version>1.5</version>
+            </dependency>
+            <!-- Newer Camel, see REPO-4355 -->
+            <dependency>
+                <groupId>org.apache.camel</groupId>
+                <artifactId>camel-core</artifactId>
+                <version>${dependency.camel.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.camel</groupId>
+                <artifactId>camel-jackson</artifactId>
+                <version>${dependency.camel.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.camel</groupId>
+                <artifactId>camel-spring</artifactId>
+                <version>${dependency.camel.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.camel</groupId>
+                <artifactId>camel-amqp</artifactId>
+                <version>${dependency.camel.version}</version>
             </dependency>
             <!-- Make sure JUnit is not packaged -->
             <dependency>


### PR DESCRIPTION
Added `org.apache.camel dependencies`, version 2.23.2
After the upgrade, the test on the duplicate library failed, but it was not a valid case, so I did some changes to the script that does this duplication check:
* added a whitelist of library names, in order to fix the false positives that are reported for libraries that don't follow naming/versioning standards.
* refactored the script, for consistent naming style.