### PR TITLE
Add a whitelist of library names, to the script that checks for duplicate libraries

### DIFF
--- a/docker-alfresco/test/docker-alfresco-all-amps-test/scripts/checkLibraryDuplicates.sh
+++ b/docker-alfresco/test/docker-alfresco-all-amps-test/scripts/checkLibraryDuplicates.sh
@@ -2,24 +2,47 @@
 
 # Script used to check for duplicated libraries after applying all amps
 
-Libdir=$1
-lib_list=""
-echo "Scanning libraries from $Libdir"
+# List of library names (separated by space) for which the version is not easy to identify with simple pattern matching,
+# usually libraries with versions that don't follow naming/versioning standards.
+# e.g. geronimo-jms_2.0_spec-1.0-alpha-2.jar
+#      geronimo-jms_1.1_spec-1.1.1.jar
+WHITELIST=""
 
-for lib1 in $(ls "$Libdir"); do
-    if [[ "$lib1" =~ [0-9]+.[0-9] ]]; then
-        noversion="${lib1%%"$BASH_REMATCH"*}"
-        for lib2 in $(ls -I "$lib1" "$Libdir"); do
-            if [[ "$lib2" = "$noversion"[0-9].* ]]; then
-                lib_list="$lib_list $lib1"
-            fi
-        done
-    fi
+lib_dir=$1
+multiple_version_lib_list=""
+
+echo "Scanning libraries from $lib_dir"
+if [[ -n "$WHITELIST" ]]; then
+    echo "Skipping libraries which match the whitelist, check for false positives:"
+fi
+
+for current_lib in $(ls "$lib_dir"); do
+   if [[ "$current_lib" =~ [0-9]+.[0-9] ]]; then
+       noversion_lib="${current_lib%%"$BASH_REMATCH"*}"
+
+       skip=false
+       for exclude_lib in $WHITELIST; do
+           if [[ "$noversion_lib" =~ "$exclude_lib" ]]; then
+               skip=true
+               break
+           fi
+       done
+       if [[ "$skip" = true ]]; then
+           echo "Skip $current_lib"
+           continue
+       fi
+
+       for other_lib in $(ls --ignore="$current_lib" "$lib_dir"); do
+           if [[ "$other_lib" = "$noversion_lib"[0-9].* ]]; then
+               multiple_version_lib_list="$multiple_version_lib_list $current_lib"
+           fi
+       done
+   fi
 done
 
-if [ -n "$lib_list" ]; then
-    >&2 echo "The following libraries have more than one version: $lib_list"
-    exit 1
+if [[ -n "$multiple_version_lib_list" ]]; then
+   >&2 echo "[ERROR] The following libraries have more than one version: $multiple_version_lib_list"
+   exit 1
 else
-    echo "There are no duplicated libraries"
+   echo "[INFO] There are no duplicated libraries."
 fi


### PR DESCRIPTION
Added a whitelist of library names, to the script that checks for duplicate libraries, empty for now, but could be useful to bypass false positives reported for libraries that don't follow naming/versioning standards (this is used on 6.0.N branch already).
Refactored the script, for consistent naming style.