### PR TITLE
REPO-4278 Service Pack: MNT-18557 Location Of alfresco.log is Ultimately Incorrect

### DIFF
--- a/docker-alfresco/Dockerfile
+++ b/docker-alfresco/Dockerfile
@@ -58,8 +58,11 @@ COPY ${resource_path}/amps ${TOMCAT_DIR}/amps
 RUN java -jar ${TOMCAT_DIR}/alfresco-mmt/alfresco-mmt*.jar install \
               ${TOMCAT_DIR}/amps ${TOMCAT_DIR}/webapps/alfresco -directory -nobackup -force
 
-# Make webapps folder read-only.
-RUN chmod -R =r ${TOMCAT_DIR}/webapps && \
+# Move the log file and make webapps folder read-only.
+RUN sed -i -e "s_log4j.appender.File.File\=alfresco.log_log4j.appender.File.File\=${TOMCAT_DIR}/logs\/alfresco.log_" \
+        ${TOMCAT_DIR}/webapps/alfresco/WEB-INF/classes/log4j.properties && \
+    chmod -R =r ${TOMCAT_DIR}/webapps && \
+
 # Add catalina.policy to ROOT.war and alfresco.war
 # Grant all security permissions to alfresco webapp because of numerous permissions required in order to work properly.
 # Grant only deployXmlPermission to ROOT webapp.
@@ -87,7 +90,6 @@ RUN mkdir -p ${TOMCAT_DIR}/conf/Catalina/localhost && \
     groupadd -g ${GROUPID} ${GROUPNAME} && \
     useradd -u ${USERID} -G ${GROUPNAME} ${USERNAME} && \
     chgrp -R ${GROUPNAME} ${TOMCAT_DIR} && \
-    chmod g+w ${TOMCAT_DIR}/logs && \
     chmod g+rx ${TOMCAT_DIR}/conf && \
     chmod -R g+r ${TOMCAT_DIR}/conf && \
     find ${TOMCAT_DIR}/webapps -type d -exec chmod 0750 {} \; && \
@@ -96,13 +98,10 @@ RUN mkdir -p ${TOMCAT_DIR}/conf/Catalina/localhost && \
     chmod g+r ${TOMCAT_DIR}/conf/Catalina && \
     chmod g+rwx ${TOMCAT_DIR}/alf_data && \
     chmod g+rwx ${TOMCAT_DIR}/logs && \
+    chmod o-w ${TOMCAT_DIR}/logs && \
     chmod g+rwx ${TOMCAT_DIR}/temp && \
     chmod g+rwx ${TOMCAT_DIR}/work && \
-
-# After MNT-18557 is fixed we need to uncomment the appender change and remove the write access on the tomcat dir.
-#    sed -i -e "s_log4j.appender.File.File\=alfresco.log_log4j.appender.File.File\=${TOMCAT_DIR}/logs\/alfresco.log_" \ 
-#        ${TOMCAT_DIR}/webapps/alfresco/WEB-INF/classes/log4j.properties && \
-    chmod g+w ${TOMCAT_DIR} && \
+    chmod o-w ${TOMCAT_DIR}/work && \
 
     # Configure YourKit Java Profiler access
     chgrp -R ${GROUPNAME} ${JAVA_PROFILER_DIR} && \

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
 
         <dependency.alfresco-hb-data-sender.version>1.0.10</dependency.alfresco-hb-data-sender.version>
 
-        <dependency.alfresco-enterprise-repository.version>7.log.32</dependency.alfresco-enterprise-repository.version>
+        <dependency.alfresco-enterprise-repository.version>7.32</dependency.alfresco-enterprise-repository.version>
         <dependency.alfresco-enterprise-remote-api.version>7.27</dependency.alfresco-enterprise-remote-api.version>
 
         <dependency.alfresco-spring-encryptor.version>6.1</dependency.alfresco-spring-encryptor.version>

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
 
         <dependency.alfresco-hb-data-sender.version>1.0.10</dependency.alfresco-hb-data-sender.version>
 
-        <dependency.alfresco-enterprise-repository.version>7.31</dependency.alfresco-enterprise-repository.version>
+        <dependency.alfresco-enterprise-repository.version>7.log.32</dependency.alfresco-enterprise-repository.version>
         <dependency.alfresco-enterprise-remote-api.version>7.27</dependency.alfresco-enterprise-remote-api.version>
 
         <dependency.alfresco-spring-encryptor.version>6.1</dependency.alfresco-spring-encryptor.version>

--- a/war/src/main/resources/log4j.properties
+++ b/war/src/main/resources/log4j.properties
@@ -1,8 +1,15 @@
 # Set root logger level to error
-log4j.rootLogger=error, Console, File
+log4j.rootLogger=error, Console, File, jmxlogger1
+
+###### jmxlogger appender definition #######
+log4j.appender.jmxlogger1=jmxlogger.integration.log4j.JmxLogAppender
+log4j.appender.jmxlogger1.layout=org.apache.log4j.PatternLayout
+log4j.appender.jmxlogger1.layout.ConversionPattern=%-5p [%c] [%t] %m%n
+log4j.appender.jmxlogger1.ObjectName=jmxlogger:type=LogEmitterAlfresco
+log4j.appender.jmxlogger1.threshold=debug
+log4j.appender.jmxlogger1.serverSelection=platform
 
 ###### Console appender definition #######
-
 # All outputs currently set to be a ConsoleAppender.
 log4j.appender.Console=org.apache.log4j.ConsoleAppender
 log4j.appender.Console.layout=org.apache.log4j.PatternLayout

--- a/war/src/main/resources/log4j.properties
+++ b/war/src/main/resources/log4j.properties
@@ -278,3 +278,18 @@ log4j.logger.org.alfresco.repo.content.transform.TikaPoweredContentTransformer=i
 
 # Repository probes
 log4j.logger.org.alfresco.rest.api.probes.ProbeEntityResource=info
+
+# Enterprise repository heartbeat
+log4j.logger.org.alfresco.enterprise.heartbeat=info
+
+log4j.logger.org.alfresco.enterprise.repo.admin.indexcheck.ADMIndexCheckServiceImpl=info
+
+# Hybrid (Cloud) Sync
+log4j.logger.org.alfresco.enterprise.repo.sync=info
+log4j.logger.org.alfresco.enterprise.repo.web.scripts.sync=info
+
+# Cryptodoc logging
+log4j.logger.org.alfresco.module.cryptodoc=WARN
+
+# License
+log4j.logger.org.alfresco.enterprise.license=info


### PR DESCRIPTION
Integrated the jmxlogger into the log4j.properties file from acs-packaging. 
jmxlogger was previously configured in the alfresco-enterprise-repository project (in a repository-log4j.properties file that was removed with this fix)
Also, in the docker image, I moved the alfresco.log file to the tomcat/logs folder and fixed the permissions for the folders to make the docker image more secure