### PR TITLE
REPO-4400: Moving keystore folder contents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ alfresco/*
 *.iml
 *.iws
 
+#VScode
+/.vscode
+
 # Mac
 .DS_Store
 

--- a/distribution/src/main/resources/keystore/CreateSSLKeystores.txt
+++ b/distribution/src/main/resources/keystore/CreateSSLKeystores.txt
@@ -1,0 +1,141 @@
+Instructions for Generating Repository SSL Keystores
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+<store password> is the keystore password. The file ${dir.keystore}/ssl-keystore-passwords.properties contains passwords for the SSL keystore,
+${dir.keystore}/ssl-truststore-passwords.properties contains passwords for the SSL truststore.
+
+These instructions will create an RSA public/private key pair for the repository with a certificate that has been signed by the Alfresco Certificate Authority (CA).
+It will also create a truststore for the repository containing the CA certificate; this will be used to authenticate connections to specific repository
+URLs from Solr. It assumes the existence of the Alfresco CA key and certificate to sign the repository certificate; for security reasons these are not generally available.
+You can either generate your own CA key and certificate (see instructions below) or use a recognised Certificate Authority such as Verisign. For Alfresco employees the key
+and certificate are available in svn.
+
+(i) Generate the repository public/private key pair in a keystore:
+
+$ keytool -genkey -alias ssl.repo -keyalg RSA -keystore ssl.keystore -storetype JCEKS -storepass <store password>
+Enter keystore password:  
+Re-enter new password: 
+What is your first and last name?
+  [Unknown]:  Alfresco Repository
+What is the name of your organizational unit?
+  [Unknown]:  
+What is the name of your organization?
+  [Unknown]:  Alfresco Software Ltd.
+What is the name of your City or Locality?
+  [Unknown]:  Maidenhead 
+What is the name of your State or Province?
+  [Unknown]:  UK
+What is the two-letter country code for this unit?
+  [Unknown]:  GB
+Is CN=Alfresco Repository, OU=Unknown, O=Alfresco Software Ltd., L=Maidenhead, ST=UK, C=GB correct?
+  [no]:  yes
+
+Enter key password for <ssl.repo>
+	(RETURN if same as keystore password):  
+	
+(ii) Generate a certificate request for the repository key
+
+$ keytool -keystore ssl.keystore -alias ssl.repo -certreq -file repo.csr -storetype JCEKS -storepass <store password>
+
+(iii) Alfresco CA signs the certificate request, creating a certificate that is valid for 365 days.
+
+$ openssl x509 -CA ca.crt -CAkey ca.key -CAcreateserial -req -in repo.csr -out repo.crt -days 365
+Signature ok
+subject=/C=GB/ST=UK/L=Maidenhead/O=Alfresco Software Ltd./OU=Unknown/CN=Alfresco Repository
+Getting CA Private Key
+Enter pass phrase for ca.key:
+
+(iv) Import the Alfresco CA key into the repository key store
+
+$ keytool -import -alias ssl.alfreco.ca -file ca.crt -keystore ssl.keystore -storetype JCEKS -storepass <store password>
+Enter keystore password:  
+Owner: CN=Alfresco CA, O=Alfresco Software Ltd., L=Maidenhead, ST=UK, C=GB
+Issuer: CN=Alfresco CA, O=Alfresco Software Ltd., L=Maidenhead, ST=UK, C=GB
+Serial number: 805ba6dc8f62f8b8
+Valid from: Fri Aug 12 13:28:58 BST 2011 until: Mon Aug 09 13:28:58 BST 2021
+Certificate fingerprints:
+	 MD5:  4B:45:94:2D:8E:98:E8:12:04:67:AD:AE:48:3C:F5:A0
+	 SHA1: 74:42:22:D0:52:AD:82:7A:FD:37:46:37:91:91:F4:77:89:3A:C9:A3
+	 Signature algorithm name: SHA1withRSA
+	 Version: 3
+
+Extensions: 
+
+#1: ObjectId: 2.5.29.14 Criticality=false
+SubjectKeyIdentifier [
+KeyIdentifier [
+0000: 08 42 40 DC FE 4A 50 87   05 2B 38 4D 92 70 8E 51  .B@..JP..+8M.p.Q
+0010: 4E 38 71 D6                                        N8q.
+]
+]
+
+#2: ObjectId: 2.5.29.19 Criticality=false
+BasicConstraints:[
+  CA:true
+  PathLen:2147483647
+]
+
+#3: ObjectId: 2.5.29.35 Criticality=false
+AuthorityKeyIdentifier [
+KeyIdentifier [
+0000: 08 42 40 DC FE 4A 50 87   05 2B 38 4D 92 70 8E 51  .B@..JP..+8M.p.Q
+0010: 4E 38 71 D6                                        N8q.
+]
+
+[CN=Alfresco CA, O=Alfresco Software Ltd., L=Maidenhead, ST=UK, C=GB]
+SerialNumber: [    805ba6dc 8f62f8b8]
+]
+
+Trust this certificate? [no]:  yes
+Certificate was added to keystore
+
+(v) Import the CA-signed repository certificate into the repository keystore
+
+$ keytool -import -alias ssl.repo -file repo.crt -keystore ssl.keystore -storetype JCEKS -storepass <store password>
+Enter keystore password:  
+Certificate reply was installed in keystore
+
+(vi) Convert the repository keystore to a pkcs12 keystore (for use in browsers such as Firefox). Give the pkcs12 key store the key store password 'alfresco'.
+
+keytool -importkeystore -srckeystore ssl.keystore -srcstorepass <keystore password> -srcstoretype JCEKS -srcalias ssl.repo -srckeypass kT9X6oe68t -destkeystore firefox.p12 -deststoretype pkcs12 -deststorepass alfresco -destalias ssl.repo -destkeypass alfresco
+
+(vi) Create a repository truststore containing the Alfresco CA certificate
+
+keytool -import -alias ssl.alfreco.ca -file ca.crt -keystore ssl.keystore -storetype JCEKS -storepass <store password>
+keytool -import -alias alfreco.ca -file ca.crt -keystore ssl.truststore -storetype JCEKS -storepass <store password>
+
+(vii) Copy the keystore and truststore to the repository keystore location defined by the property 'dir.keystore'.
+(viii) Update the SSL properties i.e. properties starting with the prefixes 'alfresco.encryption.ssl.keystore' and 'alfresco.encryption.ssl.truststore'.
+
+Instructions for Generating a Certificate Authority (CA) Key and Certificate
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+(i) Generate the CA private key
+
+$ openssl genrsa -des3 -out ca.key 1024
+Generating RSA private key, 1024 bit long modulus
+..........++++++
+..++++++
+e is 65537 (0x10001)
+Enter pass phrase for ca.key:
+Verifying - Enter pass phrase for ca.key:
+
+(ii) Generate the CA self-signed certificate
+
+$ openssl req -new -x509 -days 3650 -key ca.key -out ca.crt
+Enter pass phrase for ca.key:
+You are about to be asked to enter information that will be incorporated
+into your certificate request.
+What you are about to enter is what is called a Distinguished Name or a DN.
+There are quite a few fields but you can leave some blank
+For some fields there will be a default value,
+If you enter '.', the field will be left blank.
+-----
+Country Name (2 letter code) [AU]:GB
+State or Province Name (full name) [Some-State]:UK
+Locality Name (eg, city) []:Maidenhead
+Organization Name (eg, company) [Internet Widgits Pty Ltd]:Alfresco Software Ltd.
+Organizational Unit Name (eg, section) []:
+Common Name (eg, YOUR name) []:Alfresco CA
+Email Address []:
+

--- a/distribution/src/main/resources/keystore/generate_keystores.bat
+++ b/distribution/src/main/resources/keystore/generate_keystores.bat
@@ -1,0 +1,58 @@
+@rem Please edit the variables below to suit your installation
+@rem Note: for an installation created by the Alfresco installer, you only need to edit ALFRESCO_HOME
+
+@rem Alfresco installation directory
+set ALFRESCO_HOME=C:\Alfresco-5.2
+@rem The directory containing the alfresco keystores, as referenced by keystoreFile and truststoreFile attributes in tomcat\conf\server.xml
+set ALFRESCO_KEYSTORE_HOME=%ALFRESCO_HOME%\alf_data\keystore
+@rem Java installation directory
+set JAVA_HOME=%ALFRESCO_HOME%\java
+@rem Location in which new keystore files will be generated
+set CERTIFICATE_HOME=%USERPROFILE%
+@rem The repository server certificate subject name, as specified in tomcat\conf\tomcat-users.xml with roles="repository"
+set REPO_CERT_DNAME=CN=Alfresco Repository, OU=Unknown, O=Alfresco Software Ltd., L=Maidenhead, ST=UK, C=GB
+@rem The SOLR client certificate subject name, as specified in tomcat\conf\tomcat-users.xml with roles="repoclient"
+set SOLR_CLIENT_CERT_DNAME=CN=Alfresco Repository Client, OU=Unknown, O=Alfresco Software Ltd., L=Maidenhead, ST=UK, C=GB
+@rem The number of days before the certificate expires
+set CERTIFICATE_VALIDITY=36525
+
+@rem Ensure certificate output dir exists
+@if not exist "%CERTIFICATE_HOME%" mkdir "%CERTIFICATE_HOME%"
+
+@rem Remove old output files (note they are backed up elsewhere)
+@if exist "%CERTIFICATE_HOME%\ssl.keystore" del "%CERTIFICATE_HOME%\ssl.keystore"
+@if exist "%CERTIFICATE_HOME%\ssl.truststore" del "%CERTIFICATE_HOME%\ssl.truststore"
+@if exist "%CERTIFICATE_HOME%\browser.p12" del "%CERTIFICATE_HOME%\browser.p12"
+@if exist "%CERTIFICATE_HOME%\ssl.repo.client.keystore" del "%CERTIFICATE_HOME%\ssl.repo.client.keystore"
+@if exist "%CERTIFICATE_HOME%\ssl.repo.client.truststore" del "%CERTIFICATE_HOME%\ssl.repo.client.truststore"
+
+@rem Generate new self-signed certificates for the repository and solr
+"%JAVA_HOME%\bin\keytool" -genkeypair -keyalg RSA -dname "%REPO_CERT_DNAME%" -validity %CERTIFICATE_VALIDITY% -alias ssl.repo -keypass kT9X6oe68t -keystore "%CERTIFICATE_HOME%\ssl.keystore" -storetype JCEKS -storepass kT9X6oe68t
+"%JAVA_HOME%\bin\keytool" -exportcert -alias ssl.repo -file "%CERTIFICATE_HOME%\ssl.repo.crt" -keystore "%CERTIFICATE_HOME%\ssl.keystore" -storetype JCEKS -storepass kT9X6oe68t
+"%JAVA_HOME%\bin\keytool" -genkeypair -keyalg RSA -dname "%SOLR_CLIENT_CERT_DNAME%" -validity %CERTIFICATE_VALIDITY% -alias ssl.repo.client -keypass kT9X6oe68t -keystore "%CERTIFICATE_HOME%\ssl.repo.client.keystore" -storetype JCEKS -storepass kT9X6oe68t
+"%JAVA_HOME%\bin\keytool" -exportcert -alias ssl.repo.client -file "%CERTIFICATE_HOME%\ssl.repo.client.crt" -keystore "%CERTIFICATE_HOME%\ssl.repo.client.keystore" -storetype JCEKS -storepass kT9X6oe68t
+
+@rem Create trust relationship between repository and solr
+"%JAVA_HOME%\bin\keytool" -importcert -noprompt -alias ssl.repo.client -file "%CERTIFICATE_HOME%\ssl.repo.client.crt" -keystore "%CERTIFICATE_HOME%\ssl.truststore" -storetype JCEKS -storepass kT9X6oe68t
+@rem Create trust relationship between repository and itself - used for searches
+"%JAVA_HOME%\bin\keytool" -importcert -noprompt -alias ssl.repo -file "%CERTIFICATE_HOME%\ssl.repo.crt" -keystore "%CERTIFICATE_HOME%\ssl.truststore" -storetype JCEKS -storepass kT9X6oe68t
+@rem Create trust relationship between solr and repository
+"%JAVA_HOME%\bin\keytool" -importcert -noprompt -alias ssl.repo -file "%CERTIFICATE_HOME%\ssl.repo.crt" -keystore "%CERTIFICATE_HOME%\ssl.repo.client.truststore" -storetype JCEKS -storepass kT9X6oe68t
+@rem Export repository keystore to pkcs12 format for browser compatibility
+"%JAVA_HOME%\bin\keytool" -importkeystore -srckeystore "%CERTIFICATE_HOME%\ssl.keystore" -srcstorepass kT9X6oe68t -srcstoretype JCEKS -srcalias ssl.repo -srckeypass kT9X6oe68t -destkeystore "%CERTIFICATE_HOME%\browser.p12" -deststoretype pkcs12 -deststorepass alfresco -destalias ssl.repo -destkeypass alfresco
+
+@rem Ensure keystore dir actually exists
+@if not exist "%ALFRESCO_KEYSTORE_HOME%" mkdir "%ALFRESCO_KEYSTORE_HOME%"
+
+@rem Install the new files
+copy /Y "%CERTIFICATE_HOME%\ssl.keystore" "%ALFRESCO_KEYSTORE_HOME%\ssl.keystore"
+copy /Y "%CERTIFICATE_HOME%\ssl.truststore" "%ALFRESCO_KEYSTORE_HOME%\ssl.truststore"
+copy /Y "%CERTIFICATE_HOME%\browser.p12" "%ALFRESCO_KEYSTORE_HOME%\browser.p12"
+
+@echo ****************************************
+@echo You must copy the following files to the correct location.
+@echo %CERTIFICATE_HOME%\ssl.repo.client.keystore
+@echo %CERTIFICATE_HOME%\ssl.repo.client.truststore
+@echo eg. for Solr 4 the location is SOLR_HOME\workspace-SpacesStore\conf and SOLR_HOME\archive-SpacesStore\conf  
+@echo Please ensure that you set dir.keystore=%ALFRESCO_KEYSTORE_HOME% in alfresco-global.properties
+@echo ****************************************

--- a/distribution/src/main/resources/keystore/generate_keystores.sh
+++ b/distribution/src/main/resources/keystore/generate_keystores.sh
@@ -1,0 +1,82 @@
+#! /bin/sh
+# Please edit the variables below to suit your installation
+# Note: for an installation created by the Alfresco installer, you only need to edit ALFRESCO_HOME
+
+# Alfresco installation directory
+if [ -z "$ALFRESCO_HOME" ]; then
+    ALFRESCO_HOME=/opt/alfresco-5.2
+    echo "Setting ALFRESCO_HOME to $ALFRESCO_HOME"
+fi
+
+# The directory containing the alfresco keystores, as referenced by keystoreFile and truststoreFile attributes in tomcat/conf/server.xml
+ALFRESCO_KEYSTORE_HOME=$ALFRESCO_HOME/alf_data/keystore
+
+# Location in which new keystore files will be generated
+if [ -z "$CERTIFICATE_HOME" ]; then
+    CERTIFICATE_HOME=$HOME
+    echo "Certificates will be generated in $CERTIFICATE_HOME and then moved to $ALFRESCO_KEYSTORE_HOME"
+fi
+
+# Java installation directory
+JAVA_HOME=$ALFRESCO_HOME/java
+
+# The repository server certificate subject name, as specified in tomcat/conf/tomcat-users.xml with roles="repository"
+REPO_CERT_DNAME="CN=Alfresco Repository, OU=Unknown, O=Alfresco Software Ltd., L=Maidenhead, ST=UK, C=GB"
+# The SOLR client certificate subject name, as specified in tomcat/conf/tomcat-users.xml with roles="repoclient"
+SOLR_CLIENT_CERT_DNAME="CN=Alfresco Repository Client, OU=Unknown, O=Alfresco Software Ltd., L=Maidenhead, ST=UK, C=GB"
+# The number of days before the certificate expires
+CERTIFICATE_VALIDITY=36525
+
+# Stop
+if [ -f "$ALFRESCO_HOME/alfresco.sh" ]; then "$ALFRESCO_HOME/alfresco.sh" stop; fi
+
+# Ensure certificate output dir exists
+mkdir -p "$CERTIFICATE_HOME"
+
+# Remove old output files (note they are backed up elsewhere)
+if [ -f "$CERTIFICATE_HOME/ssl.keystore" ]; then rm "$CERTIFICATE_HOME/ssl.keystore"; fi
+if [ -f "$CERTIFICATE_HOME/ssl.truststore" ]; then rm "$CERTIFICATE_HOME/ssl.truststore"; fi
+if [ -f "$CERTIFICATE_HOME/browser.p12" ]; then rm "$CERTIFICATE_HOME/browser.p12"; fi
+if [ -f "$CERTIFICATE_HOME/ssl.repo.client.keystore" ]; then rm "$CERTIFICATE_HOME/ssl.repo.client.keystore"; fi
+if [ -f "$CERTIFICATE_HOME/ssl.repo.client.truststore" ]; then rm "$CERTIFICATE_HOME/ssl.repo.client.truststore"; fi
+
+# Generate new self-signed certificates for the repository and solr
+"$JAVA_HOME/bin/keytool" -genkeypair -keyalg RSA -dname "$REPO_CERT_DNAME" -validity $CERTIFICATE_VALIDITY -alias ssl.repo -keypass kT9X6oe68t -keystore "$CERTIFICATE_HOME/ssl.keystore" -storetype JCEKS -storepass kT9X6oe68t
+"$JAVA_HOME/bin/keytool" -exportcert -alias ssl.repo -file "$CERTIFICATE_HOME/ssl.repo.crt" -keystore "$CERTIFICATE_HOME/ssl.keystore" -storetype JCEKS -storepass kT9X6oe68t
+"$JAVA_HOME/bin/keytool" -genkeypair -keyalg RSA -dname "$SOLR_CLIENT_CERT_DNAME" -validity $CERTIFICATE_VALIDITY -alias ssl.repo.client -keypass kT9X6oe68t -keystore "$CERTIFICATE_HOME/ssl.repo.client.keystore" -storetype JCEKS -storepass kT9X6oe68t
+"$JAVA_HOME/bin/keytool" -exportcert -alias ssl.repo.client -file "$CERTIFICATE_HOME/ssl.repo.client.crt" -keystore "$CERTIFICATE_HOME/ssl.repo.client.keystore" -storetype JCEKS -storepass kT9X6oe68t
+
+# Create trust relationship between repository and solr
+"$JAVA_HOME/bin/keytool" -importcert -noprompt -alias ssl.repo.client -file "$CERTIFICATE_HOME/ssl.repo.client.crt" -keystore "$CERTIFICATE_HOME/ssl.truststore" -storetype JCEKS -storepass kT9X6oe68t
+# Create trust relationship between repository and itself - used for searches
+"$JAVA_HOME/bin/keytool" -importcert -noprompt -alias ssl.repo -file "$CERTIFICATE_HOME/ssl.repo.crt" -keystore "$CERTIFICATE_HOME/ssl.truststore" -storetype JCEKS -storepass kT9X6oe68t
+# Create trust relationship between solr and repository
+"$JAVA_HOME/bin/keytool" -importcert -noprompt -alias ssl.repo -file "$CERTIFICATE_HOME/ssl.repo.crt" -keystore "$CERTIFICATE_HOME/ssl.repo.client.truststore" -storetype JCEKS -storepass kT9X6oe68t
+# Export repository keystore to pkcs12 format for browser compatibility
+"$JAVA_HOME/bin/keytool" -importkeystore -srckeystore "$CERTIFICATE_HOME/ssl.keystore" -srcstorepass kT9X6oe68t -srcstoretype JCEKS -srcalias ssl.repo -srckeypass kT9X6oe68t -destkeystore "$CERTIFICATE_HOME/browser.p12" -deststoretype pkcs12 -deststorepass alfresco -destalias ssl.repo -destkeypass alfresco
+
+# Ensure keystore dir actually exists
+mkdir -p "$ALFRESCO_KEYSTORE_HOME"
+
+# Back up old files
+cp "$ALFRESCO_KEYSTORE_HOME/ssl.keystore" "$ALFRESCO_KEYSTORE_HOME/ssl.keystore.old"
+cp "$ALFRESCO_KEYSTORE_HOME/ssl.truststore" "$ALFRESCO_KEYSTORE_HOME/ssl.truststore.old"
+cp "$ALFRESCO_KEYSTORE_HOME/browser.p12" "$ALFRESCO_KEYSTORE_HOME/browser.p12.old"
+
+# Install the new files
+cp "$CERTIFICATE_HOME/ssl.keystore" "$ALFRESCO_KEYSTORE_HOME/ssl.keystore"
+cp "$CERTIFICATE_HOME/ssl.truststore" "$ALFRESCO_KEYSTORE_HOME/ssl.truststore"
+cp "$CERTIFICATE_HOME/browser.p12" "$ALFRESCO_KEYSTORE_HOME/browser.p12"
+
+echo " "
+echo "*******************************************"
+echo "You must copy the following files to the correct location."
+echo " "
+echo " $CERTIFICATE_HOME/ssl.repo.client.keystore"
+echo " $CERTIFICATE_HOME/ssl.repo.client.truststore"
+echo " eg. for Solr 4 the location is SOLR_HOME/workspace-SpacesStore/conf/ and SOLR_HOME/archive-SpacesStore/conf/"
+echo " "
+echo "$ALFRESCO_KEYSTORE_HOME/browser.p12 has also been generated."
+echo " "
+echo "Please ensure that you set dir.keystore=$ALFRESCO_KEYSTORE_HOME in alfresco-global.properties"
+echo "*******************************************"

--- a/distribution/src/main/resources/keystore/readme.txt
+++ b/distribution/src/main/resources/keystore/readme.txt
@@ -1,0 +1,7 @@
+See https://wiki.alfresco.com/wiki/Data_Encryption and https://wiki.alfresco.com/wiki/Alfresco_And_SOLR.
+
+keystore is the secret key keystore, containing the secret key used to encrypt and decrypt node properties.
+ssl.keystore is the repository keystore, containing the repository private/public key pair and certificate.
+ssl.truststore is the repository truststore, containing certificates that the repository trusts.
+
+browser.p12 is a pkcs12 keystore generated from ssl.keystore that contains the repository private key and certificate for use in browsers such as Firefox.


### PR DESCRIPTION
In removing the ssl.keystore and ssl.truststore the following files were found. It would be more appropriate for these to be part of packaging.