### PR TITLE
REPO-4503: upgrade hazelcast 3.11.2 on 6.0.N

### DIFF
--- a/docker-alfresco/test/docker-alfresco-all-amps-test/pom.xml
+++ b/docker-alfresco/test/docker-alfresco-all-amps-test/pom.xml
@@ -268,6 +268,8 @@
                                     <overWrite>false</overWrite>
                                     <outputDirectory>${project.build.directory}/amps</outputDirectory>
                                 </artifactItem>
+                                <!--
+                                Uncomment this when REPO-4233 is fixed and we have a compatible saml module
                                 <artifactItem>
                                     <groupId>org.alfresco.saml</groupId>
                                     <artifactId>alfresco-saml-repo</artifactId>
@@ -284,6 +286,9 @@
                                     <overWrite>false</overWrite>
                                     <outputDirectory>${project.build.directory}/amps_share</outputDirectory>
                                 </artifactItem>
+                                -->
+                                <!--
+                                Uncomment this when MM-785 is fixed and we have a compatible mm module
                                 <artifactItem>
                                     <groupId>org.alfresco.mediamanagement</groupId>
                                     <artifactId>alfresco-mm-repo</artifactId>
@@ -300,6 +305,7 @@
                                     <overWrite>false</overWrite>
                                     <outputDirectory>${project.build.directory}/amps_share</outputDirectory>
                                 </artifactItem>
+                                -->
                                 <artifactItem>
                                     <groupId>org.alfresco</groupId>
                                     <artifactId>alfresco-document-transformation-engine-repo</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <dependency.alfresco-remote-api.version>6.39.19</dependency.alfresco-remote-api.version>
         <dependency.alfresco-hb-data-sender.version>1.0.10</dependency.alfresco-hb-data-sender.version>
 
-        <dependency.alfresco-enterprise-repository.version>6.36.19</dependency.alfresco-enterprise-repository.version>
+        <dependency.alfresco-enterprise-repository.version>6.36.20.hazelcastupgrade</dependency.alfresco-enterprise-repository.version>
         <dependency.alfresco-enterprise-remote-api.version>6.28.16</dependency.alfresco-enterprise-remote-api.version>
 
         <dependency.alfresco-spring-encryptor.version>6.1</dependency.alfresco-spring-encryptor.version>

--- a/pom.xml
+++ b/pom.xml
@@ -667,6 +667,11 @@
                 <artifactId>jsoup</artifactId>
                 <version>1.11.3</version>
             </dependency>
+            <dependency>
+                <groupId>com.hazelcast</groupId>
+                <artifactId>hazelcast</artifactId>
+                <version>3.11.2</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <dependency.alfresco-remote-api.version>6.39.19</dependency.alfresco-remote-api.version>
         <dependency.alfresco-hb-data-sender.version>1.0.10</dependency.alfresco-hb-data-sender.version>
 
-        <dependency.alfresco-enterprise-repository.version>6.36.20.hazelcastupgrade</dependency.alfresco-enterprise-repository.version>
+        <dependency.alfresco-enterprise-repository.version>6.36.20</dependency.alfresco-enterprise-repository.version>
         <dependency.alfresco-enterprise-remote-api.version>6.28.16</dependency.alfresco-enterprise-remote-api.version>
 
         <dependency.alfresco-spring-encryptor.version>6.1</dependency.alfresco-spring-encryptor.version>


### PR DESCRIPTION
Exclude from acs-packaging-all-amps MM and SAML module as they are not compatible with hazelcast 3.11.2 until MM-785 and REPO-4233 are fixed.