### PR TITLE
REPO-4503: Revert Hazelcast upgrade on 6.0.N

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <dependency.alfresco-remote-api.version>6.39.21</dependency.alfresco-remote-api.version>
         <dependency.alfresco-hb-data-sender.version>1.0.10</dependency.alfresco-hb-data-sender.version>
 
-        <dependency.alfresco-enterprise-repository.version>6.36.19</dependency.alfresco-enterprise-repository.version>
+        <dependency.alfresco-enterprise-repository.version>6.36.22</dependency.alfresco-enterprise-repository.version>
         <dependency.alfresco-enterprise-remote-api.version>6.28.16</dependency.alfresco-enterprise-remote-api.version>
 
         <dependency.alfresco-spring-encryptor.version>6.1</dependency.alfresco-spring-encryptor.version>


### PR DESCRIPTION
Update enterprise-alfresco-repository to 6.36.22 (hazelcast upgrade revert)