### PR TITLE
REPO-4504 Update cxf to 3.3.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,14 +34,15 @@
         <version.edition>Enterprise</version.edition>
         <image.tag>latest</image.tag>
 
-        <dependency.alfresco-core.version>7.5.5</dependency.alfresco-core.version>
-        <dependency.alfresco-data-model.version>8.18.10</dependency.alfresco-data-model.version>
-        <dependency.alfresco-repository.version>6.56.31</dependency.alfresco-repository.version>
-        <dependency.alfresco-remote-api.version>6.39.21</dependency.alfresco-remote-api.version>
+        <dependency.alfresco-core.version>7.5.6</dependency.alfresco-core.version>
+        <dependency.alfresco-data-model.version>8.18.11</dependency.alfresco-data-model.version>
+        <dependency.alfresco-repository.version>6.56.32</dependency.alfresco-repository.version>
+        <dependency.alfresco-remote-api.version>6.39.22</dependency.alfresco-remote-api.version>
+    
         <dependency.alfresco-hb-data-sender.version>1.0.10</dependency.alfresco-hb-data-sender.version>
 
-        <dependency.alfresco-enterprise-repository.version>6.36.22</dependency.alfresco-enterprise-repository.version>
-        <dependency.alfresco-enterprise-remote-api.version>6.28.16</dependency.alfresco-enterprise-remote-api.version>
+        <dependency.alfresco-enterprise-repository.version>6.36.24</dependency.alfresco-enterprise-repository.version>
+        <dependency.alfresco-enterprise-remote-api.version>6.28.17</dependency.alfresco-enterprise-remote-api.version>
 
         <dependency.alfresco-spring-encryptor.version>6.1</dependency.alfresco-spring-encryptor.version>
         <dependency.alfresco-enterprise-crypto.version>6.1</dependency.alfresco-enterprise-crypto.version>
@@ -58,6 +59,7 @@
         <dependency.fabric8.version>3.5.37</dependency.fabric8.version>
         <dependency.jackson.version>2.9.9</dependency.jackson.version>
         <dependency.camel.version>2.23.2</dependency.camel.version>
+        <dependency.cxf.version>3.3.2</dependency.cxf.version>
 
         <!-- Alfresco Share version -->
         <alfresco.share.version>6.0.1.1</alfresco.share.version>
@@ -416,17 +418,17 @@
             <dependency>
                 <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-rt-frontend-jaxws</artifactId>
-                <version>3.0.12</version>
+                <version>${dependency.cxf.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-rt-transports-http</artifactId>
-                <version>3.0.12</version>
+                <version>${dependency.cxf.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-rt-ws-policy</artifactId>
-                <version>3.0.12</version>
+                <version>${dependency.cxf.version}</version>
             </dependency>
             <!-- newer version, see REPO-3133 -->
             <dependency>


### PR DESCRIPTION
Update libraries:
alfresco-core to 7.5.6
alfresco-data-model to 8.18.11
alfresco-repository to 6.56.32
alfresco-remote-api to 6.39.22
alfresco-enterprise-repository to 6.36.24
alfresco-enterprise-remote-api to 6.28.17