### PR TITLE
Remove trailing whitespaces in log4j.properties

### DIFF
--- a/war/src/main/resources/log4j.properties
+++ b/war/src/main/resources/log4j.properties
@@ -15,7 +15,7 @@ log4j.appender.Console=org.apache.log4j.ConsoleAppender
 log4j.appender.Console.layout=org.apache.log4j.PatternLayout
 
 # use log4j NDC to replace %x with tenant domain / username
-log4j.appender.Console.layout.ConversionPattern=%d{ISO8601} %x %-5p [%c{3}] [%t] %m%n 
+log4j.appender.Console.layout.ConversionPattern=%d{ISO8601} %x %-5p [%c{3}] [%t] %m%n
 #log4j.appender.Console.layout.ConversionPattern=%d{ABSOLUTE} %-5p [%c] %m%n
 
 ###### File appender definition #######
@@ -210,7 +210,7 @@ log4j.logger.org.apache.chemistry.opencmis.server.impl.atompub.CmisAtomPubServle
 log4j.logger.org.alfresco.repo.imap=info
 
 # JBPM
-# Note: non-fatal errors (eg. logged during job execution) should be handled by Alfresco's retrying transaction handler 
+# Note: non-fatal errors (eg. logged during job execution) should be handled by Alfresco's retrying transaction handler
 log4j.logger.org.jbpm.graph.def.GraphElement=fatal
 
 #log4j.logger.org.alfresco.repo.googledocs=debug


### PR DESCRIPTION
Followup of https://github.com/Alfresco/acs-community-packaging/pull/258