### PR TITLE
REPO-4645: Whitesource High: CVE-2015-0254 - standard-1.1.2 - Assess …

### DIFF
--- a/distribution/src/main/resources/licenses/notice.txt
+++ b/distribution/src/main/resources/licenses/notice.txt
@@ -75,7 +75,6 @@ JSlidesShare    http://code.google.com/p/jslideshare/
 JSON.simple http://code.google.com/p/json-simple/
 jsr107cache http://jsr107cache.sourceforge.net/
 JSR 305 http://findbugs.sourceforge.net/
-jstl    http://tomcat.apache.org/taglibs/index.html
 jug-asl http://jug.safehaus.org/ 
 LESS for Java   http://www.asual.com/lesscss/
 LiveTribe   http://livetribe.codehaus.org/

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -71,11 +71,6 @@
             <artifactId>avalon-framework-impl</artifactId>
             <version>4.3.1</version>
         </dependency>
-        <dependency>
-            <groupId>taglibs</groupId>
-            <artifactId>standard</artifactId>
-            <version>1.1.2</version>
-        </dependency>
         <!-- required by MM and GDocs-->
         <dependency>
             <groupId>commons-lang</groupId>


### PR DESCRIPTION
…Impact

   - removed taglibs standard