### PR TITLE
REPO-4675 Reinstate removed deprecated functionality for ACS6.2: Add Blogs (acs-packaging)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,9 +34,6 @@
   <li>
     DB2 support was removed.
   </li>
-  <li>
-    Discussions, blogs and forums APIs were removed.
-  </li>
 </ul>
 
                                                                                        

--- a/distribution/src/main/resources/licenses/notice.txt
+++ b/distribution/src/main/resources/licenses/notice.txt
@@ -113,7 +113,6 @@ xbean   http://geronimo.apache.org/xbean/
 xercesImpl  http://xerces.apache.org/xerces2-j
 XML Commons External Components http://xml.apache.org/commons/components/external/
 XMLBeans    http://xmlbeans.apache.org/
-XML-RPC http://ws.apache.org/xmlrpc/
 XML Schema  http://ws.apache.org/commons/XmlSchema/
 Santuario   http://santuario.apache.org/
 OpenSSL http://www.openssl.org/


### PR DESCRIPTION
- Discussions & Blogs no longer removed.
- xmlrpc has been removed in 6.1.1, so should not be in notice.txt