### PR TITLE
Bump Glacier and S3 connectors versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,10 +69,10 @@
         <alfresco.googledocs.version>3.1.0</alfresco.googledocs.version>
 
         <!-- Alfresco S3 Connector integration version -->
-        <alfresco.s3connector.version>2.3.0</alfresco.s3connector.version>
+        <alfresco.s3connector.version>3.0-RC4</alfresco.s3connector.version>
 
         <!-- Alfresco Glacier Connector Repo version -->
-        <alfresco.glacier-connector.version>1.0.0</alfresco.glacier-connector.version>
+        <alfresco.glacier-connector.version>2.0.0-RC1</alfresco.glacier-connector.version>
 
         <!-- Alfresco Content Connector for Azure version -->
         <alfresco.azure-connector.version>1.0-RC1</alfresco.azure-connector.version>


### PR DESCRIPTION
Bump S3 connector version to 3.0-RC4
Bump Glacier connector version to 2.0.0-RC1