### PR TITLE
RM-7056: Add AGS to ACS Packaging "all-amps" startup test

### DIFF
--- a/distribution/src/main/resources/VERSIONS.md
+++ b/distribution/src/main/resources/VERSIONS.md
@@ -23,7 +23,7 @@ This file lists the recommended components for this Service Pack. Use it along w
 |---|---|---|
 | Alfresco Share Services | @alfresco.alfresco-share-services.version@ |
 | Alfresco Google Docs Integration | @alfresco.googledocs.version@ |
-| Alfresco Records Management | @alfresco.records-management.version@ |
+| Alfresco Governance Services | @alfresco.ags.version@ |
 | Alfresco Media Management | @alfresco.mm.version@ |
 | Alfresco Intelligence Services | @alfresco.ais.version@ |
 | Alfresco Office Services | @alfresco.aos-module.version@ |

--- a/docker-alfresco/test/docker-alfresco-all-amps-test/pom.xml
+++ b/docker-alfresco/test/docker-alfresco-all-amps-test/pom.xml
@@ -333,6 +333,22 @@
                                     <overWrite>false</overWrite>
                                     <outputDirectory>${project.build.directory}/amps_share</outputDirectory>
                                 </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.alfresco</groupId>
+                                    <artifactId>alfresco-governance-services-enterprise-repo</artifactId>
+                                    <version>${alfresco.ags.version}</version>
+                                    <type>amp</type>
+                                    <overWrite>false</overWrite>
+                                    <outputDirectory>${project.build.directory}/amps</outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.alfresco</groupId>
+                                    <artifactId>alfresco-governance-services-enterprise-share</artifactId>
+                                    <version>${alfresco.ags.version}</version>
+                                    <type>amp</type>
+                                    <overWrite>false</overWrite>
+                                    <outputDirectory>${project.build.directory}/amps_share</outputDirectory>
+                                </artifactItem>
                             </artifactItems>
                         </configuration>
                     </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -95,8 +95,8 @@
         <!-- Document Transformation Engine -->
         <alfresco.transformation-engine.version>2.2.1</alfresco.transformation-engine.version>
 
-        <!-- Alfresco Records Management -->
-        <alfresco.records-management.version>3.0.0</alfresco.records-management.version>
+        <!-- Alfresco Governance Services (AGS) -->
+        <alfresco.ags.version>3.2.0</alfresco.ags.version>
 
         <!-- Alfresco Office Services Module -->
         <alfresco.aos-module.version>1.3.0</alfresco.aos-module.version>
@@ -109,9 +109,6 @@
 
         <!-- Alfresco Alfresco Intelligence Services (AIS) -->
         <alfresco.ais.version>1.1.0</alfresco.ais.version>
-
-        <!-- Alfresco Governance Services (AGS) -->
-        <alfresco.ags.version>3.2.0</alfresco.ags.version>
 
         <installer.version.name>${project.version}</installer.version.name>
         <alfresco.package.name>alfresco</alfresco.package.name>

--- a/pom.xml
+++ b/pom.xml
@@ -110,6 +110,9 @@
         <!-- Alfresco Alfresco Intelligence Services (AIS) -->
         <alfresco.ais.version>1.1.0</alfresco.ais.version>
 
+        <!-- Alfresco Governance Services (AGS) -->
+        <alfresco.ags.version>3.2.0</alfresco.ags.version>
+
         <installer.version.name>${project.version}</installer.version.name>
         <alfresco.package.name>alfresco</alfresco.package.name>
         <alfresco.distribution.name>${alfresco.package.name}-distribution</alfresco.distribution.name>


### PR DESCRIPTION
- first attempt for AGS 3.2.0 on ACS 6.2.0 (hence branched from "support/SP/6.2.N")
- ... if successful then also merge up to master (ie. AGS 3.2.0 on ACS 6.3.0-SNAPSHOT)