### PR TITLE
REPO-4774: classpath collision commons-logging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -360,6 +360,14 @@
                 <groupId>org.springframework</groupId>
                 <artifactId>spring-core</artifactId>
                 <version>${dependency.spring.version}</version>
+                <!-- exclude commons-logging which is brought in by spring-jcl -->
+                <!-- see https://issues.alfresco.com/jira/browse/REPO-4774 -->
+                <exclusions>
+                    <exclusion>
+                        <groupId>commons-logging</groupId>
+                        <artifactId>commons-logging</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.springframework</groupId>


### PR DESCRIPTION
- Exclude `commons-logging` classes that are being brought in by `spring-jcl`