### PR TITLE
Remove com.benfante:JSlideShare library from alfresco-repository project

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -206,6 +206,13 @@
                 <groupId>org.alfresco</groupId>
                 <artifactId>alfresco-repository</artifactId>
                 <version>${dependency.alfresco-repository.version}</version>
+		<exclusions>
+	                <exclusion>
+	                    <groupId>com.benfante</groupId>
+	                    <artifactId>JSlideShare</artifactId>
+			    <version>0.6</version>
+	                </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.alfresco</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -206,12 +206,6 @@
                 <groupId>org.alfresco</groupId>
                 <artifactId>alfresco-repository</artifactId>
                 <version>${dependency.alfresco-repository.version}</version>
-		<exclusions>
-	                <exclusion>
-	                    <groupId>com.benfante</groupId>
-	                    <artifactId>JSlideShare</artifactId>
-	                </exclusion>
-                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.alfresco</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -210,7 +210,6 @@
 	                <exclusion>
 	                    <groupId>com.benfante</groupId>
 	                    <artifactId>JSlideShare</artifactId>
-			    <version>0.6</version>
 	                </exclusion>
                 </exclusions>
             </dependency>

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -20,6 +20,12 @@
         <dependency>
             <groupId>org.alfresco</groupId>
             <artifactId>alfresco-repository</artifactId>
+            <exclusions/>
+                <exclusion>
+                    <groupId>com.benfante</groupId>
+                    <artifactId>JSlideShare</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.alfresco</groupId>

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>org.alfresco</groupId>
             <artifactId>alfresco-repository</artifactId>
-            <exclusions/>
+            <exclusions>
                 <exclusion>
                     <groupId>com.benfante</groupId>
                     <artifactId>JSlideShare</artifactId>


### PR DESCRIPTION
Regarding the issue REPO-4695, this is a library that can be removed according with the analysis done.