### PR TITLE
REPO-4800 - Remove library oro:oro

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -206,6 +206,12 @@
                 <groupId>org.alfresco</groupId>
                 <artifactId>alfresco-repository</artifactId>
                 <version>${dependency.alfresco-repository.version}</version>
+		<exclusions>
+	                <exclusion>
+	                    <groupId>oro</groupId>
+	                    <artifactId>oro</artifactId>
+	                </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.alfresco</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -206,12 +206,6 @@
                 <groupId>org.alfresco</groupId>
                 <artifactId>alfresco-repository</artifactId>
                 <version>${dependency.alfresco-repository.version}</version>
-		<exclusions>
-	                <exclusion>
-	                    <groupId>oro</groupId>
-	                    <artifactId>oro</artifactId>
-	                </exclusion>
-                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.alfresco</groupId>

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -20,6 +20,12 @@
         <dependency>
             <groupId>org.alfresco</groupId>
             <artifactId>alfresco-repository</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>oro</groupId>
+                    <artifactId>oro</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.alfresco</groupId>


### PR DESCRIPTION
Regarding the issue REPO-4695, this is a library that can be removed according with the analysis done.

