### PR TITLE
REPO-4801 - Remove library org.springframework:spring-orm

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
         <dependency.alfresco-enterprise-remote-api.version>8.13</dependency.alfresco-enterprise-remote-api.version>
         <dependency.alfresco-enterprise-repository.version>8.15</dependency.alfresco-enterprise-repository.version>
         <dependency.alfresco-remote-api.version>8.28</dependency.alfresco-remote-api.version>
-        <dependency.alfresco-repository.version>8.22</dependency.alfresco-repository.version>
+        <dependency.alfresco-repository.version>8.24</dependency.alfresco-repository.version>
         <dependency.alfresco-data-model.version>8.55</dependency.alfresco-data-model.version>
         <dependency.alfresco-core.version>7.22</dependency.alfresco-core.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
         <image.tag>latest</image.tag>
 
         <dependency.alfresco-enterprise-remote-api.version>8.13</dependency.alfresco-enterprise-remote-api.version>
-        <dependency.alfresco-enterprise-repository.version>8.13</dependency.alfresco-enterprise-repository.version>
+        <dependency.alfresco-enterprise-repository.version>8.15</dependency.alfresco-enterprise-repository.version>
         <dependency.alfresco-remote-api.version>8.28</dependency.alfresco-remote-api.version>
         <dependency.alfresco-repository.version>8.22</dependency.alfresco-repository.version>
         <dependency.alfresco-data-model.version>8.55</dependency.alfresco-data-model.version>

--- a/pom.xml
+++ b/pom.xml
@@ -206,6 +206,12 @@
                 <groupId>org.alfresco</groupId>
                 <artifactId>alfresco-repository</artifactId>
                 <version>${dependency.alfresco-repository.version}</version>
+		<exclusions>
+	                <exclusion>
+	                    <groupId>org.springframework</groupId>
+	                    <artifactId>spring-orm</artifactId>
+	                </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.alfresco</groupId>
@@ -394,11 +400,6 @@
             <dependency>
                 <groupId>org.springframework</groupId>
                 <artifactId>spring-jms</artifactId>
-                <version>${dependency.spring.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.springframework</groupId>
-                <artifactId>spring-orm</artifactId>
                 <version>${dependency.spring.version}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
Regarding the issue REPO-4695, this is a library that can be removed according with the analysis done.

