### PR TITLE
REPO-4801 - Remove library org.springframework:spring-orm

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -206,6 +206,12 @@
                 <groupId>org.alfresco</groupId>
                 <artifactId>alfresco-repository</artifactId>
                 <version>${dependency.alfresco-repository.version}</version>
+		<exclusions>
+	            <exclusion>
+	               <groupId>org.springframework</groupId>
+	               <artifactId>spring-orm</artifactId>
+	            </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.alfresco</groupId>
@@ -394,11 +400,6 @@
             <dependency>
                 <groupId>org.springframework</groupId>
                 <artifactId>spring-jms</artifactId>
-                <version>${dependency.spring.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.springframework</groupId>
-                <artifactId>spring-orm</artifactId>
                 <version>${dependency.spring.version}</version>
             </dependency>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -206,12 +206,6 @@
                 <groupId>org.alfresco</groupId>
                 <artifactId>alfresco-repository</artifactId>
                 <version>${dependency.alfresco-repository.version}</version>
-		<exclusions>
-	            <exclusion>
-	               <groupId>org.springframework</groupId>
-	               <artifactId>spring-orm</artifactId>
-	            </exclusion>
-                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.alfresco</groupId>

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -20,6 +20,12 @@
         <dependency>
             <groupId>org.alfresco</groupId>
             <artifactId>alfresco-repository</artifactId>
+            <exclusions>
+                <exclusion>
+                   <groupId>org.springframework</groupId>
+                   <artifactId>spring-orm</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.alfresco</groupId>


### PR DESCRIPTION
Regarding the issue REPO-4695, this is a library that can be removed according with the analysis done.

