### PR TITLE
REPO-4774: classpath collision commons-logging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,11 +35,11 @@
         <image.tag>latest</image.tag>
 
         <dependency.alfresco-enterprise-remote-api.version>8.13</dependency.alfresco-enterprise-remote-api.version>
-        <dependency.alfresco-enterprise-repository.version>8.13</dependency.alfresco-enterprise-repository.version>
+        <dependency.alfresco-enterprise-repository.version>8.18</dependency.alfresco-enterprise-repository.version>
         <dependency.alfresco-remote-api.version>8.28</dependency.alfresco-remote-api.version>
-        <dependency.alfresco-repository.version>8.21</dependency.alfresco-repository.version>
-        <dependency.alfresco-data-model.version>8.55</dependency.alfresco-data-model.version>
-        <dependency.alfresco-core.version>7.22</dependency.alfresco-core.version>
+        <dependency.alfresco-repository.version>8.27</dependency.alfresco-repository.version>
+        <dependency.alfresco-data-model.version>8.56</dependency.alfresco-data-model.version>
+        <dependency.alfresco-core.version>7.23</dependency.alfresco-core.version>
 
         <dependency.alfresco-hb-data-sender.version>1.0.12</dependency.alfresco-hb-data-sender.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -380,6 +380,14 @@
                 <groupId>org.springframework</groupId>
                 <artifactId>spring-core</artifactId>
                 <version>${dependency.spring.version}</version>
+                <!-- exclude commons-logging which is brought in by spring-jcl -->
+                <!-- see https://issues.alfresco.com/jira/browse/REPO-4774 -->
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.springframework</groupId>
+                        <artifactId>spring-jcl</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.springframework</groupId>


### PR DESCRIPTION
- Exclude `spring-jcl` from `spring-orm` which is a direct dependency.