### PR TITLE
REPO-4812 - Remove library org.apache.commons:commons-email from alfresco-repository and alfresco-remote-api project

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -195,6 +195,12 @@
                 <groupId>org.alfresco</groupId>
                 <artifactId>alfresco-remote-api</artifactId>
                 <version>${dependency.alfresco-remote-api.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <artifactId>org.apache.commons</artifactId>
+                        <groupId>commons-email</groupId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.alfresco</groupId>
@@ -206,6 +212,12 @@
                 <groupId>org.alfresco</groupId>
                 <artifactId>alfresco-repository</artifactId>
                 <version>${dependency.alfresco-repository.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <artifactId>org.apache.commons</artifactId>
+                        <groupId>commons-email</groupId>
+                    </exclusion>
+                </exclusions>                
             </dependency>
             <dependency>
                 <groupId>org.alfresco</groupId>
@@ -472,12 +484,6 @@
                 <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-rt-ws-policy</artifactId>
                 <version>${dependency.cxf.version}</version>
-            </dependency>
-            <!-- newer version, see REPO-3133 -->
-            <dependency>
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-email</artifactId>
-                <version>1.5</version>
             </dependency>
             <!-- Make sure JUnit is not packaged -->
             <dependency>

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -20,10 +20,22 @@
         <dependency>
             <groupId>org.alfresco</groupId>
             <artifactId>alfresco-repository</artifactId>
+            <exclusions>
+                <exclusion>
+                    <artifactId>org.apache.commons</artifactId>
+                    <groupId>commons-email</groupId>
+                </exclusion>
+            </exclusions>            
         </dependency>
         <dependency>
             <groupId>org.alfresco</groupId>
             <artifactId>alfresco-remote-api</artifactId>
+            <exclusions>
+                <exclusion>
+                    <artifactId>org.apache.commons</artifactId>
+                    <groupId>commons-email</groupId>
+                </exclusion>
+            </exclusions>            
         </dependency>
         <dependency>
             <groupId>org.alfresco</groupId>


### PR DESCRIPTION
Regarding the issue REPO-4695, this is a library that can be removed according with the analysis done.

