### PR TITLE
REPO-4815 - Remove library com.google.gdata:gdata-youtube-2.0 from al…

### DIFF
--- a/war/pom.xml
+++ b/war/pom.xml
@@ -20,6 +20,12 @@
         <dependency>
             <groupId>org.alfresco</groupId>
             <artifactId>alfresco-repository</artifactId>
+            <exclusions>
+                <exclusion>
+                    <artifactId>com.google.gdata</artifactId>
+                    <groupId>gdata-youtube-2.0</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.alfresco</groupId>


### PR DESCRIPTION
…fresco-repository project
Regarding the issue REPO-4695, this is a library that can be removed according with the analysis done.

