### PR TITLE
REPO-4816 - Remove library edu.ucar:netcdf from alfresco-repository p…

### DIFF
--- a/war/pom.xml
+++ b/war/pom.xml
@@ -20,6 +20,12 @@
         <dependency>
             <groupId>org.alfresco</groupId>
             <artifactId>alfresco-repository</artifactId>
+            <exclusions>
+                <exclusion>
+                    <artifactId>edu.ucar</artifactId>
+                    <groupId>netcdf</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.alfresco</groupId>


### PR DESCRIPTION
…roject
Regarding the issue REPO-4695, this is a library that can be removed according with the analysis done.

