### PR TITLE
REPO-4819 - Remove library com.rometools:rome from alfresco-remote-ap…

### DIFF
--- a/war/pom.xml
+++ b/war/pom.xml
@@ -24,6 +24,12 @@
         <dependency>
             <groupId>org.alfresco</groupId>
             <artifactId>alfresco-remote-api</artifactId>
+            <exclusions>
+                <exclusion>
+                    <artifactId>com.rometools</artifactId>
+                    <groupId>rome</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.alfresco</groupId>


### PR DESCRIPTION
…i project
Regarding the issue REPO-4695, this is a library that can be removed according with the analysis done.

