### PR TITLE
REPO-4824 - Remove library org.activiti:activiti-webapp-explorer2-ui-…

### DIFF
--- a/war/pom.xml
+++ b/war/pom.xml
@@ -28,10 +28,22 @@
         <dependency>
             <groupId>org.alfresco</groupId>
             <artifactId>alfresco-enterprise-remote-api</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.activiti</groupId>
+                    <artifactId>activiti-webapp-explorer2-ui-jar</artifactId>
+                </exclusion>
+            </exclusions>     
         </dependency>
         <dependency>
             <groupId>org.alfresco</groupId>
             <artifactId>alfresco-enterprise-repository</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.activiti</groupId>
+                    <artifactId>activiti-webapp-explorer2-ui-jar</artifactId>
+                </exclusion>
+            </exclusions>     
         </dependency>
         <dependency>
             <groupId>org.alfresco</groupId>


### PR DESCRIPTION
…jar from alfresco-enterprise-repository project
Regarding the issue REPO-4695, this is a library that can be removed according with the analysis done.

