### PR TITLE
REPO-4826 - Remove library com.google.gdata:gdata-client-meta-1.0 fro…

### DIFF
--- a/war/pom.xml
+++ b/war/pom.xml
@@ -20,6 +20,12 @@
         <dependency>
             <groupId>org.alfresco</groupId>
             <artifactId>alfresco-repository</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.gdata</groupId>
+                    <artifactId>gdata-client-meta-1.0</artifactId>
+                </exclusion>
+            </exclusions>               
         </dependency>
         <dependency>
             <groupId>org.alfresco</groupId>


### PR DESCRIPTION
…m alfresco-repository project
Regarding the issue REPO-4695, this is a library that can be removed according with the analysis done.

