### PR TITLE
REPO-4827 - Remove library com.google.gdata:gdata-docs-3.0 from alfre…

### DIFF
--- a/war/pom.xml
+++ b/war/pom.xml
@@ -20,6 +20,12 @@
         <dependency>
             <groupId>org.alfresco</groupId>
             <artifactId>alfresco-repository</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.gdata</groupId>
+                    <artifactId>gdata-docs-3.0</artifactId>
+                </exclusion>
+            </exclusions>               
         </dependency>
         <dependency>
             <groupId>org.alfresco</groupId>


### PR DESCRIPTION
…sco-repository project
Regarding the issue REPO-4695, this is a library that can be removed according with the analysis done.

