### PR TITLE
REPO-4830 - Remove library commons-modeler:commons-modeler from acs-p…

### DIFF
--- a/war/pom.xml
+++ b/war/pom.xml
@@ -46,17 +46,6 @@
             <artifactId>xalan</artifactId>
         </dependency>
         <dependency>
-            <groupId>commons-modeler</groupId>
-            <artifactId>commons-modeler</artifactId>
-            <version>2.0.1</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>commons-logging</groupId>
-                    <artifactId>commons-logging-api</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
             <version>1.2</version>


### PR DESCRIPTION
…ackaging project
Regarding the issue REPO-4695, this is a library that can be removed according with the analysis done.

