### PR TITLE
REPO-4832 - Remove library org.alfresco:alfresco-ai-repo from acs-packaging project

### DIFF
--- a/docker-alfresco/aws/pom.xml
+++ b/docker-alfresco/aws/pom.xml
@@ -19,12 +19,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.alfresco</groupId>
-            <artifactId>alfresco-ai-repo</artifactId>
-            <version>${alfresco.ais.version}</version>
-            <type>amp</type>
-        </dependency>
-        <dependency>
             <groupId>org.alfresco.integrations</groupId>
             <artifactId>alfresco-s3-connector</artifactId>
             <version>${alfresco.s3connector.version}</version>
@@ -182,14 +176,6 @@
                                     <groupId>org.alfresco.integrations</groupId>
                                     <artifactId>alfresco-s3-connector</artifactId>
                                     <version>${alfresco.s3connector.version}</version>
-                                    <type>amp</type>
-                                    <overWrite>false</overWrite>
-                                    <outputDirectory>${project.build.directory}/amps</outputDirectory>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>org.alfresco</groupId>
-                                    <artifactId>alfresco-ai-repo</artifactId>
-                                    <version>${alfresco.ais.version}</version>
                                     <type>amp</type>
                                     <overWrite>false</overWrite>
                                     <outputDirectory>${project.build.directory}/amps</outputDirectory>

--- a/docker-alfresco/test/docker-alfresco-all-amps-test/pom.xml
+++ b/docker-alfresco/test/docker-alfresco-all-amps-test/pom.xml
@@ -215,14 +215,6 @@
                                 </artifactItem>
                                 <artifactItem>
                                     <groupId>org.alfresco</groupId>
-                                    <artifactId>alfresco-ai-repo</artifactId>
-                                    <version>${alfresco.ais.version}</version>
-                                    <type>amp</type>
-                                    <overWrite>false</overWrite>
-                                    <outputDirectory>${project.build.directory}/amps</outputDirectory>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>org.alfresco</groupId>
                                     <artifactId>alfresco-ai-share</artifactId>
                                     <version>${alfresco.ais.version}</version>
                                     <type>amp</type>

--- a/tests/tas-all-amps/pom.xml
+++ b/tests/tas-all-amps/pom.xml
@@ -205,14 +205,6 @@
                                         </artifactItem>
                                         <artifactItem>
                                             <groupId>org.alfresco</groupId>
-                                            <artifactId>alfresco-ai-repo</artifactId>
-                                            <version>${alfresco.ais.version}</version>
-                                            <type>amp</type>
-                                            <overWrite>false</overWrite>
-                                            <outputDirectory>${project.build.directory}/amps</outputDirectory>
-                                        </artifactItem>
-                                        <artifactItem>
-                                            <groupId>org.alfresco</groupId>
                                             <artifactId>alfresco-ai-share</artifactId>
                                             <version>${alfresco.ais.version}</version>
                                             <type>amp</type>


### PR DESCRIPTION
Regarding the issue REPO-4695, this is a library that can be removed according with the analysis done.

