### PR TITLE
REPO-4833 - Remove library org.alfresco:alfresco-content-services-sha…

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -61,17 +61,6 @@
         </dependency>
         <!-- SOLR Distribution: Run Alfresco Search Services Separately -->
         <!-- SHARE Distribution -->
-        <dependency>
-            <groupId>org.alfresco</groupId>
-            <artifactId>alfresco-content-services-share-distribution</artifactId>
-            <type>zip</type>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
     </dependencies>
 
     <build>
@@ -99,12 +88,6 @@
                                     <groupId>org.alfresco</groupId>
                                     <artifactId>alfresco-repository</artifactId>
                                     <includes>alfresco/keystore/**</includes>
-                                </artifactItem>
-
-                                <artifactItem>
-                                    <groupId>org.alfresco</groupId>
-                                    <artifactId>alfresco-content-services-share-distribution</artifactId>
-                                    <type>zip</type>
                                 </artifactItem>
                             </artifactItems>
                         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -522,12 +522,6 @@
             </dependency>
             <dependency>
                 <groupId>org.alfresco</groupId>
-                <artifactId>alfresco-content-services-share-distribution</artifactId>
-                <version>${alfresco.share.version}</version>
-                <type>zip</type>
-            </dependency>
-            <dependency>
-                <groupId>org.alfresco</groupId>
                 <artifactId>alfresco-share-services</artifactId>
                 <version>${alfresco.alfresco-share-services.version}</version>
                 <type>amp</type>


### PR DESCRIPTION
…re-distribution from acs-packaging project
Regarding the issue REPO-4695, this is a library that can be removed according with the analysis done.

