### PR TITLE
REPO-4835 - Remove library org.gytheio:gytheio-commons from acs-packa…

### DIFF
--- a/war/pom.xml
+++ b/war/pom.xml
@@ -81,17 +81,6 @@
         <!-- some of the dependencies are declared and used in alfresco-repository -->
         <dependency>
             <groupId>org.gytheio</groupId>
-            <artifactId>gytheio-commons</artifactId>
-            <version>${dependency.gytheio.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.gytheio</groupId>
             <artifactId>gytheio-content-handler-s3</artifactId>
             <version>${dependency.gytheio.version}</version>
             <exclusions>


### PR DESCRIPTION
…ging project
Regarding the issue REPO-4695, this is a library that can be removed according with the analysis done.

