### PR TITLE
REPO-4836 - Remove library org.gytheio:gytheio-content-handler-s3 fro…

### DIFF
--- a/war/pom.xml
+++ b/war/pom.xml
@@ -92,17 +92,6 @@
         </dependency>
         <dependency>
             <groupId>org.gytheio</groupId>
-            <artifactId>gytheio-content-handler-s3</artifactId>
-            <version>${dependency.gytheio.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.gytheio</groupId>
             <artifactId>gytheio-content-handler-webdav</artifactId>
             <version>${dependency.gytheio.version}</version>
             <exclusions>


### PR DESCRIPTION
…m acs-packaging project
Regarding the issue REPO-4695, this is a library that can be removed according with the analysis done.


