### PR TITLE
REPO-4837 - Remove library org.gytheio:gytheio-content-handler-webdav…

### DIFF
--- a/war/pom.xml
+++ b/war/pom.xml
@@ -103,17 +103,6 @@
         </dependency>
         <dependency>
             <groupId>org.gytheio</groupId>
-            <artifactId>gytheio-content-handler-webdav</artifactId>
-            <version>${dependency.gytheio.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.gytheio</groupId>
             <artifactId>gytheio-health-commons</artifactId>
             <version>${dependency.gytheio.version}</version>
             <exclusions>


### PR DESCRIPTION
… from acs-packaging project
Regarding the issue REPO-4695, this is a library that can be removed according with the analysis done.

