### PR TITLE
REPO-4838 - Remove library org.gytheio:gytheio-health-commons from ac…

### DIFF
--- a/war/pom.xml
+++ b/war/pom.xml
@@ -114,17 +114,6 @@
         </dependency>
         <dependency>
             <groupId>org.gytheio</groupId>
-            <artifactId>gytheio-health-commons</artifactId>
-            <version>${dependency.gytheio.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.gytheio</groupId>
             <artifactId>gytheio-messaging-camel</artifactId>
             <version>${dependency.gytheio.version}</version>
             <exclusions>


### PR DESCRIPTION
…s-packaging project
Regarding the issue REPO-4695, this is a library that can be removed according with the analysis done.

