### PR TITLE
REPO-4839 - Remove library org.gytheio:gytheio-transform-commons from…

### DIFF
--- a/war/pom.xml
+++ b/war/pom.xml
@@ -147,17 +147,6 @@
         </dependency>
         <dependency>
             <groupId>org.gytheio</groupId>
-            <artifactId>gytheio-transform-commons</artifactId>
-            <version>${dependency.gytheio.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.gytheio</groupId>
             <artifactId>gytheio-transform-messaging</artifactId>
             <version>${dependency.gytheio.version}</version>
             <exclusions>


### PR DESCRIPTION
… acs-packaging project
Regarding the issue REPO-4695, this is a library that can be removed according with the analysis done.

