### PR TITLE
REPO-4840 - Remove library org.gytheio:gytheio-transform-messaging fr…

### DIFF
--- a/war/pom.xml
+++ b/war/pom.xml
@@ -158,17 +158,6 @@
         </dependency>
         <dependency>
             <groupId>org.gytheio</groupId>
-            <artifactId>gytheio-transform-messaging</artifactId>
-            <version>${dependency.gytheio.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.gytheio</groupId>
             <artifactId>gytheio-transform-worker-ffmpeg</artifactId>
             <version>${dependency.gytheio.version}</version>
             <exclusions>


### PR DESCRIPTION
…om acs-packaging project
Regarding the issue REPO-4695, this is a library that can be removed according with the analysis done.

