### PR TITLE
REPO-4841 - Remove library org.gytheio:gytheio-transform-worker-ffmpe…

### DIFF
--- a/war/pom.xml
+++ b/war/pom.xml
@@ -168,17 +168,6 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.gytheio</groupId>
-            <artifactId>gytheio-transform-worker-ffmpeg</artifactId>
-            <version>${dependency.gytheio.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
             <groupId>org.alfresco</groupId>
             <artifactId>alfresco-log-sanitizer</artifactId>
         </dependency>


### PR DESCRIPTION
…g from acs-packaging project
Regarding the issue REPO-4695, this is a library that can be removed according with the analysis done.

