### PR TITLE
REPO-4798 - Remove library org.apache.httpcomponents:httpclient-cache…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -347,11 +347,6 @@
                 <version>4.5.10</version>
             </dependency>
             <dependency>
-                <groupId>org.apache.httpcomponents</groupId>
-                <artifactId>httpclient-cache</artifactId>
-                <version>4.5.10</version>
-            </dependency>
-            <dependency>
                 <groupId>org.apache.xmlbeans</groupId>
                 <artifactId>xmlbeans</artifactId>
                 <version>3.1.0</version>


### PR DESCRIPTION
… from acs-packaging project
Regarding the issue REPO-4695, this is a library that can be removed according with the analysis done.

