### PR TITLE
REPO-4855 - Remove library com.beetstra.jutf7:jutf7 from alfresco-rep…

### DIFF
--- a/war/pom.xml
+++ b/war/pom.xml
@@ -20,6 +20,12 @@
         <dependency>
             <groupId>org.alfresco</groupId>
             <artifactId>alfresco-repository</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.beetstra.jutf7</groupId>
+                    <artifactId>jutf7</artifactId>
+                </exclusion>
+            </exclusions>            
         </dependency>
         <dependency>
             <groupId>org.alfresco</groupId>


### PR DESCRIPTION
…ository project
Regarding the issue REPO-4695, this is a library that can be removed according with the analysis done.

