### PR TITLE
REPO-4857 - Remove library org.apache.activemq:activemq-amqp from alf…

### DIFF
--- a/war/pom.xml
+++ b/war/pom.xml
@@ -20,6 +20,12 @@
         <dependency>
             <groupId>org.alfresco</groupId>
             <artifactId>alfresco-repository</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.activemq</groupId>
+                    <artifactId>activemq-amqp</artifactId>
+                </exclusion>
+            </exclusions>            
         </dependency>
         <dependency>
             <groupId>org.alfresco</groupId>


### PR DESCRIPTION
…resco-repository project
Regarding the issue REPO-4695, this is a library that can be removed according with the analysis done.

