### PR TITLE
Bump dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,11 +34,11 @@
         <version.edition>Enterprise</version.edition>
         <image.tag>latest</image.tag>
 
-        <dependency.alfresco-enterprise-remote-api.version>8.38</dependency.alfresco-enterprise-remote-api.version>
-        <dependency.alfresco-enterprise-repository.version>8.40</dependency.alfresco-enterprise-repository.version>
-        <dependency.alfresco-remote-api.version>8.52</dependency.alfresco-remote-api.version>
-        <dependency.alfresco-repository.version>8.43</dependency.alfresco-repository.version>
-        <dependency.alfresco-data-model.version>8.67</dependency.alfresco-data-model.version>
+        <dependency.alfresco-enterprise-remote-api.version>8.40</dependency.alfresco-enterprise-remote-api.version>
+        <dependency.alfresco-enterprise-repository.version>8.43</dependency.alfresco-enterprise-repository.version>
+        <dependency.alfresco-remote-api.version>8.55</dependency.alfresco-remote-api.version>
+        <dependency.alfresco-repository.version>8.44</dependency.alfresco-repository.version>
+        <dependency.alfresco-data-model.version>8.68</dependency.alfresco-data-model.version>
         <dependency.alfresco-core.version>8.6</dependency.alfresco-core.version>
 
         <dependency.alfresco-hb-data-sender.version>1.0.12</dependency.alfresco-hb-data-sender.version>


### PR DESCRIPTION
Bump repository to 8.44
Bump remote-api to 8.55
Bump enterprise-repository to 8.43
Bump enterprise-remote-api to  8.40
Bump data-model to 8.68