### PR TITLE
REPO-4895 - Remove library org.apache.ws.security:wss4j from alfresco…

### DIFF
--- a/war/pom.xml
+++ b/war/pom.xml
@@ -24,6 +24,12 @@
         <dependency>
             <groupId>org.alfresco</groupId>
             <artifactId>alfresco-remote-api</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.ws.security</groupId>
+                    <artifactId>wss4j</artifactId>
+                </exclusion>
+            </exclusions>            
         </dependency>
         <dependency>
             <groupId>org.alfresco</groupId>


### PR DESCRIPTION
…-remote-api
Regarding the issue REPO-4695, this is a library that can be removed according with the analysis done.