### PR TITLE
REPO-4896 - Remove library org.alfresco.cmis.client:alfresco-opencmis…

### DIFF
--- a/war/pom.xml
+++ b/war/pom.xml
@@ -24,6 +24,12 @@
         <dependency>
             <groupId>org.alfresco</groupId>
             <artifactId>alfresco-remote-api</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.alfresco.cmis.client</groupId>
+                    <artifactId>alfresco-opencmis-extension</artifactId>
+                </exclusion>
+            </exclusions>            
         </dependency>
         <dependency>
             <groupId>org.alfresco</groupId>


### PR DESCRIPTION
…-extension from alfresco-remote-api
Regarding the issue REPO-4695, this is a library that can be removed according with the analysis done.