### PR TITLE
REPO-4897 - Remove library org.apache.chemistry.opencmis:chemistry-op…

### DIFF
--- a/war/pom.xml
+++ b/war/pom.xml
@@ -24,6 +24,12 @@
         <dependency>
             <groupId>org.alfresco</groupId>
             <artifactId>alfresco-remote-api</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.chemistry.opencmis</groupId>
+                    <artifactId>chemistry-opencmis-client-impl</artifactId>
+                </exclusion>
+            </exclusions>            
         </dependency>
         <dependency>
             <groupId>org.alfresco</groupId>


### PR DESCRIPTION
…encmis-client-impl from alfresco-remote-api
Regarding the issue REPO-4695, this is a library that can be removed according with the analysis done.