### PR TITLE
REPO-4898 - Remove library Remove library com.vaadin:vaadin from alfr…

### DIFF
--- a/war/pom.xml
+++ b/war/pom.xml
@@ -32,6 +32,12 @@
         <dependency>
             <groupId>org.alfresco</groupId>
             <artifactId>alfresco-enterprise-repository</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.vaadin</groupId>
+                    <artifactId>vaadin</artifactId>
+                </exclusion>                
+            </exclusions>            
         </dependency>
         <dependency>
             <groupId>org.alfresco</groupId>


### PR DESCRIPTION
…esco-enterprise-repository
Regarding the issue REPO-4695, this is a library that can be removed according with the analysis done.