### PR TITLE
REPO-4753: test acs-packaging build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
         <dependency.alfresco-enterprise-remote-api.version>8.75</dependency.alfresco-enterprise-remote-api.version>
         <dependency.alfresco-enterprise-repository.version>8.74</dependency.alfresco-enterprise-repository.version>
         <dependency.alfresco-remote-api.version>8.96</dependency.alfresco-remote-api.version>
-        <dependency.alfresco-repository.version>8.92</dependency.alfresco-repository.version>
+        <dependency.alfresco-repository.version>repo-4753-1</dependency.alfresco-repository.version>
         <dependency.alfresco-data-model.version>8.87</dependency.alfresco-data-model.version>
         <dependency.alfresco-core.version>8.21</dependency.alfresco-core.version>
 


### PR DESCRIPTION
Test acs-packing build after removing com.googlecode.mp4parser.isoparser. This lib is not used in repository project and triggers some conflict issues in tika.