### PR TITLE
REPO-4924 Add "Start Activiti Process" Action to repository codebase

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,7 @@
         <dependency.alfresco-core.version>8.21</dependency.alfresco-core.version>
 
         <dependency.alfresco-hb-data-sender.version>1.0.12</dependency.alfresco-hb-data-sender.version>
+        <dependency.activiti-repo-connector.version>1.2</dependency.activiti-repo-connector.version>
 
         <dependency.alfresco-spring-encryptor.version>6.1</dependency.alfresco-spring-encryptor.version>
         <dependency.alfresco-enterprise-crypto.version>6.2</dependency.alfresco-enterprise-crypto.version>
@@ -559,6 +560,11 @@
                 <groupId>org.alfresco</groupId>
                 <artifactId>alfresco-enterprise-remote-api</artifactId>
                 <version>${dependency.alfresco-enterprise-remote-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.activiti</groupId>
+                <artifactId>activiti-repo-connector</artifactId>
+                <version>${dependency.activiti-repo-connector.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.alfresco</groupId>

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -38,6 +38,10 @@
             <artifactId>alfresco-enterprise-crypto</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.activiti</groupId>
+            <artifactId>activiti-repo-connector</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.alfresco</groupId>
             <artifactId>alfresco-trashcan-cleaner</artifactId>
         </dependency>


### PR DESCRIPTION
Bring in the ACS 6 compatible activiti-repo-connector.jar as a dependency of acs-packaging. Code is enabled by setting an alfresco-global.property activitiRepoConnector.enabled=true

https://github.com/Alfresco/activiti-bpm-suite/tree/develop/integrations/alfresco