### PR TITLE
[REPO-4993] activation class duplicates

### DIFF
--- a/war/pom.xml
+++ b/war/pom.xml
@@ -180,6 +180,13 @@
             <groupId>org.glassfish.jaxb</groupId>
             <artifactId>jaxb-runtime</artifactId>
             <version>2.3.2</version>
+            <exclusions>
+                <!-- Duplicate classes from com.sun.activation:jakarta.activation-->
+                <exclusion>
+                    <groupId>jakarta.activation</groupId>
+                    <artifactId>jakarta.activation-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>javax.xml.soap</groupId>


### PR DESCRIPTION
Fixes: REPO-4993, REPO-4990 and REPO-4995: Use only jakarta.activation-1.2.1.jar and exclude conflicting libraries: jakarta.activation-api-1.2.1.jar, javax.activation-1.2.0.jar and activation-1.1.jar