### PR TITLE
Fix/repo 4906 veracode static scan

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ branches:
   only:
     - master
     - /support\/.*/
-    - fix/REPO-4906_veracode-static-scan
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ sudo: required
 language: java
 jdk:
   - openjdk11
-env:
-  - DATE=`date +"%Y-%m-%d-%H%M"`
 
 services:
   - docker
@@ -21,8 +19,10 @@ branches:
   only:
     - master
     - /support\/.*/
+    - fix/REPO-4906_veracode-static-scan
 
 env:
+  - DATE=`date +"%Y-%m-%d-%H%M"`
   global:
     # Release version has to start with real version (6.3.0-....) for the docker image to build successfully.
     - RELEASE_VERSION=

--- a/.travis.yml
+++ b/.travis.yml
@@ -179,5 +179,5 @@ matrix:
         - travis_retry travis_wait 30 mvn -q install -f war/pom.xml
       script:
         - java -jar vosp-api-wrappers-java-$VERACODE_WRAPPER_VERSION.jar -vid $VERACODE_API_ID -vkey $VERACODE_API_KEY
-          -action uploadandscan -appname "ACS Repository"-sandboxname "ACS Repo Team Sandbox" -createprofile false -filepath war/target/alfresco.war -version "$TRAVIS_JOB_ID - $TRAVIS_JOB_NUMBER $DATE"
+          -action uploadandscan -appname "ACS Repository" -sandboxname "ACS Repo Team Sandbox" -createprofile false -filepath war/target/alfresco.war -version "$TRAVIS_JOB_ID - $TRAVIS_JOB_NUMBER $DATE"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,11 +22,12 @@ branches:
     - fix/REPO-4906_veracode-static-scan
 
 env:
-  - DATE=`date +"%Y-%m-%d-%H%M"`
   global:
     # Release version has to start with real version (6.3.0-....) for the docker image to build successfully.
     - RELEASE_VERSION=
     - DEVELOPMENT_VERSION=
+    # Vercode static scan version
+    - DATE=`date +"%Y-%m-%d-%H%M"`
 
 stages:
   - name: test

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,6 @@ branches:
   only:
     - master
     - /support\/.*/
-    - fix/REPO-4906_veracode-static-scan
 
 # This should not be required on community build
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -174,11 +174,11 @@ matrix:
         - ./tests/scripts/start-compose.sh ./tests/environment/docker-compose-all-amps-test.yml
         - ./tests/scripts/wait-for-alfresco-start.sh "http://localhost:8082/alfresco"
         - travis_wait 20 mvn install -f tests/tas-all-amps/pom.xml -Pall-tas-tests -Denvironment=default -DrunBugs=false
-    - name: "Vercaode static code scan"
-        jdk: openjdk11
-        install:
-          - travis_retry travis_wait 30 mvn -q install -f war/pom.xml
-        script:
-          - java -jar vosp-api-wrappers-java-$VERACODE_WRAPPER_VERSION.jar -vid $VERACODE_API_ID -vkey $VERACODE_API_KEY
-            -action uploadandscan -appname "ACS Repository"-sandboxname "ACS Repo Team Sandbox" -createprofile false -filepath war/target/alfresco.war -version "$TRAVIS_JOB_ID - $TRAVIS_JOB_NUMBER $DATE"
+    - name: "Veracode static code scan"
+      jdk: openjdk11
+      install:
+        - travis_retry travis_wait 30 mvn -q install -f war/pom.xml
+      script:
+        - java -jar vosp-api-wrappers-java-$VERACODE_WRAPPER_VERSION.jar -vid $VERACODE_API_ID -vkey $VERACODE_API_KEY
+          -action uploadandscan -appname "ACS Repository"-sandboxname "ACS Repo Team Sandbox" -createprofile false -filepath war/target/alfresco.war -version "$TRAVIS_JOB_ID - $TRAVIS_JOB_NUMBER $DATE"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,6 @@ branches:
 before_install:
   - "cp .travis.settings.xml $HOME/.m2/settings.xml"
   - wget https://repo1.maven.org/maven2/com/veracode/vosp/api/wrappers/vosp-api-wrappers-java/$VERACODE_WRAPPER_VERSION/vosp-api-wrappers-java-$VERACODE_WRAPPER_VERSION.jar
-  - sha1sum -c <<< "$VERACODE_WAPPER_SHA1 vosp-api-wrappers-java-$VERACODE_WRAPPER_VERSION.jar"
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,6 @@ env:
     # Release version has to start with real version (6.3.0-....) for the docker image to build successfully.
     - RELEASE_VERSION=
     - DEVELOPMENT_VERSION=
-    # Vercode static scan version
-    - DATE=`date +"%Y-%m-%d-%H%M"`
 
 stages:
   - name: test
@@ -191,9 +189,10 @@ jobs:
       jdk: openjdk11
       install:
         - travis_retry travis_wait 30 mvn -q install -f war/pom.xml
+      before_install:
+        - bash scripts/veracode/static_analysis_init.sh
       script:
-        - java -jar vosp-api-wrappers-java-$VERACODE_WRAPPER_VERSION.jar -vid $VERACODE_API_ID -vkey $VERACODE_API_KEY
-          -action uploadandscan -appname "ACS Repository" -sandboxname "ACS Repo Team Sandbox" -createprofile false -filepath war/target/alfresco.war -version "$TRAVIS_JOB_ID - $TRAVIS_JOB_NUMBER $DATE"
+        - bash scripts/veracode/static_analysis.sh
     - name: "Release and Copy to S3 Staging Bucket"
       stage: release
       if: fork = false AND (branch = master OR branch =~ /support\/.*/) AND type != pull_request AND commit_message =~ /\[release\]/

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,8 +35,6 @@ stages:
 # This should not be required on community build
 before_install:
   - "cp .travis.settings.xml $HOME/.m2/settings.xml"
-  - wget https://repo1.maven.org/maven2/com/veracode/vosp/api/wrappers/vosp-api-wrappers-java/$VERACODE_WRAPPER_VERSION/vosp-api-wrappers-java-$VERACODE_WRAPPER_VERSION.jar
-
 jobs:
   include:
     - stage: test

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ branches:
   only:
     - master
     - /support\/.*/
+    - fix/REPO-4906_veracode-static-scan
 
 # This should not be required on community build
 before_install:
@@ -169,3 +170,4 @@ matrix:
         - ./tests/scripts/start-compose.sh ./tests/environment/docker-compose-all-amps-test.yml
         - ./tests/scripts/wait-for-alfresco-start.sh "http://localhost:8082/alfresco"
         - travis_wait 20 mvn install -f tests/tas-all-amps/pom.xml -Pall-tas-tests -Denvironment=default -DrunBugs=false
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ sudo: required
 language: java
 jdk:
   - openjdk11
+env:
+  - DATE=`date +"%Y-%m-%d-%H%M"`
 
 services:
   - docker
@@ -23,6 +25,8 @@ branches:
 # This should not be required on community build
 before_install:
   - "cp .travis.settings.xml $HOME/.m2/settings.xml"
+  - wget https://repo1.maven.org/maven2/com/veracode/vosp/api/wrappers/vosp-api-wrappers-java/$VERACODE_WRAPPER_VERSION/vosp-api-wrappers-java-$VERACODE_WRAPPER_VERSION.jar
+  - sha1sum -c <<< "$VERACODE_WAPPER_SHA1 vosp-api-wrappers-java-$VERACODE_WRAPPER_VERSION.jar"
 
 matrix:
   include:
@@ -170,4 +174,11 @@ matrix:
         - ./tests/scripts/start-compose.sh ./tests/environment/docker-compose-all-amps-test.yml
         - ./tests/scripts/wait-for-alfresco-start.sh "http://localhost:8082/alfresco"
         - travis_wait 20 mvn install -f tests/tas-all-amps/pom.xml -Pall-tas-tests -Denvironment=default -DrunBugs=false
+    - name: "Vercaode static code scan"
+        jdk: openjdk11
+        install:
+          - travis_retry travis_wait 30 mvn -q install -f war/pom.xml
+        script:
+          - java -jar vosp-api-wrappers-java-$VERACODE_WRAPPER_VERSION.jar -vid $VERACODE_API_ID -vkey $VERACODE_API_KEY
+            -action uploadandscan -appname "ACS Repository"-sandboxname "ACS Repo Team Sandbox" -createprofile false -filepath war/target/alfresco.war -version "$TRAVIS_JOB_ID - $TRAVIS_JOB_NUMBER $DATE"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -183,6 +183,8 @@ jobs:
         - ./tests/scripts/wait-for-alfresco-start.sh "http://localhost:8082/alfresco"
         - travis_wait 20 mvn install -f tests/tas-all-amps/pom.xml -Pall-tas-tests -Denvironment=default -DrunBugs=false
     - name: "Veracode static code scan"
+        # only on support branches or master and if it is not a PR
+      if: fork = false AND (branch = master OR branch =~ /support\/.*/) AND type != pull_request
       jdk: openjdk11
       install:
         - travis_retry travis_wait 30 mvn -q install -f war/pom.xml

--- a/scripts/veracode/static_analysis.sh
+++ b/scripts/veracode/static_analysis.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-
+set -e
 echo "=========================== Starting Static Analysis Script ==========================="
 
 java -jar vosp-api-wrappers-java-$VERACODE_WRAPPER_VERSION.jar -vid $VERACODE_API_ID -vkey $VERACODE_API_KEY \

--- a/scripts/veracode/static_analysis.sh
+++ b/scripts/veracode/static_analysis.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+echo "=========================== Starting Static Analysis Script ==========================="
+
+java -jar vosp-api-wrappers-java-$VERACODE_WRAPPER_VERSION.jar -vid $VERACODE_API_ID -vkey $VERACODE_API_KEY \
+          -action uploadandscan -appname "ACS Repository" -sandboxname "ACS Repo Team Sandbox" -createprofile false \
+           -filepath war/target/alfresco.war -version "$TRAVIS_JOB_ID - $TRAVIS_JOB_NUMBER"
+
+
+echo "=========================== Finishing Static Analysis Script =========================="

--- a/scripts/veracode/static_analysis_init.sh
+++ b/scripts/veracode/static_analysis_init.sh
@@ -2,5 +2,6 @@
 echo "=========================== Starting Static Analysis Init Script ==========================="
 
 wget https://repo1.maven.org/maven2/com/veracode/vosp/api/wrappers/vosp-api-wrappers-java/$VERACODE_WRAPPER_VERSION/vosp-api-wrappers-java-$VERACODE_WRAPPER_VERSION.jar
+sha1sum -c <<< "$VERACODE_WRAPPER_SHA1 vosp-api-wrappers-java-$VERACODE_WRAPPER_VERSION.jar"
 
 echo "=========================== Finishing Static Analysis Init Script =========================="

--- a/scripts/veracode/static_analysis_init.sh
+++ b/scripts/veracode/static_analysis_init.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+echo "=========================== Starting Static Analysis Init Script ==========================="
+
+wget https://repo1.maven.org/maven2/com/veracode/vosp/api/wrappers/vosp-api-wrappers-java/$VERACODE_WRAPPER_VERSION/vosp-api-wrappers-java-$VERACODE_WRAPPER_VERSION.jar
+
+echo "=========================== Finishing Static Analysis Init Script =========================="

--- a/scripts/veracode/static_analysis_init.sh
+++ b/scripts/veracode/static_analysis_init.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 echo "=========================== Starting Static Analysis Init Script ==========================="
 
 wget https://repo1.maven.org/maven2/com/veracode/vosp/api/wrappers/vosp-api-wrappers-java/$VERACODE_WRAPPER_VERSION/vosp-api-wrappers-java-$VERACODE_WRAPPER_VERSION.jar


### PR DESCRIPTION
Integrate Veracode static code scan with Travis.  Modified the travis file to add a new task to upload and scan alfresco.war file which generates a report on security flaws.