### PR TITLE
MNT-21472 : Space in Windows installation path cause FileNotFound

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,11 +34,11 @@
         <version.edition>Enterprise</version.edition>
         <image.tag>latest</image.tag>
 
-        <dependency.alfresco-enterprise-remote-api.version>7.54.1</dependency.alfresco-enterprise-remote-api.version>
-        <dependency.alfresco-enterprise-repository.version>7.69.2</dependency.alfresco-enterprise-repository.version>
-        <dependency.alfresco-remote-api.version>7.107.1</dependency.alfresco-remote-api.version>
-        <dependency.alfresco-repository.version>7.134.1</dependency.alfresco-repository.version>
-        <dependency.alfresco-data-model.version>8.50.2</dependency.alfresco-data-model.version>
+        <dependency.alfresco-enterprise-remote-api.version>7.54.2</dependency.alfresco-enterprise-remote-api.version>
+        <dependency.alfresco-enterprise-repository.version>7.69.3</dependency.alfresco-enterprise-repository.version>
+        <dependency.alfresco-remote-api.version>7.107.2</dependency.alfresco-remote-api.version>
+        <dependency.alfresco-repository.version>7.134.5</dependency.alfresco-repository.version>
+        <dependency.alfresco-data-model.version>8.50.2.1</dependency.alfresco-data-model.version>
         <dependency.alfresco-core.version>7.22</dependency.alfresco-core.version>
 
         <dependency.alfresco-hb-data-sender.version>1.0.12</dependency.alfresco-hb-data-sender.version>


### PR DESCRIPTION
   Bump data-model to 8.50.2.1
   Bump alfresco-repository to 7.134.5
   Bump alfresco-remote-api to 7.107.2
   Bump alfresco-enterprise-repository to 7.69.3
   Bump alfresco-enterprise-remote-api to 7.54.2