### PR TITLE
ACE-6029 alfresco-content-services-distribution-6.2.1-RC3.zip is miss…

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -88,6 +88,17 @@
         </dependency>
         <!-- SOLR Distribution: Run Alfresco Search Services Separately -->
         <!-- SHARE Distribution -->
+        <dependency>
+            <groupId>org.alfresco</groupId>
+            <artifactId>alfresco-content-services-share-distribution</artifactId>
+            <type>zip</type>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
     </dependencies>
 
     <build>
@@ -115,6 +126,12 @@
                                     <groupId>org.alfresco</groupId>
                                     <artifactId>alfresco-repository</artifactId>
                                     <includes>alfresco/keystore/**</includes>
+                                </artifactItem>
+
+                                <artifactItem>
+                                    <groupId>org.alfresco</groupId>
+                                    <artifactId>alfresco-content-services-share-distribution</artifactId>
+                                    <type>zip</type>
                                 </artifactItem>
                             </artifactItems>
                         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -527,6 +527,12 @@
             </dependency>
             <dependency>
                 <groupId>org.alfresco</groupId>
+                <artifactId>alfresco-content-services-share-distribution</artifactId>
+                <version>${alfresco.share.version}</version>
+                <type>zip</type>
+            </dependency>
+            <dependency>
+                <groupId>org.alfresco</groupId>
                 <artifactId>alfresco-share-services</artifactId>
                 <version>${alfresco.alfresco-share-services.version}</version>
                 <type>amp</type>


### PR DESCRIPTION
…ing all ACS Share components

Revert "REPO-4833 - Remove library org.alfresco:alfresco-content-services-share-distribution from acs-packaging project (#675)"

This reverts commit 542936a7397ca09b40bab309a600f3d8f948230d.