### PR TITLE
ACS-100 Update api-explorer to 6.2.1.1 into master

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <dependency.alfresco-trashcan-cleaner.version>2.3</dependency.alfresco-trashcan-cleaner.version>
         <dependency.alfresco-jlan.version>7.1</dependency.alfresco-jlan.version>
         <dependency.alfresco-server-root.version>6.0.1</dependency.alfresco-server-root.version>
-        <dependency.alfresco-api-explorer.version>6.3.0</dependency.alfresco-api-explorer.version>
+        <dependency.alfresco-api-explorer.version>6.2.1.1</dependency.alfresco-api-explorer.version>
         <dependency.gytheio.version>0.11.3</dependency.gytheio.version>
         <dependency.alfresco-log-sanitizer.version>0.2</dependency.alfresco-log-sanitizer.version>
 


### PR DESCRIPTION
Currently ACS 6.2.1-RC3 contains a reference to rest-api-explorer 6.3.0. This is wrong. There is a released 6.2.1 version but there have been more commits since. This PR updates master in order to use 6.2.1.1 version (released 29/04/20) which include these additional commits.