### PR TITLE
ACS-222 / REPO-4859 : HTTP_UNAUTHORIZED instead of HTTP_FORBIDDEN for some CMIS apis

### DIFF
--- a/tests/environment/realms/alfresco-realm.json
+++ b/tests/environment/realms/alfresco-realm.json
@@ -4,7 +4,7 @@
   "notBefore": 0,
   "revokeRefreshToken": false,
   "refreshTokenMaxReuse": 0,
-  "accessTokenLifespan": 100,
+  "accessTokenLifespan": 300,
   "accessTokenLifespanForImplicitFlow": 900,
   "ssoSessionIdleTimeout": 1800,
   "ssoSessionMaxLifespan": 36000,

--- a/tests/tas-cmis/src/test/java/org/alfresco/cmis/UpdatePropertiesTests.java
+++ b/tests/tas-cmis/src/test/java/org/alfresco/cmis/UpdatePropertiesTests.java
@@ -115,7 +115,7 @@ public class UpdatePropertiesTests extends CmisTest
         dataUser.deleteUser(toBeDeleted);
         // Token will still be valid right after this call
         // Just wait for it to expire
-        Thread.sleep(120 * 1000);
+        Thread.sleep(320 * 1000);
         
         cmisApi.updateProperty("cmis:name", propertyNameValue);
     }


### PR DESCRIPTION
    - reverting changes hoping to fix intermitent test failures