### PR TITLE
MNT-21430-Added cors-filter dependency

### DIFF
--- a/war/pom.xml
+++ b/war/pom.xml
@@ -209,6 +209,11 @@
             <version>3.0.1</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>com.thetransactioncompany</groupId>
+            <artifactId>cors-filter</artifactId>
+            <version>2.9</version>
+        </dependency>
         <!-- Test dependencies -->
         <dependency>
             <groupId>org.alfresco</groupId>


### PR DESCRIPTION
cors-filter jar was missing in 6.2.1 release. ACS fails to start if CORS is enabled(cors.enabled=true) in alfresco-global.properties because of the missing jars.
https://issues.alfresco.com/jira/browse/MNT-21430