### PR TITLE
REPO-4641: Azure Connector supports more authentication options

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
         <alfresco.glacier-connector.version>2.1.0-A2</alfresco.glacier-connector.version>
 
         <!-- Alfresco Content Connector for Azure version -->
-        <alfresco.azure-connector.version>1.0</alfresco.azure-connector.version>
+        <alfresco.azure-connector.version>1.1-RC1</alfresco.azure-connector.version>
 
         <!-- Alfresco Centera Connector version -->
         <alfresco.centera-connector.version>2.2.1</alfresco.centera-connector.version>

--- a/tests/environment/docker-compose-all-amps-test.yml
+++ b/tests/environment/docker-compose-all-amps-test.yml
@@ -54,6 +54,7 @@ services:
         -Ds3.autoLowerCaseBucketName=true
 
         -Dconnector.az.account.name=${AZURE_STORAGE_ACCOUNT_NAME}
+        -Dconnector.az.authentication.mode=${AZURE_AUTHENTICATION_MODE}
         -Dconnector.az.account.key=${AZURE_STORAGE_ACCOUNT_KEY}
         -Dconnector.az.containerName=packaging-test-container
         -Dconnector.az.deleted.containerName=packaging-test-container-del

--- a/tests/environment/docker-compose-all-amps-test.yml
+++ b/tests/environment/docker-compose-all-amps-test.yml
@@ -8,7 +8,7 @@ version: "3"
 # Add the following environment variable to CATALINA_OPTS to activate YourKit profiling agent on tomcat
 #-agentpath:/usr/local/YourKit-JavaProfiler-2018.04/bin/linux-x86-64/libyjpagent.so=delay=200000,listen=all,sessionname=$$HOSTNAME,dir=/tmp/Alfresco/yourkit,onexit=snapshot,periodicperf=600,periodicmem=600,probe_off=*
 
-# This docker-compose requires AZURE_STORAGE_ACCOUNT_NAME and AZURE_STORAGE_ACCOUNT_KEY environment variables to be set to startup
+# This docker-compose requires AZURE_STORAGE_ACCOUNT_NAME, AZURE_AUTHENTICATION_MODE and AZURE_STORAGE_ACCOUNT_KEY environment variables to be set to startup
 
 services:
   alfresco:

--- a/tests/tas-all-amps/src/test/java/org/alfresco/rest/discovery/DiscoveryTests.java
+++ b/tests/tas-all-amps/src/test/java/org/alfresco/rest/discovery/DiscoveryTests.java
@@ -71,6 +71,7 @@ public class DiscoveryTests extends RestTest
                 "org.alfresco.integrations.google.docs",
                 "alfresco-trashcan-cleaner",
                 "org_alfresco_integrations_S3Connector",
+                "org_alfresco_integrations_AzureConnector",
                 "org_alfresco_module_xamconnector",
                 "alfresco-content-connector-for-salesforce-repo",
                 "alfresco-share-services",

--- a/tests/tas-all-amps/src/test/java/org/alfresco/rest/discovery/DiscoveryTests.java
+++ b/tests/tas-all-amps/src/test/java/org/alfresco/rest/discovery/DiscoveryTests.java
@@ -78,14 +78,15 @@ public class DiscoveryTests extends RestTest
                 "alfresco-saml-repo",
                 "org_alfresco_device_sync_repo",
                 "org_alfresco_mm_repo", "alfresco-ai-repo",
+                "org_alfresco_module_rm", "alfresco-rm-enterprise-repo",
                 "alfresco-glacier-connector-repo",
                 "org.alfresco.module.TransformationServer");
 
         expectedModules.forEach(module ->
                 assertTrue(modules.contains(module), String.format("Expected module %s is not installed", module)));
 
-        // Check that all installed modules are in INSTALLED state
+        // Check that all installed modules are in INSTALLED and also UNKNOWN state as reported by some
         List<String> modulesStates = restClient.onResponse().getResponse().jsonPath().getList("entry.repository.modules.installState", String.class);
-        assertEquals("Number of amps installed should match expected", expectedModules.size(), Collections.frequency(modulesStates, "INSTALLED"));
+        assertEquals("Number of amps installed should match expected" + modulesStates, expectedModules.size(), Collections.frequency(modulesStates, "INSTALLED") + Collections.frequency(modulesStates, "UNKNOWN"));
     }
 }


### PR DESCRIPTION
- Bump Azure Connector to `1.1-RC1` and use default `sharedKey` authentication mode in CI/CD pipeline

Note: While making changes below was observed:
```
{"id":"org_alfresco_module_rm","title":"AGS Repo","description":"Alfresco Governance Services Repository Extension","version":"3.3.1","installState":"UNKNOWN","versionMin":"6.2","versionMax":"999"}

{"id":"alfresco-ai-repo","title":"Alfresco Intelligence Services Repository AMP","description":"Extensions in Alfresco Repository for the Alfresco Intelligence Services","version":"1.1.2","installState":"UNKNOWN","versionMin":"6.2.0","versionMax":"6.99.99"}

{"id":"alfresco-trashcan-cleaner","title":"alfresco-trashcan-cleaner project","description":"The Alfresco Trashcan Cleaner (Alfresco Module)","version":"2.3","installState":"UNKNOWN","versionMin":"0","versionMax":"999"}
```
No idea on why the `installState` is being `UNKNOWN` although they seems to be installed