### PR TITLE
ATS-761: Bump to AIS 1.2.0-A1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@
         <alfresco.desktop-sync.version>3.3.2</alfresco.desktop-sync.version>
 
         <!-- Alfresco Alfresco Intelligence Services (AIS) -->
-        <alfresco.ais.version>1.1.2</alfresco.ais.version>
+        <alfresco.ais.version>1.2.0-A1</alfresco.ais.version>
 
         <installer.version.name>${project.version}</installer.version.name>
         <alfresco.package.name>alfresco</alfresco.package.name>


### PR DESCRIPTION
- note: requires ATS (T-Router) 1.3.0-A2 (or higher)