### PR TITLE
ACS-370: Newer metadata-extractor (2.13.0)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -697,6 +697,12 @@
                 <artifactId>jsoup</artifactId>
                 <version>1.12.2</version>
             </dependency>
+            <!-- Newer metadata-extractor, used in TIKA, see ACS-370 -->
+            <dependency>
+                <groupId>com.drewnoakes</groupId>
+                <artifactId>metadata-extractor</artifactId>
+                <version>2.13.0</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 </project>

--- a/tests/tas-all-amps/pom.xml
+++ b/tests/tas-all-amps/pom.xml
@@ -283,7 +283,7 @@
                                             <overWrite>false</overWrite>
                                             <outputDirectory>${project.build.directory}/amps_share</outputDirectory>
                                         </artifactItem>
-                                        <artifactItem>
+                                      <!--  <artifactItem>
                                             <groupId>org.alfresco.mediamanagement</groupId>
                                             <artifactId>alfresco-mm-repo</artifactId>
                                             <version>${alfresco.mm.version}</version>
@@ -298,7 +298,7 @@
                                             <type>amp</type>
                                             <overWrite>false</overWrite>
                                             <outputDirectory>${project.build.directory}/amps_share</outputDirectory>
-                                        </artifactItem>
+                                        </artifactItem>-->
                                         <artifactItem>
                                             <groupId>org.alfresco</groupId>
                                             <artifactId>alfresco-document-transformation-engine-repo</artifactId>

--- a/tests/tas-all-amps/src/test/java/org/alfresco/rest/discovery/DiscoveryTests.java
+++ b/tests/tas-all-amps/src/test/java/org/alfresco/rest/discovery/DiscoveryTests.java
@@ -76,7 +76,8 @@ public class DiscoveryTests extends RestTest
                 "alfresco-share-services",
                 "alfresco-saml-repo",
                 "org_alfresco_device_sync_repo",
-                "org_alfresco_mm_repo", "alfresco-ai-repo",
+//                "org_alfresco_mm_repo", 
+                "alfresco-ai-repo",
 //                "alfresco-glacier-connector-repo",
                 "org.alfresco.module.TransformationServer");
 


### PR DESCRIPTION
- Add direct dependency in acs-packaging
- Comment out the MM amps, which are incompatible with the new metadata-extractor version