### PR TITLE
Fix/mnt 21602 script node return invalid donwload url

### DIFF
--- a/war/src/main/java/org/alfresco/web/app/Application.java
+++ b/war/src/main/java/org/alfresco/web/app/Application.java
@@ -1,0 +1,238 @@
+/*
+ * #%L
+ * Alfresco Repository WAR Community
+ * %%
+ * Copyright (C) 2005 - 2016 Alfresco Software Limited
+ * %%
+ * This file is part of the Alfresco software.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail.  Otherwise, the software is
+ * provided under the following open source license terms:
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+package org.alfresco.web.app;
+
+import org.alfresco.repo.content.MimetypeMap;
+import org.alfresco.repo.importer.ImporterBootstrap;
+import org.alfresco.service.cmr.repository.StoreRef;
+import org.alfresco.web.app.servlet.AuthenticationHelper;
+import org.alfresco.web.bean.repository.User;
+import org.apache.commons.logging.Log;
+import org.springframework.context.ApplicationContext;
+import org.springframework.extensions.surf.util.I18NUtil;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.context.support.WebApplicationContextUtils;
+
+import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+import java.io.IOException;
+import java.util.Locale;
+import java.util.ResourceBundle;
+
+/**
+ * Utilities class
+ *
+ * @author gavinc
+ */
+public class Application
+{
+   private static final String LOCALE = "locale";
+
+   public static final String BEAN_IMPORTER_BOOTSTRAP = "spacesBootstrap";
+
+   public static final String MESSAGE_BUNDLE = "alfresco.messages.webclient";
+
+   private static ThreadLocal<Boolean> inPortalServer = new ThreadLocal<Boolean>();
+   private static StoreRef repoStoreRef = null;
+   private static String companyRootId;
+
+
+   /**
+    * Private constructor to prevent instantiation of this class
+    */
+   private Application()
+   {
+   }
+
+   /**
+    * Determines whether the server is running in a portal
+    *
+    * @return true if we are running inside a portal server
+    */
+   public static boolean inPortalServer()
+   {
+      Boolean result = inPortalServer.get();
+      return result == null ? false : result;
+   }
+
+   /**
+    * Handles error conditions detected by servlets.
+    *
+    * @param servletContext
+    *           The servlet context
+    * @param request
+    *           The HTTP request
+    * @param response
+    *           The HTTP response
+    * @param messageKey
+    *           the resource bundle key for the error mesage
+    * @param statusCode
+    *           the status code to set on the response
+    * @param logger
+    *           The logger
+    * @throws IOException
+    *            Signals that an I/O exception has occurred.
+    * @throws ServletException
+    *            the servlet exception
+    */
+   public static void handleSystemError(ServletContext servletContext, HttpServletRequest request,
+         HttpServletResponse response, String messageKey, int statusCode, Log logger)
+         throws IOException, ServletException
+   {
+      // get the error bean from the session and set the error that occurred.
+      HttpSession session = request.getSession();
+      throw new ServletException(getMessage(session, messageKey));
+   }
+
+   /**
+    * Retrieves the configured error page for the application
+    *
+    * @param servletContext The servlet context
+    * @return The configured error page or null if the configuration is missing
+    */
+   public static String getErrorPage(ServletContext servletContext)
+   {
+      return getErrorPage(WebApplicationContextUtils.getRequiredWebApplicationContext(servletContext));
+   }
+
+   /**
+    * Retrieves the configured login page for the application
+    *
+    * @param servletContext The servlet context
+    * @return The configured login page or null if the configuration is missing
+    */
+   public static String getLoginPage(ServletContext servletContext)
+   {
+      return getLoginPage(WebApplicationContextUtils.getRequiredWebApplicationContext(servletContext));
+   }
+
+   /**
+    * @return Returns the User object representing the currently logged in user
+    */
+   public static User getCurrentUser(HttpSession session)
+   {
+      return (User)session.getAttribute(AuthenticationHelper.AUTHENTICATION_USER);
+   }
+
+   /**
+    * @return Returns id of the company root
+    *
+    * @deprecated Replace with user-context-specific getCompanyRootId (e.g. could be tenant-specific)
+    */
+   public static String getCompanyRootId()
+   {
+      return companyRootId;
+   }
+
+   /**
+    * Get the specified I18N message string from the default message bundle for this user
+    *
+    * @param session        HttpSession
+    * @param msg            Message ID
+    *
+    * @return String from message bundle or $$msg$$ if not found
+    */
+   public static String getMessage(HttpSession session, String msg)
+   {
+      return getBundle(session).getString(msg);
+   }
+
+   /**
+    * Get the specified the default message bundle for this user
+    *
+    * @param session        HttpSession
+    *
+    * @return ResourceBundle for this user
+    */
+   public static ResourceBundle getBundle(HttpSession session)
+   {
+      ResourceBundle bundle = (ResourceBundle)session.getAttribute(MESSAGE_BUNDLE);
+      if (bundle == null)
+      {
+         // get Locale from language selected by each user on login
+         Locale locale = (Locale)session.getAttribute(LOCALE);
+         if (locale == null)
+         {
+            bundle = ResourceBundleWrapper.getResourceBundle(MESSAGE_BUNDLE, I18NUtil.getLocale());
+         }
+         else
+         {
+            // Only cache the bundle if/when we have a session locale
+            bundle = ResourceBundleWrapper.getResourceBundle(MESSAGE_BUNDLE, locale);
+            session.setAttribute(MESSAGE_BUNDLE, bundle);
+         }
+      }
+
+      return bundle;
+   }
+
+   /**
+    * Returns the repository store URL
+    *
+    * @param context The spring context
+    * @return The repository store URL to use
+    */
+   public static StoreRef getRepositoryStoreRef(WebApplicationContext context)
+   {
+      if (repoStoreRef == null)
+      {
+         ImporterBootstrap bootstrap = (ImporterBootstrap)context.getBean(BEAN_IMPORTER_BOOTSTRAP);
+         repoStoreRef = bootstrap.getStoreRef();
+      }
+
+      return repoStoreRef;
+   }
+
+      public static StoreRef getStoreRef()
+      {
+         return repoStoreRef;
+      }
+
+   /**
+    * Retrieves the configured error page for the application
+    *
+    * @param context The Spring context
+    * @return The configured error page or null if the configuration is missing
+    */
+   public static String getErrorPage(ApplicationContext context)
+   {
+      return null;
+   }
+
+   /**
+    * Retrieves the configured login page for the application
+    *
+    * @param context The Spring context
+    * @return The configured login page or null if the configuration is missing
+    */
+   public static String getLoginPage(ApplicationContext context)
+   {
+      return null;
+   }
+}

--- a/war/src/main/java/org/alfresco/web/app/ResourceBundleWrapper.java
+++ b/war/src/main/java/org/alfresco/web/app/ResourceBundleWrapper.java
@@ -81,22 +81,6 @@ public final class ResourceBundleWrapper extends ResourceBundle implements Seria
    }
 
    /**
-    * Get the message service
-    *
-    * @return   MessageService  message service
-    */
-   private MessageService getMessageService()
-   {
-//       if (this.messageService == null && FacesContext.getCurrentInstance() != null)
-//       {
-//           this.messageService = (MessageService) FacesContextUtils.getRequiredWebApplicationContext(
-//                                       FacesContext.getCurrentInstance()).getBean(BEAN_RESOURCE_MESSAGE_SERVICE);
-//       }
-//       return this.messageService;
-      return null;
-   }
-
-   /**
     * Get a list of the delegate resource bundles
     *
     * @return   List<ResourceBundle>    list of delegate resource bundles
@@ -109,38 +93,6 @@ public final class ResourceBundleWrapper extends ResourceBundle implements Seria
 
          // Check for custom bundle (if any) - first try in the repo otherwise try the classpath
          ResourceBundle customBundle = null;
-
-         if (getMessageService() != null)
-         {
-             StoreRef storeRef = null;
-             String path = null;
-
-             try
-             {
-                String customName = null;
-                int idx = this.bundleName.lastIndexOf(".");
-                if (idx != -1)
-                {
-                   customName = this.bundleName.substring(idx+1, this.bundleName.length());
-                }
-                else
-                {
-                   customName = this.bundleName;
-                }
-
-                storeRef = Application.getStoreRef();
-
-                // TODO - make path configurable in one place ...
-                // Note: path here is XPath for selectNodes query
-                path = PATH + "/cm:" + customName;
-                customBundle = getMessageService().getRepoResourceBundle(Application.getStoreRef(), path, locale);
-             }
-             catch (Throwable t)
-             {
-                // for now ... ignore the error, cannot be found or read from repo
-                logger.debug("Custom Web Client properties not found: " + storeRef + path);
-             }
-         }
 
          if (customBundle == null)
          {
@@ -284,16 +236,6 @@ public final class ResourceBundleWrapper extends ResourceBundle implements Seria
    public static ResourceBundle getResourceBundle(String name, Locale locale)
    {
        return new ResourceBundleWrapper(locale, name);
-   }
-
-   /**
-    * Adds a resource bundle to the collection of custom bundles available
-    *
-    * @param name   the name of the resource bundle
-    */
-   public static void addResourceBundle(String name)
-   {
-       ResourceBundleWrapper.addedBundleNames.add(name);
    }
 
    /**

--- a/war/src/main/java/org/alfresco/web/app/ResourceBundleWrapper.java
+++ b/war/src/main/java/org/alfresco/web/app/ResourceBundleWrapper.java
@@ -1,0 +1,324 @@
+/*
+ * #%L
+ * Alfresco Repository WAR Community
+ * %%
+ * Copyright (C) 2005 - 2016 Alfresco Software Limited
+ * %%
+ * This file is part of the Alfresco software.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail.  Otherwise, the software is
+ * provided under the following open source license terms:
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+package org.alfresco.web.app;
+
+import org.alfresco.repo.i18n.MessageService;
+import org.alfresco.service.cmr.repository.StoreRef;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+//import javax.faces.context.FacesContext;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.Locale;
+import java.util.MissingResourceException;
+import java.util.ResourceBundle;
+import java.util.Vector;
+
+/**
+ * Wrapper around Alfresco Resource Bundle objects. Used to catch and handle missing
+ * resource exception to help identify missing I18N strings in client apps.
+ * Also used to look for the requested string in a custom resource bundle.
+ *
+ * @author Kevin Roast
+ */
+public final class ResourceBundleWrapper extends ResourceBundle implements Serializable
+{
+   private static final long serialVersionUID = -3230653664902689948L;
+   private static Log logger = LogFactory.getLog(ResourceBundleWrapper.class);
+
+   /** List of custom bundle names */
+   private static List<String> addedBundleNames = new ArrayList<String>(10);
+
+   /** Serializable details of the resource bundles being wrapped */
+   final private Locale locale;
+   final private String bundleName;
+
+   /** List of delegate resource bundles */
+   transient private List<ResourceBundle> delegates;
+
+   /** Message service */
+   transient private MessageService messageService;
+
+   public static final String BEAN_RESOURCE_MESSAGE_SERVICE = "messageService";
+   public static final String PATH = "app:company_home/app:dictionary/app:webclient_extension";
+
+   /**
+    * Constructor
+    *
+    * @param locale         the locale
+    * @param bundleName     the bundle name
+    */
+   private ResourceBundleWrapper(Locale locale, String bundleName)
+   {
+      this.locale = locale;
+      this.bundleName = bundleName;
+   }
+
+   /**
+    * Get the message service
+    *
+    * @return   MessageService  message service
+    */
+   private MessageService getMessageService()
+   {
+//       if (this.messageService == null && FacesContext.getCurrentInstance() != null)
+//       {
+//           this.messageService = (MessageService) FacesContextUtils.getRequiredWebApplicationContext(
+//                                       FacesContext.getCurrentInstance()).getBean(BEAN_RESOURCE_MESSAGE_SERVICE);
+//       }
+//       return this.messageService;
+      return null;
+   }
+
+   /**
+    * Get a list of the delegate resource bundles
+    *
+    * @return   List<ResourceBundle>    list of delegate resource bundles
+    */
+   private List<ResourceBundle> getDelegates()
+   {
+      if (this.delegates == null)
+      {
+         this.delegates = new ArrayList<ResourceBundle>(ResourceBundleWrapper.addedBundleNames.size() + 2);
+
+         // Check for custom bundle (if any) - first try in the repo otherwise try the classpath
+         ResourceBundle customBundle = null;
+
+         if (getMessageService() != null)
+         {
+             StoreRef storeRef = null;
+             String path = null;
+
+             try
+             {
+                String customName = null;
+                int idx = this.bundleName.lastIndexOf(".");
+                if (idx != -1)
+                {
+                   customName = this.bundleName.substring(idx+1, this.bundleName.length());
+                }
+                else
+                {
+                   customName = this.bundleName;
+                }
+
+                storeRef = Application.getStoreRef();
+
+                // TODO - make path configurable in one place ...
+                // Note: path here is XPath for selectNodes query
+                path = PATH + "/cm:" + customName;
+                customBundle = getMessageService().getRepoResourceBundle(Application.getStoreRef(), path, locale);
+             }
+             catch (Throwable t)
+             {
+                // for now ... ignore the error, cannot be found or read from repo
+                logger.debug("Custom Web Client properties not found: " + storeRef + path);
+             }
+         }
+
+         if (customBundle == null)
+         {
+            // also look up the custom version of the bundle in the extension package
+            String customName = determineCustomBundleName(this.bundleName);
+            customBundle = getResourceBundle(locale, customName);
+         }
+
+         // Add the custom bundle (if any) - add first to allow override (eg. in MT/dynamic web client env)
+         if (customBundle != null)
+         {
+            this.delegates.add(customBundle);
+         }
+
+         // Add the normal bundle
+         ResourceBundle normalBundle = getResourceBundle(locale, this.bundleName);
+         if (normalBundle != null)
+         {
+            this.delegates.add(normalBundle);
+         }
+         else
+         {
+            if (logger.isWarnEnabled())
+            {
+               logger.warn("Resource bundle missing : " + this.bundleName + ", locale : " + locale);
+            }
+         }
+
+         // Add the added bundles
+         for (String addedBundleName : ResourceBundleWrapper.addedBundleNames)
+         {
+            this.delegates.add(getResourceBundle(locale, addedBundleName));
+         }
+      }
+      return this.delegates;
+   }
+
+   /**
+    * Given a local and name, gets the resource bundle
+    *
+    * @param locale             locale
+    * @param bundleName         bundle name
+    * @return ResourceBundle    resource bundle
+    */
+   private ResourceBundle getResourceBundle(Locale locale, String bundleName)
+   {
+       ResourceBundle bundle = null;
+       try
+       {
+           // Load the bundle
+           bundle = ResourceBundle.getBundle(bundleName, locale);
+           this.delegates.add(bundle);
+
+           if (logger.isDebugEnabled())
+           {
+              logger.debug("Located and loaded bundle " + bundleName);
+           }
+       }
+       catch (MissingResourceException mre)
+       {
+          // ignore the error, just log some debug info
+          if (logger.isDebugEnabled())
+          {
+              logger.debug("Unable to load bundle " + bundleName);
+          }
+       }
+       return bundle;
+   }
+
+   /**
+    * @see java.util.ResourceBundle#getKeys()
+    */
+   public Enumeration<String> getKeys()
+   {
+      if (getDelegates().size() == 1)
+      {
+         return getDelegates().get(0).getKeys();
+      }
+      else
+      {
+         Vector<String> allKeys = new Vector<String>(100, 2);
+         for (ResourceBundle delegate : getDelegates())
+         {
+             Enumeration<String> keys = delegate.getKeys();
+             while(keys.hasMoreElements() == true)
+             {
+                 allKeys.add(keys.nextElement());
+             }
+         }
+
+         return allKeys.elements();
+      }
+   }
+
+   /**
+    * @see java.util.ResourceBundle#handleGetObject(java.lang.String)
+    */
+   protected Object handleGetObject(String key)
+   {
+      Object result = null;
+
+      for (ResourceBundle delegate : getDelegates())
+      {
+         try
+         {
+            // Try and lookup the key from the resource bundle
+            result = delegate.getObject(key);
+            if (result != null)
+            {
+                break;
+            }
+         }
+         catch (MissingResourceException mre)
+         {
+            // ignore as this means the key was not present
+         }
+      }
+
+      // if the key was not found return a default string
+      if (result == null)
+      {
+         if (logger.isWarnEnabled() == true)
+         {
+            logger.warn("Failed to find I18N message key: " + key + " for locale: " + locale.toString());
+         }
+
+         result = "$$" + key + "$$";
+      }
+
+      return result;
+   }
+
+   /**
+    * Factory method to get a named wrapped resource bundle for a particular locale.
+    *
+    * @param name               Bundle name
+    * @param locale             Locale to retrieve bundle for
+    *
+    * @return Wrapped ResourceBundle instance for specified locale
+    */
+   public static ResourceBundle getResourceBundle(String name, Locale locale)
+   {
+       return new ResourceBundleWrapper(locale, name);
+   }
+
+   /**
+    * Adds a resource bundle to the collection of custom bundles available
+    *
+    * @param name   the name of the resource bundle
+    */
+   public static void addResourceBundle(String name)
+   {
+       ResourceBundleWrapper.addedBundleNames.add(name);
+   }
+
+   /**
+    * Determines the name for the custom bundle to lookup based on the given
+    * bundle name
+    *
+    * @param bundleName The standard bundle
+    * @return The name of the custom bundle (in the alfresco.extension package)
+    */
+   protected static String determineCustomBundleName(String bundleName)
+   {
+      String extensionPackage = "alfresco.extension.";
+      String customBundleName = null;
+
+      int idx = bundleName.lastIndexOf(".");
+      if (idx == -1)
+      {
+         customBundleName = extensionPackage + bundleName;
+      }
+      else
+      {
+         customBundleName = extensionPackage +
+               bundleName.substring(idx+1, bundleName.length());
+      }
+
+      return customBundleName;
+   }
+}

--- a/war/src/main/java/org/alfresco/web/app/servlet/AuthenticationHelper.java
+++ b/war/src/main/java/org/alfresco/web/app/servlet/AuthenticationHelper.java
@@ -1,0 +1,637 @@
+/*
+ * #%L
+ * Alfresco Repository WAR Community
+ * %%
+ * Copyright (C) 2005 - 2016 Alfresco Software Limited
+ * %%
+ * This file is part of the Alfresco software.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail.  Otherwise, the software is
+ * provided under the following open source license terms:
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+package org.alfresco.web.app.servlet;
+
+import org.alfresco.error.AlfrescoRuntimeException;
+import org.alfresco.model.ContentModel;
+import org.alfresco.repo.SessionUser;
+import org.alfresco.repo.management.subsystems.ActivateableBean;
+import org.alfresco.repo.security.authentication.AuthenticationComponent;
+import org.alfresco.repo.security.authentication.AuthenticationException;
+import org.alfresco.repo.security.authentication.AuthenticationUtil;
+import org.alfresco.repo.security.authentication.external.RemoteUserMapper;
+import org.alfresco.repo.security.permissions.AccessDeniedException;
+import org.alfresco.repo.transaction.RetryingTransactionHelper;
+import org.alfresco.repo.webdav.auth.AuthenticationDriver;
+import org.alfresco.service.ServiceRegistry;
+import org.alfresco.service.cmr.repository.NodeRef;
+import org.alfresco.service.cmr.repository.NodeService;
+import org.alfresco.service.cmr.security.AuthenticationService;
+import org.alfresco.service.cmr.security.AuthorityService;
+import org.alfresco.service.cmr.security.PersonService;
+import org.alfresco.web.app.Application;
+import org.alfresco.web.bean.repository.User;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.extensions.surf.util.Base64;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.context.support.WebApplicationContextUtils;
+
+import javax.servlet.ServletContext;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+
+/**
+ * Helper to authenticate the current user using available Ticket information.
+ * <p>
+ * User information is looked up in the Session. If found the ticket is retrieved and validated.
+ * If the ticket is invalid then a redirect is performed to the login page.
+ * <p>
+ * If no User info is found then a search will be made for a previous username stored in a Cookie
+ * value. If the username if found then a redirect to the Login page will occur. If no username
+ * is found then Guest access login will be attempted by the system. Guest access can be forced
+ * with the appropriate method call.
+ *
+ * @author Kevin Roast
+ */
+public final class AuthenticationHelper
+{
+   /** session variables */
+   public static final String AUTHENTICATION_USER = AuthenticationDriver.AUTHENTICATION_USER;
+   public static final String SESSION_USERNAME = "_alfLastUser";
+   public static final String SESSION_INVALIDATED = "_alfSessionInvalid";
+    public static final String LOGIN_EXTERNAL_AUTH = "_alfExternalAuth";
+
+   /** JSF bean IDs */
+   public static final String LOGIN_BEAN = "LoginBean";
+
+   /** public service bean IDs **/
+   private static final String AUTHENTICATION_SERVICE = "AuthenticationService";
+   private static final String AUTHENTICATION_COMPONENT = "AuthenticationComponent";
+   private static final String REMOTE_USER_MAPPER = "RemoteUserMapper";
+   private static final String UNPROTECTED_AUTH_SERVICE = "authenticationService";
+   private static final String PERSON_SERVICE = "personService";
+   private static final String AUTHORITY_SERVICE = "AuthorityService";
+
+   /** cookie names */
+   private static final String COOKIE_ALFUSER = "alfUser0";
+
+   private static Log logger = LogFactory.getLog(AuthenticationHelper.class);
+
+   /**
+    * Does all the stuff you need to do after successfully authenticating/validating a user ticket to set up the request
+    * thread. A useful utility method for an authentication filter.
+    *
+    * @param sc
+    *           the servlet context
+    * @param req
+    *           the request
+    * @param res
+    *           the response
+    */
+   public static void setupThread(ServletContext sc, HttpServletRequest req, HttpServletResponse res, boolean useInterfaceLanguage)
+   {
+      if (logger.isDebugEnabled())
+          logger.debug("Setting up the request thread.");
+   }
+
+   /**
+    * Helper to authenticate the current user using session based Ticket information.
+    * <p>
+    * User information is looked up in the Session. If found the ticket is retrieved and validated.
+    * If no User info is found or the ticket is invalid then a redirect is performed to the login page.
+    *
+    * @param forceGuest       True to force a Guest login attempt
+    *
+    * @return AuthenticationStatus result.
+    */
+   public static AuthenticationStatus authenticate(
+         ServletContext sc, HttpServletRequest req, HttpServletResponse res, boolean forceGuest)
+         throws IOException
+   {
+      return authenticate(sc, req, res, forceGuest, true);
+   }
+
+   /**
+    * Helper to authenticate the current user using session based Ticket information.
+    * <p>
+    * User information is looked up in the Session. If found the ticket is retrieved and validated.
+    * If no User info is found or the ticket is invalid then a redirect is performed to the login page.
+    *
+    * @param forceGuest       True to force a Guest login attempt
+    * @param allowGuest       True to allow the Guest user if no user object represent
+    *
+    * @return AuthenticationStatus result.
+    */
+   public static AuthenticationStatus authenticate(
+         ServletContext sc, HttpServletRequest req, HttpServletResponse res, boolean forceGuest, boolean allowGuest)
+         throws IOException
+   {
+      if (logger.isDebugEnabled())
+          logger.debug("Authenticating the current user using session based Ticket information.");
+      // retrieve the User object
+      User user = getUser(sc, req, res);
+
+      HttpSession session = req.getSession();
+
+      // setup the authentication context
+      WebApplicationContext wc = WebApplicationContextUtils.getRequiredWebApplicationContext(sc);
+      AuthenticationService auth = (AuthenticationService)wc.getBean(AUTHENTICATION_SERVICE);
+
+      if (logger.isDebugEnabled())
+          logger.debug("Force guest is: " + forceGuest);
+      if (user == null || forceGuest)
+      {
+         if (logger.isDebugEnabled())
+             logger.debug("The user is null.");
+         // Check for the session invalidated flag - this is set by the Logout action in the LoginBean
+         // it signals a forced Logout and means we should not immediately attempt a relogin as Guest.
+         // The attribute is removed from the session by the login.jsp page after the Cookie containing
+         // the last stored username string is cleared.
+         if (session.getAttribute(AuthenticationHelper.SESSION_INVALIDATED) == null)
+         {
+            if (logger.isDebugEnabled())
+                logger.debug("The session is not invalidated.");
+            Cookie authCookie = getAuthCookie(req);
+            if (allowGuest == true && (authCookie == null || forceGuest))
+            {
+               if (logger.isDebugEnabled())
+                   logger.debug("No previous authentication or forced Guest - attempt Guest access.");
+               try
+               {
+                  auth.authenticateAsGuest();
+
+                  // if we get here then Guest access was allowed and successful
+                  setUser(sc, req, AuthenticationUtil.getGuestUserName(), auth.getCurrentTicket(), false);
+
+                  // Set up the thread context
+                  setupThread(sc, req, res, true);
+
+                  // remove the session invalidated flag
+                  session.removeAttribute(AuthenticationHelper.SESSION_INVALIDATED);
+
+                   if (logger.isDebugEnabled())
+                       logger.debug("Successfully authenticated as guest.");
+                  // it is the responsibilty of the caller to handle the Guest return status
+                  return AuthenticationStatus.Guest;
+               }
+               catch (AuthenticationException guestError)
+               {
+                  if (logger.isDebugEnabled())
+                      logger.debug("An AuthenticationException occurred, expected if Guest access not allowed - continue to login page as usual", guestError);
+               }
+               catch (AccessDeniedException accessError)
+               {
+                  // Guest is unable to access either properties on Person
+                  AuthenticationService unprotAuthService = (AuthenticationService)wc.getBean(UNPROTECTED_AUTH_SERVICE);
+                  unprotAuthService.invalidateTicket(unprotAuthService.getCurrentTicket());
+                  unprotAuthService.clearCurrentSecurityContext();
+                  logger.warn("Unable to login as Guest: ", accessError);
+               }
+               catch (Throwable e)
+               {
+                  // Some other kind of serious failure to report
+                  AuthenticationService unprotAuthService = (AuthenticationService)wc.getBean(UNPROTECTED_AUTH_SERVICE);
+                  unprotAuthService.invalidateTicket(unprotAuthService.getCurrentTicket());
+                  unprotAuthService.clearCurrentSecurityContext();
+                  throw new AlfrescoRuntimeException("Failed to authenticate as Guest user.", e);
+               }
+            }
+         }
+         if (logger.isDebugEnabled())
+             logger.debug("Session invalidated - return to login screen.");
+         return AuthenticationStatus.Failure;
+      }
+      return AuthenticationStatus.Failure;
+   }
+
+   /**
+    * Helper to authenticate the current user using the supplied Ticket value.
+    *
+    * @return true if authentication successful, false otherwise.
+    */
+   public static AuthenticationStatus authenticate(
+         ServletContext context, HttpServletRequest httpRequest, HttpServletResponse httpResponse, String ticket)
+         throws IOException
+   {
+      if (logger.isDebugEnabled())
+          logger.debug("Authenticate the current user using the supplied Ticket value.");
+      // setup the authentication context
+      WebApplicationContext wc = WebApplicationContextUtils.getRequiredWebApplicationContext(context);
+      AuthenticationService auth = (AuthenticationService)wc.getBean(AUTHENTICATION_SERVICE);
+      HttpSession session = httpRequest.getSession();
+      try
+      {
+          // If we already have a cached user, make sure it is for the right ticket
+         SessionUser user = (SessionUser)session.getAttribute(AuthenticationHelper.AUTHENTICATION_USER);
+         if (user != null && !user.getTicket().equals(ticket))
+         {
+             if (logger.isDebugEnabled())
+                 logger.debug("Found a previously-cached user with the wrong identity.");
+             session.removeAttribute(AUTHENTICATION_USER);
+             if (!Application.inPortalServer())
+             {
+                if (logger.isDebugEnabled())
+                    logger.debug("The server is not running in a portal, invalidating session.");
+                session.invalidate();
+                session = httpRequest.getSession();
+             }
+             user = null;
+         }
+
+         // Validate the ticket and associate it with the session
+         auth.validate(ticket);
+
+         if (user == null)
+         {
+            if (logger.isDebugEnabled())
+                logger.debug("Ticket is valid; caching a new user in the session.");
+            setUser(context, httpRequest, auth.getCurrentUserName(), ticket, false);
+         }
+         else if (logger.isDebugEnabled())
+                logger.debug("Ticket is valid; retaining cached user in session.");
+      }
+      catch (AuthenticationException authErr)
+      {
+         if (logger.isDebugEnabled())
+             logger.debug("An AuthenticationException occured: ", authErr);
+         session.removeAttribute(AUTHENTICATION_USER);
+         if (!Application.inPortalServer())
+         {
+            if (logger.isDebugEnabled())
+                logger.debug("The server is not running in a portal, invalidating session.");
+            session.invalidate();
+         }
+         return AuthenticationStatus.Failure;
+      }
+      catch (Throwable e)
+      {
+         if (logger.isDebugEnabled())
+             logger.debug("Authentication failed due to unexpected error", e);
+         // Some other kind of serious failure
+         AuthenticationService unprotAuthService = (AuthenticationService)wc.getBean(UNPROTECTED_AUTH_SERVICE);
+         unprotAuthService.invalidateTicket(unprotAuthService.getCurrentTicket());
+         unprotAuthService.clearCurrentSecurityContext();
+         return AuthenticationStatus.Failure;
+      }
+
+      // As we are authenticating via a ticket, establish the session locale using request headers rather than web client preferences
+      setupThread(context, httpRequest, httpResponse, false);
+
+      return AuthenticationStatus.Success;
+   }
+
+    /**
+     * Creates an object for an authenticated user and stores it in the session.
+     *
+     * @param context
+     *            the servlet context
+     * @param req
+     *            the request
+     * @param currentUsername
+     *            the current user name
+     * @param ticket
+     *            a validated ticket
+     * @param externalAuth
+     *            was this user authenticated externally?
+     * @return the user object
+     */
+    public static User setUser(ServletContext context, HttpServletRequest req, String currentUsername,
+            String ticket, boolean externalAuth)
+    {
+        if (logger.isDebugEnabled())
+            logger.debug("Creating an object for " + currentUsername + " and storing it in the session");
+        WebApplicationContext wc = WebApplicationContextUtils.getRequiredWebApplicationContext(context);
+
+        User user = createUser(wc, currentUsername, ticket);
+        // store the User object in the Session - the authentication servlet will then proceed
+        HttpSession session = req.getSession(true);
+        session.setAttribute(AuthenticationHelper.AUTHENTICATION_USER, user);
+        setExternalAuth(session, externalAuth);
+        return user;
+    }
+
+    /**
+     * Sets or clears the external authentication flag on the session
+     *
+     * @param session
+     *            the session
+     * @param externalAuth
+     *            was the user authenticated externally?
+     */
+    private static void setExternalAuth(HttpSession session, boolean externalAuth)
+    {
+        if (logger.isDebugEnabled())
+            logger.debug("Settings the external authentication flag on the session to " + externalAuth);
+        if (externalAuth)
+        {
+            session.setAttribute(LOGIN_EXTERNAL_AUTH, Boolean.TRUE);
+        }
+        else
+        {
+            session.removeAttribute(LOGIN_EXTERNAL_AUTH);
+        }
+    }
+
+   /**
+    * Creates an object for an authentication user.
+    *
+    * @param wc
+    *           the web application context
+    * @param currentUsername
+    *           the current user name
+    * @param ticket
+    *           a validated ticket
+    * @return the user object
+    */
+   private static User createUser(final WebApplicationContext wc, final String currentUsername, final String ticket)
+   {
+      if (logger.isDebugEnabled())
+          logger.debug("Creating an object for " + currentUsername + " with ticket: " + ticket);
+      final ServiceRegistry services = (ServiceRegistry) wc.getBean(ServiceRegistry.SERVICE_REGISTRY);
+
+      // If the repository is read only, we have to settle for a read only transaction. Auto user creation
+      // will not be possible.
+      boolean readOnly = services.getTransactionService().isReadOnly();
+
+      return services.getTransactionService().getRetryingTransactionHelper().doInTransaction(
+            new RetryingTransactionHelper.RetryingTransactionCallback<User>()
+            {
+               public User execute() throws Throwable
+               {
+                  NodeService nodeService = services.getNodeService();
+                  PersonService personService = (PersonService) wc.getBean(PERSON_SERVICE);
+                  NodeRef personRef = personService.getPerson(currentUsername);
+                  User user = new User(currentUsername, ticket, personRef);
+                  NodeRef homeRef = (NodeRef) nodeService.getProperty(personRef, ContentModel.PROP_HOMEFOLDER);
+
+                  if (homeRef==null || !nodeService.exists(homeRef))
+                  {
+                      throw new AuthenticationException("Home folder is missing for user " + currentUsername);
+                  }
+
+                  user.setHomeSpaceId(homeRef.getId());
+                  return user;
+               }
+            }, readOnly, false);
+   }
+
+   /**
+    * Uses the remote user mapper, if one is configured, to extract a user ID from the request
+    *
+    * @param sc
+    *           the servlet context
+    * @param httpRequest
+    *           The HTTP request
+    * @return the user ID if a user has been externally authenticated or <code>null</code> otherwise.
+    */
+   public static String getRemoteUser(final ServletContext sc, final HttpServletRequest httpRequest)
+   {
+      String userId = null;
+
+      // If the remote user mapper is configured, we may be able to map in an externally authenticated user
+      RemoteUserMapper remoteUserMapper = getRemoteUserMapper(sc);
+      if (remoteUserMapper != null)
+      {
+         userId = remoteUserMapper.getRemoteUser(httpRequest);
+      }
+      if (logger.isDebugEnabled())
+      {
+          if (userId == null)
+          {
+             logger.debug("No external user ID in request.");
+          }
+          else
+          {
+             logger.debug("Extracted external user ID from request: " + userId);
+          }
+      }
+
+      return userId;
+   }
+
+   /**
+    * Gets the remote user mapper if one is configured and active (i.e. external authentication is in use).
+    * @param sc
+    *           the servlet context
+    * @return the remote user mapper if one is configured and active; otherwise <code>null</code>
+    */
+   public static RemoteUserMapper getRemoteUserMapper(final ServletContext sc)
+   {
+      final WebApplicationContext wc = WebApplicationContextUtils.getRequiredWebApplicationContext(sc);
+      RemoteUserMapper remoteUserMapper = (RemoteUserMapper) wc.getBean(REMOTE_USER_MAPPER);
+      if (remoteUserMapper != null && !(remoteUserMapper instanceof ActivateableBean) || ((ActivateableBean) remoteUserMapper).isActive())
+      {
+          if (logger.isDebugEnabled())
+          {
+              logger.debug("Remote user mapper configured and active.");
+          }
+          return remoteUserMapper;
+      }
+      if (logger.isDebugEnabled())
+      {
+         logger.debug("No active remote user mapper.");
+      }
+      return null;
+   }
+
+   /**
+     * Attempts to retrieve the User object stored in the current session.
+     *
+     * @param sc
+     *            the servlet context
+     * @param httpRequest
+     *            The HTTP request
+     * @param httpResponse
+     *            The HTTP response
+     * @return The User object representing the current user or null if it could not be found
+     */
+   public static User getUser(final ServletContext sc, final HttpServletRequest httpRequest, HttpServletResponse httpResponse)
+   {
+      // If the remote user mapper is configured, we may be able to map in an externally authenticated user
+      String userId = getRemoteUser(sc, httpRequest);
+
+      final WebApplicationContext wc = WebApplicationContextUtils.getRequiredWebApplicationContext(sc);
+      HttpSession session = httpRequest.getSession();
+      User user = null;
+
+      // examine the appropriate session to try and find the User object
+      SessionUser sessionUser = Application.getCurrentUser(session);
+
+      // Make sure the ticket is valid, the person exists, and the cached user is of the right type (WebDAV users have
+      // been known to leak in but shouldn't now)
+      if (sessionUser != null)
+      {
+         if (logger.isDebugEnabled())
+             logger.debug("SessionUser is: " + sessionUser.getUserName());
+         AuthenticationService auth = (AuthenticationService) wc.getBean(AUTHENTICATION_SERVICE);
+         try
+         {
+            auth.validate(sessionUser.getTicket());
+            if (sessionUser instanceof User)
+            {
+               user = (User)sessionUser;
+               setExternalAuth(session, userId != null);
+            }
+            else
+            {
+               user = setUser(sc, httpRequest, sessionUser.getUserName(), sessionUser.getTicket(), userId != null);
+            }
+         }
+         catch (AuthenticationException authErr)
+         {
+            if (logger.isDebugEnabled())
+                logger.debug("An authentication error occured while setting the session user", authErr);
+            session.removeAttribute(AUTHENTICATION_USER);
+            if (!Application.inPortalServer())
+            {
+               if (logger.isDebugEnabled())
+                   logger.debug("Invalidating the session.");
+               session.invalidate();
+            }
+         }
+      }
+
+      // If the remote user mapper is configured, we may be able to map in an externally authenticated user
+      if (userId != null)
+      {
+         AuthorityService authorityService = (AuthorityService) wc.getBean(AUTHORITY_SERVICE);
+         // We have a previously-cached user with the wrong identity - replace them
+         if (user != null && !authorityService.isGuestAuthority(user.getUserName()) && !user.getUserName().equals(userId))
+         {
+             if (logger.isDebugEnabled())
+                 logger.debug("We have a previously-cached user with the wrong identity - replace them");
+             session.removeAttribute(AUTHENTICATION_USER);
+             if (!Application.inPortalServer())
+             {
+                if (logger.isDebugEnabled())
+                    logger.debug("Invalidating session.");
+                session.invalidate();
+             }
+             user = null;
+         }
+
+         if (user == null)
+         {
+            if (logger.isDebugEnabled())
+                logger.debug("There are no previously-cached users.");
+            // If we have been authenticated by other means, just propagate through the user identity
+            AuthenticationComponent authenticationComponent = (AuthenticationComponent) wc
+                  .getBean(AUTHENTICATION_COMPONENT);
+            try
+            {
+               if (logger.isDebugEnabled())
+                   logger.debug("We have been authenticated by other means, authenticating the user: " + userId);
+               authenticationComponent.setCurrentUser(userId);
+               AuthenticationService authenticationService = (AuthenticationService) wc.getBean(AUTHENTICATION_SERVICE);
+               user = setUser(sc, httpRequest, userId, authenticationService.getCurrentTicket(), true);
+            }
+            catch (AuthenticationException authErr)
+            {
+               if (logger.isDebugEnabled())
+                   logger.debug("An authentication error occured while setting the session user" , authErr);
+               // Allow for an invalid external user ID to be indicated
+               session.removeAttribute(AUTHENTICATION_USER);
+               if (!Application.inPortalServer())
+               {
+                  if (logger.isDebugEnabled())
+                      logger.debug("Invalidating the session.");
+                  session.invalidate();
+               }
+            }
+         }
+      }
+      return user;
+   }
+
+   /**
+    * Setup the Alfresco auth cookie value.
+    *
+    * @param httpRequest
+    * @param httpResponse
+    * @param username
+    */
+   public static void setUsernameCookie(HttpServletRequest httpRequest, HttpServletResponse httpResponse, String username)
+   {
+      if (logger.isDebugEnabled())
+          logger.debug("Setting up the Alfresco auth cookie for " + username);
+      Cookie authCookie = getAuthCookie(httpRequest);
+      // Let's Base 64 encode the username so it is a legal cookie value
+      String encodedUsername;
+      try
+      {
+         encodedUsername = Base64.encodeBytes(username.getBytes("UTF-8"));
+         if (logger.isDebugEnabled())
+             logger.debug("Base 64 encode the username: " + encodedUsername);
+      }
+      catch (UnsupportedEncodingException e)
+      {
+         throw new RuntimeException(e);
+      }
+      if (authCookie == null)
+      {
+         if (logger.isDebugEnabled())
+             logger.debug("No Alfresco auth cookie wa found, creating new one.");
+         authCookie = new Cookie(COOKIE_ALFUSER, encodedUsername);
+      }
+      else
+      {
+         if (logger.isDebugEnabled())
+             logger.debug("Updating the previous Alfresco auth cookie value.");
+         authCookie.setValue(encodedUsername);
+      }
+      authCookie.setPath(httpRequest.getContextPath());
+      // TODO: make this configurable - currently 7 days (value in seconds)
+      authCookie.setMaxAge(60*60*24*7);
+      httpResponse.addCookie(authCookie);
+   }
+
+   /**
+    * Helper to return the Alfresco auth cookie. The cookie saves the last used username value.
+    *
+    * @param httpRequest
+    *
+    * @return Cookie if found or null if not present
+    */
+   public static Cookie getAuthCookie(HttpServletRequest httpRequest)
+   {
+      if (logger.isDebugEnabled())
+          logger.debug("Searching for Alfresco auth cookie.");
+      Cookie authCookie = null;
+      Cookie[] cookies = httpRequest.getCookies();
+      if (cookies != null)
+      {
+         if (logger.isDebugEnabled())
+             logger.debug("Cookies present.");
+         for (int i=0; i<cookies.length; i++)
+         {
+            if (COOKIE_ALFUSER.equals(cookies[i].getName()))
+            {
+               // found cookie
+               if (logger.isDebugEnabled())
+                   logger.debug("Found Alfresco auth cookie: " + cookies[i].toString());
+               authCookie = cookies[i];
+               break;
+            }
+         }
+      }
+      return authCookie;
+   }
+}

--- a/war/src/main/java/org/alfresco/web/app/servlet/AuthenticationStatus.java
+++ b/war/src/main/java/org/alfresco/web/app/servlet/AuthenticationStatus.java
@@ -1,0 +1,34 @@
+/*
+ * #%L
+ * Alfresco Repository WAR Community
+ * %%
+ * Copyright (C) 2005 - 2016 Alfresco Software Limited
+ * %%
+ * This file is part of the Alfresco software. 
+ * If the software was purchased under a paid Alfresco license, the terms of 
+ * the paid license agreement will prevail.  Otherwise, the software is 
+ * provided under the following open source license terms:
+ * 
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+package org.alfresco.web.app.servlet;
+
+/**
+ * @author Kevin Roast
+ */
+public enum AuthenticationStatus
+{
+   Success, Failure, Guest;
+}

--- a/war/src/main/java/org/alfresco/web/app/servlet/BaseDownloadContentServlet.java
+++ b/war/src/main/java/org/alfresco/web/app/servlet/BaseDownloadContentServlet.java
@@ -1,0 +1,454 @@
+/*
+ * #%L
+ * Alfresco Repository WAR Community
+ * %%
+ * Copyright (C) 2005 - 2016 Alfresco Software Limited
+ * %%
+ * This file is part of the Alfresco software. 
+ * If the software was purchased under a paid Alfresco license, the terms of 
+ * the paid license agreement will prevail.  Otherwise, the software is 
+ * provided under the following open source license terms:
+ * 
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+package org.alfresco.web.app.servlet;
+
+import java.io.IOException;
+import java.net.SocketException;
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.StringTokenizer;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.alfresco.error.AlfrescoRuntimeException;
+import org.alfresco.model.ContentModel;
+import org.alfresco.repo.content.filestore.FileContentReader;
+import org.alfresco.repo.web.util.HttpRangeProcessor;
+import org.alfresco.service.ServiceRegistry;
+import org.alfresco.service.cmr.model.FileInfo;
+import org.alfresco.service.cmr.model.FileNotFoundException;
+import org.alfresco.service.cmr.repository.ContentIOException;
+import org.alfresco.service.cmr.repository.ContentReader;
+import org.alfresco.service.cmr.repository.ContentService;
+import org.alfresco.service.cmr.repository.MimetypeService;
+import org.alfresco.service.cmr.repository.NodeRef;
+import org.alfresco.service.cmr.repository.NodeService;
+import org.alfresco.service.cmr.repository.StoreRef;
+import org.alfresco.service.cmr.security.PermissionService;
+import org.alfresco.service.namespace.QName;
+import org.alfresco.web.app.Application;
+import org.apache.commons.logging.Log;
+import org.springframework.extensions.surf.util.URLDecoder;
+import org.springframework.extensions.surf.util.URLEncoder;
+import org.springframework.extensions.webscripts.ui.common.StringUtils;
+
+/**
+ * Base class for the download content servlets. Provides common
+ * processing for the request.
+ * 
+ * @see DownloadContentServlet
+ * 
+ * @author Kevin Roast
+ * @author gavinc
+ */
+public abstract class BaseDownloadContentServlet extends BaseServlet
+{
+   private static final String HEADER_IF_MODIFIED_SINCE = "If-Modified-Since";
+
+   private static final long serialVersionUID = -4558907921887235967L;
+   
+   private static final String POWER_POINT_DOCUMENT_MIMETYPE = "application/vnd.ms-powerpoint";
+   private static final String POWER_POINT_2007_DOCUMENT_MIMETYPE = "application/vnd.openxmlformats-officedocument.presentationml.presentation";
+   
+   private static final String HEADER_CONTENT_RANGE  = "Content-Range";
+   private static final String HEADER_CONTENT_LENGTH = "Content-Length";
+   private static final String HEADER_ACCEPT_RANGES  = "Accept-Ranges";
+   private static final String HEADER_RANGE          = "Range";
+   private static final String HEADER_ETAG           = "ETag";
+   private static final String HEADER_CACHE_CONTROL  = "Cache-Control";
+   private static final String HEADER_LAST_MODIFIED  = "Last-Modified";
+   private static final String HEADER_USER_AGENT     = "User-Agent";
+   private static final String HEADER_CONTENT_DISPOSITION = "Content-Disposition";
+   
+   protected static final String MIMETYPE_OCTET_STREAM = "application/octet-stream";
+   
+   protected static final String MSG_ERROR_CONTENT_MISSING = "error_content_missing";
+   protected static final String MSG_ERROR_NOT_FOUND = "error_not_found";
+   
+   protected static final String URL_DIRECT        = "d";
+   protected static final String URL_DIRECT_LONG   = "direct";
+   protected static final String URL_ATTACH        = "a";
+   protected static final String URL_ATTACH_LONG   = "attach";
+   protected static final String ARG_PROPERTY = "property";
+   protected static final String ARG_PATH     = "path";
+
+   /**
+    * Gets the logger to use for this request.
+    * <p>
+    * This will show all debug entries from this class as though they
+    * came from the subclass.
+    * 
+    * @return The logger
+    */
+   protected abstract Log getLogger();
+
+   /**
+    * Processes the download request using the current context i.e. no authentication checks are made, it is presumed
+    * they have already been done.
+    * 
+    * @param req
+    *           The HTTP request
+    * @param res
+    *           The HTTP response
+    * @param allowLogIn
+    *           Indicates whether guest users without access to the content should be redirected to the log in page. If
+    *           <code>false</code>, a status 403 forbidden page is displayed instead.
+    */
+   protected void processDownloadRequest(HttpServletRequest req, HttpServletResponse res,
+         boolean allowLogIn, boolean transmitContent)
+         throws ServletException, IOException
+   {   
+      Log logger = getLogger();
+      String uri = req.getRequestURI();
+      
+      if (logger.isDebugEnabled())
+      {
+         String queryString = req.getQueryString();
+         logger.debug("Processing URL: " + uri + 
+               ((queryString != null && queryString.length() > 0) ? ("?" + queryString) : ""));
+      }
+      
+      uri = uri.substring(req.getContextPath().length());
+      StringTokenizer t = new StringTokenizer(uri, "/");
+      int tokenCount = t.countTokens();
+      
+      t.nextToken();    // skip servlet name
+      
+      // attachment mode (either 'attach' or 'direct')
+      String attachToken = t.nextToken();
+      boolean attachment = URL_ATTACH.equals(attachToken) || URL_ATTACH_LONG.equals(attachToken);
+      
+      ServiceRegistry serviceRegistry = getServiceRegistry(getServletContext());
+      
+      // get or calculate the noderef and filename to download as
+      NodeRef nodeRef;
+      String filename;
+      
+      // do we have a path parameter instead of a NodeRef?
+      String path = req.getParameter(ARG_PATH);
+      if (path != null && path.length() != 0)
+      {
+         // process the name based path to resolve the NodeRef and the Filename element
+         try
+         {
+            PathRefInfo pathInfo = resolveNamePath(getServletContext(), path);
+            nodeRef = pathInfo.NodeRef;
+            filename = pathInfo.Filename;
+         }
+         catch (IllegalArgumentException e)
+         {
+            Application.handleSystemError(getServletContext(), req, res, MSG_ERROR_NOT_FOUND,
+                  HttpServletResponse.SC_NOT_FOUND, logger);
+            return;
+         }         
+      }
+      else
+      {
+         // a NodeRef must have been specified if no path has been found
+         if (tokenCount < 6)
+         {
+            throw new IllegalArgumentException("Download URL did not contain all required args: " + uri); 
+         }
+         
+         // assume 'workspace' or other NodeRef based protocol for remaining URL elements
+         StoreRef storeRef = new StoreRef(URLDecoder.decode(t.nextToken()), URLDecoder.decode(t.nextToken()));
+         String id = URLDecoder.decode(t.nextToken());
+         
+         // build noderef from the appropriate URL elements
+         nodeRef = new NodeRef(storeRef, id);
+         
+         if (tokenCount > 6)
+         {
+            // found additional relative path elements i.e. noderefid/images/file.txt
+            // this allows a url to reference siblings nodes via a cm:name based relative path
+            // solves the issue with opening HTML content containing relative URLs in HREF or IMG tags etc.
+            List<String> paths = new ArrayList<String>(tokenCount - 5);
+            while (t.hasMoreTokens())
+            {
+               paths.add(URLDecoder.decode(t.nextToken()));
+            }
+            filename = paths.get(paths.size() - 1);
+
+            try
+            {
+               NodeRef parentRef = serviceRegistry.getNodeService().getPrimaryParent(nodeRef).getParentRef();
+               FileInfo fileInfo = serviceRegistry.getFileFolderService().resolveNamePath(parentRef, paths);
+               nodeRef = fileInfo.getNodeRef();
+            }
+            catch (FileNotFoundException e)
+            {
+               Application.handleSystemError(getServletContext(), req, res, MSG_ERROR_NOT_FOUND,
+                     HttpServletResponse.SC_NOT_FOUND, logger);
+               return;
+            }
+         }
+         else
+         {
+            // filename is last remaining token
+            filename = t.nextToken();
+         }
+      }
+      
+      // get qualified of the property to get content from - default to ContentModel.PROP_CONTENT
+      QName propertyQName = ContentModel.PROP_CONTENT;
+      String property = req.getParameter(ARG_PROPERTY);
+      if (property != null && property.length() != 0)
+      {
+          propertyQName = QName.createQName(property);
+      }
+      
+      if (logger.isDebugEnabled())
+      {
+         logger.debug("Found NodeRef: " + nodeRef);
+         logger.debug("Will use filename: " + filename);
+         logger.debug("For property: " + propertyQName);
+         logger.debug("With attachment mode: " + attachment);
+      }
+      
+      // get the services we need to retrieve the content
+      NodeService nodeService = serviceRegistry.getNodeService();
+      ContentService contentService = serviceRegistry.getContentService();
+      
+      // Check that the node still exists
+      if (!nodeService.exists(nodeRef))
+      {
+         Application.handleSystemError(getServletContext(), req, res, MSG_ERROR_NOT_FOUND,
+               HttpServletResponse.SC_NOT_FOUND, logger);
+         return;         
+      }
+
+      try
+      {
+         // check that the user has at least READ_CONTENT access - else redirect to an error or login page
+         if (!checkAccess(req, res, nodeRef, PermissionService.READ_CONTENT, allowLogIn))
+         {
+            return;
+         }
+         
+         // check If-Modified-Since header and set Last-Modified header as appropriate
+         Date modified = (Date)nodeService.getProperty(nodeRef, ContentModel.PROP_MODIFIED);
+         if (modified != null)
+         {
+            long modifiedSince = req.getDateHeader(HEADER_IF_MODIFIED_SINCE);
+            if (modifiedSince > 0L)
+            {
+               // round the date to the ignore millisecond value which is not supplied by header
+               long modDate = (modified.getTime() / 1000L) * 1000L;
+               if (modDate <= modifiedSince)
+               {
+                  if (logger.isDebugEnabled())
+                     logger.debug("Returning 304 Not Modified.");
+                  res.setStatus(HttpServletResponse.SC_NOT_MODIFIED);
+                  return;
+               }
+            }
+            res.setDateHeader(HEADER_LAST_MODIFIED, modified.getTime());
+            res.setHeader(HEADER_CACHE_CONTROL, "must-revalidate, max-age=0");
+            res.setHeader(HEADER_ETAG, "\"" + Long.toString(modified.getTime()) + "\"");
+         }
+         
+         if (attachment == true)
+         {
+             setHeaderContentDisposition(req, res, filename);
+         }
+         
+         // get the content reader
+         ContentReader reader = contentService.getReader(nodeRef, propertyQName);
+         // ensure that it is safe to use
+         reader = FileContentReader.getSafeContentReader(
+                    reader,
+                    Application.getMessage(req.getSession(), MSG_ERROR_CONTENT_MISSING),
+                    nodeRef, reader);
+         
+         String mimetype = reader.getMimetype();
+         // fall back if unable to resolve mimetype property
+         if (mimetype == null || mimetype.length() == 0)
+         {
+            MimetypeService mimetypeMap = serviceRegistry.getMimetypeService();
+            mimetype = MIMETYPE_OCTET_STREAM;
+            int extIndex = filename.lastIndexOf('.');
+            if (extIndex != -1)
+            {
+               String ext = filename.substring(extIndex + 1);
+               mimetype = mimetypeMap.getMimetype(ext);
+            }
+         }
+         
+         // explicitly set the content disposition header if the content is powerpoint
+         if (!attachment && (mimetype.equals(POWER_POINT_2007_DOCUMENT_MIMETYPE) || 
+                             mimetype.equals(POWER_POINT_DOCUMENT_MIMETYPE)))
+         {
+            setHeaderContentDisposition(req, res, filename);
+         }
+         
+         // get the content and stream directly to the response output stream
+         // assuming the repo is capable of streaming in chunks, this should allow large files
+         // to be streamed directly to the browser response stream.
+         res.setHeader(HEADER_ACCEPT_RANGES, "bytes");
+         
+         // for a GET request, transmit the content else just the headers are sent
+         if (transmitContent)
+         {
+            try
+            {
+               boolean processedRange = false;
+               String range = req.getHeader(HEADER_CONTENT_RANGE);
+               if (range == null)
+               {
+                  range = req.getHeader(HEADER_RANGE);
+               }
+               if (range != null)
+               {
+                  if (logger.isDebugEnabled())
+                     logger.debug("Found content range header: " + range);
+                  
+                  // ensure the range header is starts with "bytes=" and process the range(s)
+                  if (range.length() > 6)
+                  {
+                     HttpRangeProcessor rangeProcessor = new HttpRangeProcessor(contentService);
+                     processedRange = rangeProcessor.processRange(
+                           res, reader, range.substring(6), nodeRef, propertyQName,
+                           mimetype, req.getHeader(HEADER_USER_AGENT));
+                  }
+               }
+               if (processedRange == false)
+               {
+                  if (logger.isDebugEnabled())
+                     logger.debug("Sending complete file content...");
+                  
+                  // set mimetype for the content and the character encoding for the stream
+                  res.setContentType(mimetype);
+                  res.setCharacterEncoding(reader.getEncoding());
+                  
+                  // MNT-10642 Alfresco Explorer has javascript vulnerability opening HTML files
+                  if (req.getRequestURI().contains("/d/d/") && (mimetype.equals("text/html") || mimetype.equals("application/xhtml+xml") || mimetype.equals("text/xml")))
+                  {
+                       String content = reader.getContentString();
+
+                       if (mimetype.equals("text/html") || mimetype.equals("application/xhtml+xml"))
+                       {
+                            // process with HTML stripper
+                            content = StringUtils.stripUnsafeHTMLTags(content, false);
+                       }
+                       else if (mimetype.equals("text/xml") && mimetype.equals("text/x-component"))
+                       {
+                            // IE supports "behaviour" which means that css can load a .htc file that could
+                            // contain XSS code in the form of jscript, vbscript etc, to stop it form being
+                            // evaluated we set the contient type to text/plain
+                            res.setContentType("text/plain");
+                       }
+
+                       String encoding = reader.getEncoding();
+                       byte[] bytes = encoding != null ? content.getBytes(encoding) : content.getBytes();
+                       res.setContentLength(bytes.length);
+                       res.getOutputStream().write(bytes);
+
+                       return;
+                  }
+                        
+                  // return the complete entity range
+                  long size = reader.getSize();
+                  res.setHeader(HEADER_CONTENT_RANGE, "bytes 0-" + Long.toString(size-1L) + "/" + Long.toString(size));
+                  res.setHeader(HEADER_CONTENT_LENGTH, Long.toString(size));
+                  reader.getContent( res.getOutputStream() );
+               }
+            }
+            catch (SocketException e1)
+            {
+               // the client cut the connection - our mission was accomplished apart from a little error message
+               if (logger.isDebugEnabled())
+                  logger.debug("Client aborted stream read:\n\tnode: " + nodeRef + "\n\tcontent: " + reader);
+            }
+            catch (ContentIOException e2)
+            {
+               if (logger.isInfoEnabled())
+                  logger.info("Failed stream read:\n\tnode: " + nodeRef + " due to: " + e2.getMessage());
+            }
+            catch (Throwable err)
+            {
+               if (err.getCause() instanceof SocketException)
+               {
+                  // the client cut the connection - our mission was accomplished apart from a little error message
+                  if (logger.isDebugEnabled())
+                     logger.debug("Client aborted stream read:\n\tnode: " + nodeRef + "\n\tcontent: " + reader);
+               }
+               else throw err;
+            }
+         }
+         else
+         {
+            if (logger.isDebugEnabled())
+               logger.debug("HEAD request processed - no content sent.");
+            res.getOutputStream().close();
+         }
+      }
+      catch (Throwable err)
+      {
+         throw new AlfrescoRuntimeException("Error during download content servlet processing: " + err.getMessage(), err);
+      }
+   }
+
+   private void setHeaderContentDisposition(HttpServletRequest req, HttpServletResponse res, String filename)
+   {
+      // set header based on filename - will force a Save As from the browse if it doesn't recognise it
+      // this is better than the default response of the browser trying to display the contents
+
+      // IE requires that "Content-Disposition" header in case of "attachment" type should include
+      // "filename" part. See MNT-9900
+      String userAgent = req.getHeader(HEADER_USER_AGENT);
+      if (userAgent != null && (userAgent.toLowerCase().contains("firefox") || userAgent.toLowerCase().contains("safari")))
+      {
+         res.setHeader(HEADER_CONTENT_DISPOSITION, "attachment; filename=\"" + URLDecoder.decode(filename) + "\"");
+      }
+      else
+      {
+         res.setHeader(HEADER_CONTENT_DISPOSITION, "attachment; filename=\"" + filename + "\"");
+      }
+
+   }
+      
+   /**
+    * Helper to generate a URL to a content node for downloading content from the server.
+    * 
+    * @param pattern The pattern to use for the URL
+    * @param ref     NodeRef of the content node to generate URL for (cannot be null)
+    * @param name    File name to return in the URL (cannot be null)
+    * 
+    * @return URL to download the content from the specified node
+    */
+   protected final static String generateUrl(String pattern, NodeRef ref, String name)
+   {
+      return MessageFormat.format(pattern, new Object[] {
+              ref.getStoreRef().getProtocol(),
+              ref.getStoreRef().getIdentifier(),
+              ref.getId(),
+              URLEncoder.encode(name) } );
+   }
+}

--- a/war/src/main/java/org/alfresco/web/app/servlet/BaseServlet.java
+++ b/war/src/main/java/org/alfresco/web/app/servlet/BaseServlet.java
@@ -189,8 +189,6 @@ public abstract class BaseServlet extends HttpServlet
             if (logger.isDebugEnabled())
                logger.debug("Forwarding to error page...");
             prettyPrintError(req, res, MSG_ERROR_PERMISSIONS, HttpServletResponse.SC_FORBIDDEN, "User does not ha");
-//            Application
-//                  .handleSystemError(sc, req, res, MSG_ERROR_PERMISSIONS, HttpServletResponse.SC_FORBIDDEN, logger);
          }
          return false;
       }
@@ -232,31 +230,36 @@ public abstract class BaseServlet extends HttpServlet
     * This method pretty prints an error page instead of showing the stacktrace.
     * @param req
     * @param res
-    * @param message
-    * @param status
+    * @param statusCodeDescriptor
+    * @param statusCodeValue
     * @param actualCause
     * @throws IOException
     */
-   public static void prettyPrintError(HttpServletRequest req, HttpServletResponse res, String message, int status, String actualCause) throws IOException
+   public static void prettyPrintError(HttpServletRequest req, HttpServletResponse res, String statusCodeDescriptor, int statusCodeValue, String actualCause)
+       throws IOException
    {
       final PrintWriter out = res.getWriter();
 
-      out.println("<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Strict//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd\">");
+      // Build HTML page as response.
+      out.println(
+          "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Strict//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd\">");
       out.println("<html><head>");
+      // Add Alfresco webscript css.
       out.println("<link rel=\"stylesheet\" href=\"/alfresco/css/webscripts.css\" type=\"text/css\">");
       out.println("</head><body>");
+      // Add Alfresco logo, error status code and descriptor.
       out.println("<table>\n" + "            <tbody><tr>\n"
           + "               <td><img src=\"/alfresco/images/logo/AlfrescoLogo32.png\" alt=\"Alfresco\"></td>\n"
-          + "               <td><span class=\"title\">Servlet Status: " +  status +  " - " + message + "</span></td>\n"
+          + "               <td><span class=\"title\">Servlet Status: " + statusCodeValue + " - " + statusCodeDescriptor + "</span></td>\n"
           + "            </tr>\n" + "         </tbody></table>");
       out.println("<br>");
-      out.println("<table>\n"
-          + "            <tbody><tr><td>The Servlet <a href=\"" + req.getRequestURI() + "\">" + req.getRequestURI() + "</a> has responded with a status of " + status +" - " + message + ".</td></tr>\n"
-          + "         </tbody></table>");
+      out.println(
+          "<table>\n" + "            <tbody><tr><td>The Servlet <a href=\"" + req.getRequestURI() + "\">" + req.getRequestURI()
+              + "</a> has responded with a status of " + statusCodeValue + " - " + statusCodeDescriptor + ".</td></tr>\n"
+              + "         </tbody></table>");
       out.println("<br>");
-      out.println("<table>\n"
-          + "            <tbody><tr><td>Cause: "+ actualCause + ".</td></tr>\n"
-          + "         </tbody></table>");
+      out.println(
+          "<table>\n" + "            <tbody><tr><td>Cause: " + actualCause + ".</td></tr>\n" + "         </tbody></table>");
       out.println("</body></html>");
 
       out.close();

--- a/war/src/main/java/org/alfresco/web/app/servlet/BaseServlet.java
+++ b/war/src/main/java/org/alfresco/web/app/servlet/BaseServlet.java
@@ -1,0 +1,373 @@
+/*
+ * #%L
+ * Alfresco Repository WAR Community
+ * %%
+ * Copyright (C) 2005 - 2016 Alfresco Software Limited
+ * %%
+ * This file is part of the Alfresco software. 
+ * If the software was purchased under a paid Alfresco license, the terms of 
+ * the paid license agreement will prevail.  Otherwise, the software is 
+ * provided under the following open source license terms:
+ * 
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+package org.alfresco.web.app.servlet;
+
+import org.alfresco.repo.security.authentication.AuthenticationUtil;
+import org.alfresco.repo.security.authentication.AuthenticationUtil.RunAsWork;
+import org.alfresco.repo.tenant.TenantService;
+import org.alfresco.service.ServiceRegistry;
+import org.alfresco.service.cmr.model.FileFolderService;
+import org.alfresco.service.cmr.model.FileInfo;
+import org.alfresco.service.cmr.model.FileNotFoundException;
+import org.alfresco.service.cmr.repository.NodeRef;
+import org.alfresco.service.cmr.repository.NodeService;
+import org.alfresco.service.cmr.search.SearchService;
+import org.alfresco.service.cmr.security.AccessStatus;
+import org.alfresco.service.cmr.security.PermissionService;
+import org.alfresco.service.namespace.NamespaceService;
+import org.alfresco.web.app.Application;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.extensions.surf.util.URLDecoder;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.context.support.WebApplicationContextUtils;
+
+import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.StringTokenizer;
+
+
+/**
+ * Base servlet class containing useful constant values and common methods for Alfresco servlets.
+ * 
+ * @author Kevin Roast
+ */
+public abstract class BaseServlet extends HttpServlet
+{
+   private static final long serialVersionUID = -826295358696861789L;
+
+   public static final String KEY_ROOT_PATH = "rootPath";
+   
+   /** an existing Ticket can be passed to most servlet for non-session based authentication */
+   private static final String ARG_TICKET   = "ticket";
+   
+   /** forcing guess access is available on most servlets */
+   private static final String ARG_GUEST    = "guest";
+   
+   private static final String MSG_ERROR_PERMISSIONS = "error_permissions";
+   
+   private static Log logger = LogFactory.getLog(BaseServlet.class);
+
+   /**
+    * Return the ServiceRegistry helper instance
+    * 
+    * @param sc      ServletContext
+    * 
+    * @return ServiceRegistry
+    */
+   public static ServiceRegistry getServiceRegistry(ServletContext sc)
+   {
+      WebApplicationContext wc = WebApplicationContextUtils.getRequiredWebApplicationContext(sc);
+      return (ServiceRegistry)wc.getBean(ServiceRegistry.SERVICE_REGISTRY);
+   }
+   
+   /**
+    * Perform an authentication for the servlet request URI. Processing any "ticket" or
+    * "guest" URL arguments.
+    * 
+    * @return AuthenticationStatus
+    * 
+    * @throws IOException
+    */
+   public AuthenticationStatus servletAuthenticate(HttpServletRequest req, HttpServletResponse res) 
+      throws IOException
+   {
+      return servletAuthenticate(req, res, true);
+   }
+   
+   /**
+    * Perform an authentication for the servlet request URI. Processing any "ticket" or
+    * "guest" URL arguments.
+    * 
+    * @return AuthenticationStatus
+    * 
+    * @throws IOException
+    */
+   public AuthenticationStatus servletAuthenticate(HttpServletRequest req, HttpServletResponse res,
+         boolean redirectToLoginPage) throws IOException
+   {
+      AuthenticationStatus status;
+      
+      // see if a ticket or a force Guest parameter has been supplied
+      String ticket = req.getParameter(ARG_TICKET);
+      if (ticket != null && ticket.length() != 0)
+      {
+         status = AuthenticationHelper.authenticate(getServletContext(), req, res, ticket);
+      }
+      else
+      {
+         boolean forceGuest = false;
+         String guest = req.getParameter(ARG_GUEST);
+         if (guest != null)
+         {
+            forceGuest = Boolean.parseBoolean(guest);
+         }
+         status = AuthenticationHelper.authenticate(getServletContext(), req, res, forceGuest);
+      }
+      if (status == AuthenticationStatus.Failure && redirectToLoginPage)
+      {
+         // authentication failed - now need to display the login page to the user, if asked to
+         redirectToLoginPage(req, res, getServletContext());
+      }
+      
+      return status;
+   }
+   
+   /**
+    * Check the user has the given permission on the given node. If they do not either force a log on if this is a guest
+    * user or forward to an error page.
+    * 
+    * @param req
+    *           the request
+    * @param res
+    *           the response
+    * @param nodeRef
+    *           the node in question
+    * @param allowLogIn
+    *           Indicates whether guest users without access to the node should be redirected to the log in page. If
+    *           <code>false</code>, a status 403 forbidden page is displayed instead.
+    * @return <code>true</code>, if the user has access
+    * @throws IOException
+    *            Signals that an I/O exception has occurred.
+    * @throws ServletException
+    *            On other errors
+    */
+   public boolean checkAccess(HttpServletRequest req, HttpServletResponse res, NodeRef nodeRef, String permission,
+         boolean allowLogIn) throws IOException, ServletException
+   {
+      ServletContext sc = getServletContext();
+      ServiceRegistry serviceRegistry = getServiceRegistry(sc);
+      PermissionService permissionService = serviceRegistry.getPermissionService();
+
+      // check that the user has the permission
+      if (permissionService.hasPermission(nodeRef, permission) == AccessStatus.DENIED)
+      {
+         if (logger.isDebugEnabled())
+            logger.debug("User does not have " + permission + " permission for NodeRef: " + nodeRef.toString());
+
+         if (allowLogIn && serviceRegistry.getAuthorityService().hasGuestAuthority())
+         {
+            if (logger.isDebugEnabled())
+               logger.debug("Redirecting to login page...");
+            redirectToLoginPage(req, res, sc);
+         }
+         else
+         {
+            if (logger.isDebugEnabled())
+               logger.debug("Forwarding to error page...");
+            Application
+                  .handleSystemError(sc, req, res, MSG_ERROR_PERMISSIONS, HttpServletResponse.SC_FORBIDDEN, logger);
+         }
+         return false;
+      }
+      return true;
+   }
+   
+   /**
+    * Redirect to the Login page - saving the current URL which can be redirected back later
+    * once the user has successfully completed the authentication process.
+    */
+   public static void redirectToLoginPage(HttpServletRequest req, HttpServletResponse res, ServletContext sc)
+         throws IOException
+   {
+      redirectToLoginPage(req, res, sc, AuthenticationHelper.getRemoteUserMapper(sc) == null);
+   }
+   
+   /**
+    * Redirect to the Login page - saving the current URL which can be redirected back later
+    * once the user has successfully completed the authentication process.
+    * @param sendRedirect allow a redirect status code to be set? If <code>false</code> redirect
+    * will be via markup rather than status code (to allow the status code to be used for handshake
+    * responses etc.
+    */
+   public static void redirectToLoginPage(HttpServletRequest req, HttpServletResponse res, ServletContext sc, boolean sendRedirect)
+         throws IOException
+   {
+      // Pass the full requested URL as a parameter so the login page knows where to redirect to later
+      final String uri = req.getRequestURI();
+      String redirectURL = uri;
+
+      // Alfresco Explorer was used as a default login page for servlets that extended BaseServlet
+      // These page and Spring context was removed as part OF ACE-2091
+      // If no ticket is provided then trow a login error.
+      res.setContentType("text/html; charset=UTF-8");
+      res.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+      final PrintWriter out = res.getWriter();
+      out.println("<html><head>");
+      // Remove the auto refresh to avoid refresh loop, MNT-16931
+//      out.println("<meta http-equiv=\"Refresh\" content=\"0; url=" + redirectURL + "\">");
+      out.println("</head><body><p>Please <a href=\"" + redirectURL + "\">log in</a>.</p>");
+      out.println("</body></html>");
+      out.close();
+   }
+   
+   /**
+    * Apply the headers required to disallow caching of the response in the browser
+    */
+   public static void setNoCacheHeaders(HttpServletResponse res)
+   {
+      res.setHeader("Cache-Control", "no-cache");
+      res.setHeader("Pragma", "no-cache");
+   }
+
+   /**
+    * Resolves the given path elements to a NodeRef in the current repository
+    * 
+    * @param context ServletContext context
+    * @param args    The elements of the path to lookup
+    * @param decode  True to decode the arg from UTF-8 format, false for no decoding
+    */
+   public static NodeRef resolveWebDAVPath(ServletContext context, String[] args, boolean decode)
+   {
+      WebApplicationContext wc = WebApplicationContextUtils.getRequiredWebApplicationContext(context);
+      return resolveWebDAVPath(wc, args, decode);
+   }
+   
+   /**
+    * Resolves the given path elements to a NodeRef in the current repository
+    * 
+    * @param wc WebApplicationContext Context
+    * @param args    The elements of the path to lookup
+    * @param decode  True to decode the arg from UTF-8 format, false for no decoding
+    */
+   private static NodeRef resolveWebDAVPath(final WebApplicationContext wc, final String[] args, final boolean decode)
+   {
+      return AuthenticationUtil.runAs(new RunAsWork<NodeRef>()
+      {
+         public NodeRef doWork() throws Exception
+         {
+            NodeRef nodeRef = null;
+            
+            List<String> paths = new ArrayList<String>(args.length - 1);
+
+            FileInfo file = null;
+            try
+            {
+               // create a list of path elements (decode the URL as we go)
+               for (int x = 1; x < args.length; x++)
+               {
+                  paths.add(decode ? URLDecoder.decode(args[x]) : args[x]);
+               }
+               
+               if (logger.isDebugEnabled())
+                  logger.debug("Attempting to resolve webdav path: " + paths);
+
+               // get the company home node to start the search from
+               nodeRef = new NodeRef(Application.getRepositoryStoreRef(wc), Application.getCompanyRootId());
+               
+               TenantService tenantService = (TenantService)wc.getBean("tenantService");         
+               if (tenantService != null && tenantService.isEnabled())
+               {
+                  if (logger.isDebugEnabled())
+                     logger.debug("MT is enabled.");
+                  
+                  NodeService nodeService = (NodeService) wc.getBean("NodeService");
+                  SearchService searchService = (SearchService) wc.getBean("SearchService");
+                  NamespaceService namespaceService = (NamespaceService) wc.getBean("NamespaceService");
+                  
+                  // TODO: since these constants are used more widely than just the WebDAVServlet, 
+                  // they should be defined somewhere other than in that servlet
+                  String rootPath = wc.getServletContext().getInitParameter(BaseServlet.KEY_ROOT_PATH);
+                  
+                  // note: rootNodeRef is required (for storeRef part)
+                  nodeRef = tenantService.getRootNode(nodeService, searchService, namespaceService, rootPath, nodeRef);
+               }
+               
+               if (paths.size() != 0)
+               {
+                  FileFolderService ffs = (FileFolderService)wc.getBean("FileFolderService");
+                  file = ffs.resolveNamePath(nodeRef, paths);
+                  nodeRef = file.getNodeRef();
+               }
+               
+               if (logger.isDebugEnabled())
+                  logger.debug("Resolved webdav path to NodeRef: " + nodeRef);
+            }
+            catch (FileNotFoundException fne)
+            {
+               if (logger.isWarnEnabled())
+                  logger.warn("Failed to resolve webdav path", fne);
+               
+               nodeRef = null;
+            }
+            return nodeRef;
+         }
+      }, AuthenticationUtil.getSystemUserName());
+   }
+   
+   /**
+    * Resolve a name based into a NodeRef and Filename string
+    *  
+    * @param sc      ServletContext
+    * @param path    'cm:name' based path using the '/' character as a separator
+    *  
+    * @return PathRefInfo structure containing the resolved NodeRef and filename
+    * 
+    * @throws IllegalArgumentException
+    */
+   public final static PathRefInfo resolveNamePath(ServletContext sc, String path)
+   {
+      StringTokenizer t = new StringTokenizer(path, "/");
+      int tokenCount = t.countTokens();
+      String[] elements = new String[tokenCount];
+      for (int i=0; i<tokenCount; i++)
+      {
+         elements[i] = t.nextToken();
+      }
+      
+      // process name based path tokens using the webdav path resolving helper 
+      NodeRef nodeRef = resolveWebDAVPath(sc, elements, false);
+      if (nodeRef == null)
+      {
+         // unable to resolve path - output helpful error to the user
+         throw new IllegalArgumentException("Unable to resolve item Path: " + path);
+      }
+      
+      return new PathRefInfo(nodeRef, elements[tokenCount - 1]);
+   }
+   
+   /**
+    * Simple structure class for returning both a NodeRef and Filename String
+    * @author Kevin Roast
+    */
+   public static class PathRefInfo
+   {
+      PathRefInfo(NodeRef ref, String filename)
+      {
+         this.NodeRef = ref;
+         this.Filename = filename;
+      }
+      public NodeRef NodeRef;
+      public String Filename;
+   }
+}

--- a/war/src/main/java/org/alfresco/web/app/servlet/DownloadContentServlet.java
+++ b/war/src/main/java/org/alfresco/web/app/servlet/DownloadContentServlet.java
@@ -1,0 +1,184 @@
+/*
+ * #%L
+ * Alfresco Repository WAR Community
+ * %%
+ * Copyright (C) 2005 - 2016 Alfresco Software Limited
+ * %%
+ * This file is part of the Alfresco software. 
+ * If the software was purchased under a paid Alfresco license, the terms of 
+ * the paid license agreement will prevail.  Otherwise, the software is 
+ * provided under the following open source license terms:
+ * 
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+package org.alfresco.web.app.servlet;
+
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.alfresco.repo.transaction.RetryingTransactionHelper.RetryingTransactionCallback;
+import org.alfresco.service.ServiceRegistry;
+import org.alfresco.service.cmr.repository.NodeRef;
+import org.alfresco.service.transaction.TransactionService;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+/**
+ * Servlet responsible for streaming node content from the repo directly to the response stream.
+ * The appropriate mimetype is calculated based on filename extension.
+ * <p>
+ * The URL to the servlet should be generated thus:
+ * <pre>/alfresco/download/attach/workspace/SpacesStore/0000-0000-0000-0000/myfile.pdf</pre>
+ * or
+ * <pre>/alfresco/download/direct/workspace/SpacesStore/0000-0000-0000-0000/myfile.pdf</pre>
+ * or
+ * <pre>/alfresco/download/[direct|attach]?path=/Company%20Home/MyFolder/myfile.pdf</pre>
+ * The protocol, followed by either the store and Id (NodeRef) or instead specify a name based
+ * encoded Path to the content, note that the filename element is used for mimetype lookup and
+ * as the returning filename for the response stream.
+ * <p>
+ * The 'attach' or 'direct' element is used to indicate whether to display the stream directly
+ * in the browser or download it as a file attachment.
+ * <p>
+ * By default, the download assumes that the content is on the
+ * {@link org.alfresco.model.ContentModel#PROP_CONTENT content property}.<br>
+ * To retrieve the content of a specific model property, use a 'property' arg, providing the workspace,
+ * node ID AND the qualified name of the property.
+ * <p>
+ * Like most Alfresco servlets, the URL may be followed by a valid 'ticket' argument for authentication:
+ * ?ticket=1234567890
+ * <p>
+ * And/or also followed by the "?guest=true" argument to force guest access login for the URL. If the 
+ * guest=true parameter is used the current session will be logged out and the guest user logged in. 
+ * Therefore upon completion of this request the current user will be "guest".
+ * <p>
+ * If the user attempting the request is not authorised to access the requested node the login page
+ * will be redirected to.
+ * 
+ * @author Kevin Roast
+ * @author gavinc
+ */
+public class DownloadContentServlet extends BaseDownloadContentServlet
+{
+   private static final long serialVersionUID = -576405943603122206L;
+
+   private static Log logger = LogFactory.getLog(DownloadContentServlet.class);
+   
+   private static final String DOWNLOAD_URL  = "/d/" + URL_ATTACH + "/{0}/{1}/{2}/{3}";
+   private static final String BROWSER_URL   = "/d/" + URL_DIRECT + "/{0}/{1}/{2}/{3}";
+   
+   @Override
+   protected Log getLogger()
+   {
+      return logger;
+   }
+   
+   /* (non-Javadoc)
+    * @see javax.servlet.http.HttpServlet#doHead(javax.servlet.http.HttpServletRequest, javax.servlet.http.HttpServletResponse)
+    */
+   @Override
+   protected void doHead(final HttpServletRequest req, final HttpServletResponse res) throws ServletException, IOException
+   {
+      if (logger.isDebugEnabled())
+      {
+         String queryString = req.getQueryString();
+         logger.debug("Authenticating (HEAD) request to URL: " + req.getRequestURI() + 
+               ((queryString != null && queryString.length() > 0) ? ("?" + queryString) : ""));
+      }
+      
+      AuthenticationStatus status = servletAuthenticate(req, res);
+      if (status == AuthenticationStatus.Failure)
+      {
+         return;
+      }
+      
+      ServiceRegistry serviceRegistry = getServiceRegistry(getServletContext());
+      TransactionService transactionService = serviceRegistry.getTransactionService();
+      RetryingTransactionCallback<Void> processCallback = new RetryingTransactionCallback<Void>()
+      {
+         public Void execute() throws Throwable
+         {
+             processDownloadRequest(req, res, true, false);
+             return null;
+         }
+      };
+      transactionService.getRetryingTransactionHelper().doInTransaction(processCallback, true);
+   }
+
+   /**
+    * @see javax.servlet.http.HttpServlet#doGet(HttpServletRequest, HttpServletResponse)
+    */
+   protected void doGet(final HttpServletRequest req, final HttpServletResponse res)
+      throws ServletException, IOException
+   {
+      if (logger.isDebugEnabled())
+      {
+         String queryString = req.getQueryString();
+         logger.debug("Authenticating (GET) request to URL: " + req.getRequestURI() + 
+               ((queryString != null && queryString.length() > 0) ? ("?" + queryString) : ""));
+      }
+      
+      AuthenticationStatus status = servletAuthenticate(req, res);
+      if (status == AuthenticationStatus.Failure)
+      {
+         return;
+      }
+      
+      ServiceRegistry serviceRegistry = getServiceRegistry(getServletContext());
+      TransactionService transactionService = serviceRegistry.getTransactionService();
+      RetryingTransactionCallback<Void> processCallback = new RetryingTransactionCallback<Void>()
+      {
+         public Void execute() throws Throwable
+         {
+             processDownloadRequest(req, res, true, true);
+             return null;
+         }
+      };
+      transactionService.getRetryingTransactionHelper().doInTransaction(processCallback, true);
+   }
+   
+   /**
+    * Helper to generate a URL to a content node for downloading content from the server.
+    * The content is supplied as an HTTP1.1 attachment to the response. This generally means
+    * a browser should prompt the user to save the content to specified location.
+    * 
+    * @param ref     NodeRef of the content node to generate URL for (cannot be null)
+    * @param name    File name to return in the URL (cannot be null)
+    * 
+    * @return URL to download the content from the specified node
+    */
+   public final static String generateDownloadURL(NodeRef ref, String name)
+   {
+      return generateUrl(DOWNLOAD_URL, ref, name);
+   }
+   
+   /**
+    * Helper to generate a URL to a content node for downloading content from the server.
+    * The content is supplied directly in the reponse. This generally means a browser will
+    * attempt to open the content directly if possible, else it will prompt to save the file.
+    * 
+    * @param ref     NodeRef of the content node to generate URL for (cannot be null)
+    * @param name    File name to return in the URL (cannot be null)
+    * 
+    * @return URL to download the content from the specified node
+    */
+   public final static String generateBrowserURL(NodeRef ref, String name)
+   {
+      return generateUrl(BROWSER_URL, ref, name);
+   }
+}

--- a/war/src/main/java/org/alfresco/web/app/servlet/DownloadContentServlet.java
+++ b/war/src/main/java/org/alfresco/web/app/servlet/DownloadContentServlet.java
@@ -79,9 +79,6 @@ public class DownloadContentServlet extends BaseDownloadContentServlet
 
    private static Log logger = LogFactory.getLog(DownloadContentServlet.class);
    
-   private static final String DOWNLOAD_URL  = "/d/" + URL_ATTACH + "/{0}/{1}/{2}/{3}";
-   private static final String BROWSER_URL   = "/d/" + URL_DIRECT + "/{0}/{1}/{2}/{3}";
-   
    @Override
    protected Log getLogger()
    {
@@ -124,7 +121,7 @@ public class DownloadContentServlet extends BaseDownloadContentServlet
     * @see javax.servlet.http.HttpServlet#doGet(HttpServletRequest, HttpServletResponse)
     */
    protected void doGet(final HttpServletRequest req, final HttpServletResponse res)
-      throws ServletException, IOException
+      throws IOException
    {
       if (logger.isDebugEnabled())
       {
@@ -150,35 +147,5 @@ public class DownloadContentServlet extends BaseDownloadContentServlet
          }
       };
       transactionService.getRetryingTransactionHelper().doInTransaction(processCallback, true);
-   }
-   
-   /**
-    * Helper to generate a URL to a content node for downloading content from the server.
-    * The content is supplied as an HTTP1.1 attachment to the response. This generally means
-    * a browser should prompt the user to save the content to specified location.
-    * 
-    * @param ref     NodeRef of the content node to generate URL for (cannot be null)
-    * @param name    File name to return in the URL (cannot be null)
-    * 
-    * @return URL to download the content from the specified node
-    */
-   public final static String generateDownloadURL(NodeRef ref, String name)
-   {
-      return generateUrl(DOWNLOAD_URL, ref, name);
-   }
-   
-   /**
-    * Helper to generate a URL to a content node for downloading content from the server.
-    * The content is supplied directly in the reponse. This generally means a browser will
-    * attempt to open the content directly if possible, else it will prompt to save the file.
-    * 
-    * @param ref     NodeRef of the content node to generate URL for (cannot be null)
-    * @param name    File name to return in the URL (cannot be null)
-    * 
-    * @return URL to download the content from the specified node
-    */
-   public final static String generateBrowserURL(NodeRef ref, String name)
-   {
-      return generateUrl(BROWSER_URL, ref, name);
    }
 }

--- a/war/src/main/java/org/alfresco/web/bean/repository/User.java
+++ b/war/src/main/java/org/alfresco/web/bean/repository/User.java
@@ -1,0 +1,282 @@
+/*
+ * #%L
+ * Alfresco Repository WAR Community
+ * %%
+ * Copyright (C) 2005 - 2016 Alfresco Software Limited
+ * %%
+ * This file is part of the Alfresco software.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail.  Otherwise, the software is
+ * provided under the following open source license terms:
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+package org.alfresco.web.bean.repository;
+
+import org.alfresco.model.ApplicationModel;
+import org.alfresco.model.ContentModel;
+import org.alfresco.repo.SessionUser;
+import org.alfresco.repo.configuration.ConfigurableService;
+import org.alfresco.repo.transaction.RetryingTransactionHelper;
+import org.alfresco.repo.transaction.RetryingTransactionHelper.RetryingTransactionCallback;
+import org.alfresco.service.ServiceRegistry;
+import org.alfresco.service.cmr.repository.ChildAssociationRef;
+import org.alfresco.service.cmr.repository.NodeRef;
+import org.alfresco.service.cmr.repository.NodeService;
+import org.alfresco.service.cmr.search.SearchService;
+import org.alfresco.service.namespace.NamespaceService;
+import org.alfresco.service.namespace.QName;
+import org.alfresco.service.transaction.TransactionService;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.context.support.WebApplicationContextUtils;
+import org.springframework.web.jsf.FacesContextUtils;
+
+//import javax.faces.context.FacesContext;
+import javax.servlet.ServletContext;
+import java.io.Serializable;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Bean that represents the currently logged in user
+ *
+ * @author gavinc
+ */
+public final class User implements SessionUser
+{
+   private static final long serialVersionUID = -90577901805847829L;
+
+   private String companyRootId;
+   private String homeSpaceId;
+   private String userName;
+   private String ticket;
+   private NodeRef person;
+   private String fullName = null;
+
+   /**
+    * Constructor
+    *
+    * @param userName constructor for the user
+    */
+   public User(String userName, String ticket, NodeRef person)
+   {
+      if (userName == null || ticket == null || person == null)
+      {
+         throw new IllegalArgumentException("All user details are mandatory!");
+      }
+
+      this.userName = userName;
+      this.ticket = ticket;
+      this.person = person;
+   }
+
+   /**
+    * Forces a clear of any cached or calcluated values
+    */
+   public void reset()
+   {
+      this.fullName = null;
+   }
+
+   /**
+    * @return The user name
+    */
+   public String getUserName()
+   {
+      return this.userName;
+   }
+
+   /**
+    * Return the full name of the Person this User represents
+    *
+    * @param service        NodeService to use
+    *
+    * @return The full name
+    */
+   public String getFullName(NodeService service)
+   {
+      if (this.fullName == null)
+      {
+         String firstName = (String)service.getProperty(this.person, ContentModel.PROP_FIRSTNAME);
+         String lastName = (String)service.getProperty(this.person, ContentModel.PROP_LASTNAME);
+         this.fullName = (firstName != null ? firstName : "") + ' ' + (lastName != null ? lastName : "");
+      }
+
+      return this.fullName;
+   }
+
+   /**
+    * @return Retrieves the user's home space (this may be the id of the company home space)
+    */
+   public String getHomeSpaceId()
+   {
+      return this.homeSpaceId;
+   }
+
+   /**
+    * @param homeSpaceId Sets the id of the users home space
+    */
+   public void setHomeSpaceId(String homeSpaceId)
+   {
+      this.homeSpaceId = homeSpaceId;
+   }
+
+   /**
+    * @return Retrieves the company home space
+    */
+   public String getCompanyRootId()
+   {
+      return this.companyRootId;
+   }
+
+   /**
+    * @param companyRootId Sets the id of the company home space
+    */
+   public void setCompanyRootId(String companyRootId)
+   {
+      this.companyRootId = companyRootId;
+   }
+
+   /**
+    * @return Returns the ticket.
+    */
+   public String getTicket()
+   {
+      return this.ticket;
+   }
+
+   /**
+    * @return Returns the person NodeRef
+    */
+   public NodeRef getPerson()
+   {
+      return this.person;
+   }
+
+   /**
+    * Get or create the node used to store user preferences.
+    * Utilises the 'configurable' aspect on the Person linked to this user.
+    */
+   synchronized NodeRef getUserPreferencesRef(WebApplicationContext context)
+   {
+        final ServiceRegistry registry = (ServiceRegistry) context.getBean("ServiceRegistry");
+        final NodeService nodeService = registry.getNodeService();
+        final SearchService searchService = registry.getSearchService();
+        final NamespaceService namespaceService = registry.getNamespaceService();
+        final TransactionService txService = registry.getTransactionService();
+        final ConfigurableService configurableService = (ConfigurableService) context.getBean("ConfigurableService");
+        RetryingTransactionHelper txnHelper = registry.getTransactionService().getRetryingTransactionHelper();
+        return txnHelper.doInTransaction(new RetryingTransactionCallback<NodeRef>()
+        {
+            public NodeRef execute() throws Throwable
+            {
+                NodeRef prefRef = null;
+                NodeRef person = getPerson();
+                if (nodeService.hasAspect(person, ApplicationModel.ASPECT_CONFIGURABLE) == false)
+                {
+                    // if the repository is in read-only mode just return null
+                    if (txService.isReadOnly())
+                    {
+                        return null;
+                    }
+                    else
+                    {
+                        // create the configuration folder for this Person node
+                        configurableService.makeConfigurable(person);
+                    }
+                }
+
+                // target of the assoc is the configurations folder ref
+                NodeRef configRef = configurableService.getConfigurationFolder(person);
+                if (configRef == null)
+                {
+                    throw new IllegalStateException("Unable to find associated 'configurations' folder for node: "
+                            + person);
+                }
+
+                String xpath = NamespaceService.APP_MODEL_PREFIX + ":" + "preferences";
+                List<NodeRef> nodes = searchService.selectNodes(configRef, xpath, null, namespaceService, false);
+
+                if (nodes.size() == 1)
+                {
+                    prefRef = nodes.get(0);
+                }
+                else
+                {
+                    // create the preferences Node for this user (if repo is not read-only)
+                    if (txService.isReadOnly() == false)
+                    {
+                        ChildAssociationRef childRef = nodeService.createNode(configRef,
+                                    ContentModel.ASSOC_CONTAINS, QName.createQName(
+                                    NamespaceService.APP_MODEL_1_0_URI, "preferences"),
+                                    ContentModel.TYPE_CMOBJECT);
+
+                       prefRef = childRef.getChildRef();
+                    }
+                }
+                return prefRef;
+            }
+        }, txService.isReadOnly());
+    }
+
+   /**
+    * Returns the full name of the user represented by the given NodeRef
+    *
+    * @param nodeService The node service instance
+    * @param user The user to get the full name for
+    * @return The full name
+    */
+   public static String getFullName(NodeService nodeService, NodeRef user)
+   {
+      Map<QName, Serializable> props = nodeService.getProperties(user);
+      String firstName = (String)props.get(ContentModel.PROP_FIRSTNAME);
+      String lastName = (String)props.get(ContentModel.PROP_LASTNAME);
+      String fullName = firstName + ((lastName != null && lastName.length() > 0) ? " " + lastName : "");
+
+      return fullName;
+   }
+
+   /**
+    * Returns the full name of the user plus their userid in the form [id]
+    *
+    * @param nodeService The node service instance
+    * @param user The user to get the full name for
+    * @return The full name and userid
+    */
+   public static String getFullNameAndUserId(NodeService nodeService, NodeRef user)
+   {
+      String fullName = getFullName(nodeService, user);
+      String userId = (String)nodeService.getProperties(user).get(ContentModel.PROP_USERNAME);
+
+      StringBuilder nameAndId = new StringBuilder();
+      if (fullName != null && fullName.length() > 0 && fullName.equals("null") == false)
+      {
+         nameAndId.append(fullName);
+         nameAndId.append(" ");
+      }
+
+      nameAndId.append("[");
+      nameAndId.append(userId);
+      nameAndId.append("]");
+
+      return nameAndId.toString();
+   }
+
+   @Override
+   public String toString()
+   {
+       return this.userName;
+   }
+}

--- a/war/src/main/webapp/WEB-INF/web.xml
+++ b/war/src/main/webapp/WEB-INF/web.xml
@@ -129,6 +129,17 @@
       <filter-name>WebScript Cookie Authentication Filter</filter-name>
       <url-pattern>/wcs/*</url-pattern>
    </filter-mapping>
+
+   <filter-mapping>
+      <filter-name>WebScript Cookie Authentication Filter</filter-name>
+<!--      <url-pattern>/d/*</url-pattern>-->
+      <servlet-name>downloadContent</servlet-name>
+   </filter-mapping>
+
+   <filter-mapping>
+      <filter-name>WebScript Cookie Authentication Filter</filter-name>
+      <url-pattern>/download/*</url-pattern>
+   </filter-mapping>
    
    <!-- The WebScript Authentication filter sits in front of web service URLs in addition to the global authentication filter -->
    <filter-mapping>
@@ -139,6 +150,17 @@
    <filter-mapping>
       <filter-name>WebScript Authentication Filter</filter-name>
       <url-pattern>/wcs/*</url-pattern>
+   </filter-mapping>
+
+   <filter-mapping>
+      <filter-name>WebScript Authentication Filter</filter-name>
+<!--      <url-pattern>/d/*</url-pattern>-->
+      <servlet-name>downloadContent</servlet-name>
+   </filter-mapping>
+
+   <filter-mapping>
+      <filter-name>WebScript Authentication Filter</filter-name>
+      <url-pattern>/download/*</url-pattern>
    </filter-mapping>
    
    <filter-mapping>
@@ -260,23 +282,8 @@
    <!-- Enterprise listener placeholder -->
 
    <servlet>
-      <servlet-name>uploadContent</servlet-name>
-      <servlet-class>org.alfresco.web.app.servlet.UploadContentServlet</servlet-class>
-   </servlet>
-
-   <servlet>
       <servlet-name>downloadContent</servlet-name>
       <servlet-class>org.alfresco.web.app.servlet.DownloadContentServlet</servlet-class>
-   </servlet>
-
-   <servlet>
-      <servlet-name>downloadRawContent</servlet-name>
-      <servlet-class>org.alfresco.web.app.servlet.DownloadRawContentServlet</servlet-class>
-   </servlet>
-
-   <servlet>
-      <servlet-name>guestDownloadContent</servlet-name>
-      <servlet-class>org.alfresco.web.app.servlet.GuestDownloadContentServlet</servlet-class>
    </servlet>
 
    <servlet>
@@ -420,11 +427,6 @@
    <!-- Enterprise servlet placeholder -->
 
    <servlet-mapping>
-      <servlet-name>uploadContent</servlet-name>
-      <url-pattern>/upload/*</url-pattern>
-   </servlet-mapping>
-
-   <servlet-mapping>
       <servlet-name>downloadContent</servlet-name>
       <url-pattern>/download/*</url-pattern>
    </servlet-mapping>
@@ -432,21 +434,6 @@
    <servlet-mapping>
       <servlet-name>downloadContent</servlet-name>
       <url-pattern>/d/*</url-pattern>
-   </servlet-mapping>
-
-   <servlet-mapping>
-      <servlet-name>downloadRawContent</servlet-name>
-      <url-pattern>/dr</url-pattern>
-   </servlet-mapping>
-
-   <servlet-mapping>
-      <servlet-name>guestDownloadContent</servlet-name>
-      <url-pattern>/guestDownload/*</url-pattern>
-   </servlet-mapping>
-
-   <servlet-mapping>
-      <servlet-name>guestDownloadContent</servlet-name>
-      <url-pattern>/gd/*</url-pattern>
    </servlet-mapping>
 
    <servlet-mapping>


### PR DESCRIPTION
Revived DownloadContentServlet with respective base and helper classes.

Removed inaccessible code and methods from the original code (as tightly coupled to Alfresco Explorer).

Created `public static void prettyPrintError(HttpServletRequest req, HttpServletResponse res, String message, int status, String actualCause)` as there past error pages are not available anymore, this is done to avoid printing of stacktrace into the browser.

Removed leftover `rg.alfresco.web.app.servlet.UploadContentServlet`, `org.alfresco.web.app.servlet.DownloadRawContentServlet` and `org.alfresco.web.app.servlet.GuestDownloadContentServlet` from web.xml as those servlet implementation does not exist.