### PR TITLE
ACS-381: MM 1.4.2-RC1 release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
         <alfresco.aos-module.version>1.3.1</alfresco.aos-module.version>
 
         <!-- Alfresco Media Management Module -->
-        <alfresco.mm.version>1.4.1</alfresco.mm.version>
+        <alfresco.mm.version>1.4.2-RC1</alfresco.mm.version>
 
         <!-- Alfresco Desktop Sync Service Module -->
         <alfresco.desktop-sync.version>3.3.3-RC2</alfresco.desktop-sync.version>

--- a/tests/tas-all-amps/pom.xml
+++ b/tests/tas-all-amps/pom.xml
@@ -283,7 +283,7 @@
                                             <overWrite>false</overWrite>
                                             <outputDirectory>${project.build.directory}/amps_share</outputDirectory>
                                         </artifactItem>
-                                      <!--  <artifactItem>
+                                        <artifactItem>
                                             <groupId>org.alfresco.mediamanagement</groupId>
                                             <artifactId>alfresco-mm-repo</artifactId>
                                             <version>${alfresco.mm.version}</version>
@@ -298,7 +298,7 @@
                                             <type>amp</type>
                                             <overWrite>false</overWrite>
                                             <outputDirectory>${project.build.directory}/amps_share</outputDirectory>
-                                        </artifactItem>-->
+                                        </artifactItem>
                                         <artifactItem>
                                             <groupId>org.alfresco</groupId>
                                             <artifactId>alfresco-document-transformation-engine-repo</artifactId>

--- a/tests/tas-all-amps/src/test/java/org/alfresco/rest/discovery/DiscoveryTests.java
+++ b/tests/tas-all-amps/src/test/java/org/alfresco/rest/discovery/DiscoveryTests.java
@@ -77,7 +77,7 @@ public class DiscoveryTests extends RestTest
                 "alfresco-share-services",
                 "alfresco-saml-repo",
                 "org_alfresco_device_sync_repo",
-                //"org_alfresco_mm_repo", 
+                "org_alfresco_mm_repo", 
                 "alfresco-ai-repo",
                 "org_alfresco_module_rm", "alfresco-rm-enterprise-repo",
                 //"alfresco-glacier-connector-repo",


### PR DESCRIPTION
- update MM version from 1.4.1 to 1.4.2-RC1
- enable MM AMPs in the tas-all-amps module