### PR TITLE
ACS-222: tests jobs using AIMS fail

### DIFF
--- a/tests/scripts/wait-for-alfresco-start.sh
+++ b/tests/scripts/wait-for-alfresco-start.sh
@@ -24,6 +24,7 @@ if (("$COUNTER" < "$TIMEOUT")) ; then
    t1=$(date +%s)
    delta=$((($t1 - $t0)/60))
    echo "Alfresco Started in $delta minutes"
+   sleep 180
 else
    echo "Waited $COUNTER seconds"
    echo "Alfresco Could not start in time."

--- a/tests/scripts/wait-for-alfresco-start.sh
+++ b/tests/scripts/wait-for-alfresco-start.sh
@@ -12,6 +12,7 @@ WAIT_INTERVAL=1
 COUNTER=0
 TIMEOUT=300
 t0=$(date +%s)
+EXTRA_WAIT_INTERVAL=180
 
 echo "Waiting for alfresco to start"
 until $(curl --output /dev/null --silent --head --fail ${ALFRESCO_URL}) || [ "$COUNTER" -eq "$TIMEOUT" ]; do
@@ -23,8 +24,9 @@ done
 if (("$COUNTER" < "$TIMEOUT")) ; then
    t1=$(date +%s)
    delta=$((($t1 - $t0)/60))
-   echo "Alfresco Started in $delta minutes"
-   sleep 180
+   echo "Alfresco Started in $delta minutes, waiting for all the containers to initialise..."
+   sleep $EXTRA_WAIT_INTERVAL
+   echo "Waited $EXTRA_WAIT_INTERVAL seconds"
 else
    echo "Waited $COUNTER seconds"
    echo "Alfresco Could not start in time."


### PR DESCRIPTION
From the analysis done in ACS-222, adding an extra interval (before tests start) seems to prevent the jobs to fail - not only the AIMS jobs but also the other ones that already failed before ACS-222 (even that not very often).