### PR TITLE
MNT-21875 : [PaaS] Alfresco Content Services 7.0.0 M1 Distribution contains invalid Keystore

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -107,6 +107,14 @@
             <resource>
                 <directory>src/main/resources</directory>
                 <filtering>true</filtering>
+                <excludes>
+                    <exclude>keystore/**</exclude>
+                </excludes>
+            </resource>
+            <resource>
+                <directory>src/main/resources/keystore</directory>
+                <targetPath>keystore</targetPath>
+                <filtering>false</filtering>
             </resource>
         </resources>
         <plugins>


### PR DESCRIPTION
- excluded the keystore contents from filtering