### PR TITLE
MNT-21859 Embed old keystore in docker images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ jobs:
     - name: "REST API TAS tests part1"
       jdk: openjdk11
       install:
-        - travis_retry travis_wait 40 mvn install -q -PenterpriseDocker
+        - travis_retry travis_wait 40 mvn install -q
         - ./tests/scripts/start-compose.sh ./tests/environment/docker-compose-rest-api-tests.yml
         - ./tests/scripts/wait-for-alfresco-start.sh "http://localhost:8082/alfresco"
       script:
@@ -59,7 +59,7 @@ jobs:
     - name: "REST API TAS tests part2"
       jdk: openjdk11
       install:
-        - travis_retry travis_wait 40 mvn install -q -PenterpriseDocker
+        - travis_retry travis_wait 40 mvn install -q
         - ./tests/scripts/start-compose.sh ./tests/environment/docker-compose-rest-api-tests.yml
         - ./tests/scripts/wait-for-alfresco-start.sh "http://localhost:8082/alfresco"
       script:
@@ -67,7 +67,7 @@ jobs:
     - name: "REST API TAS tests part3"
       jdk: openjdk11
       install:
-        - travis_retry travis_wait 40 mvn install -q -PenterpriseDocker
+        - travis_retry travis_wait 40 mvn install -q
         - ./tests/scripts/start-compose.sh ./tests/environment/docker-compose-rest-api-tests.yml
         - ./tests/scripts/wait-for-alfresco-start.sh "http://localhost:8082/alfresco"
       script:
@@ -75,7 +75,7 @@ jobs:
     - name: "CMIS TAS tests"
       jdk: openjdk11
       install:
-        - travis_retry travis_wait 40 mvn install -q -PenterpriseDocker
+        - travis_retry travis_wait 40 mvn install -q
         - ./tests/scripts/start-compose.sh ./tests/environment/docker-compose-cmis-tests.yml
         - ./tests/scripts/wait-for-alfresco-start.sh "http://localhost:8082/alfresco"
       script:
@@ -83,7 +83,7 @@ jobs:
     - name: "Email TAS tests"
       jdk: openjdk11
       install:
-        - travis_retry travis_wait 40 mvn install -q -PenterpriseDocker
+        - travis_retry travis_wait 40 mvn install -q
         - ./tests/scripts/start-compose.sh ./tests/environment/docker-compose-email-tests.yml
         - ./tests/scripts/wait-for-alfresco-start.sh "http://localhost:8082/alfresco"
       script:
@@ -91,7 +91,7 @@ jobs:
     - name: "LDAP TAS tests"
       jdk: openjdk11
       install:
-        - travis_retry travis_wait 40 mvn install -q -PenterpriseDocker
+        - travis_retry travis_wait 40 mvn install -q
         - ./tests/scripts/start-compose.sh ./tests/environment/docker-compose-with-ldap.yml
         - ./tests/scripts/wait-for-alfresco-start.sh "http://localhost:8082/alfresco"
       script:
@@ -100,7 +100,7 @@ jobs:
     - name: "WebDAV TAS tests"
       jdk: openjdk11
       install:
-        - travis_retry travis_wait 40 mvn install -q -PenterpriseDocker
+        - travis_retry travis_wait 40 mvn install -q
         - ./tests/scripts/start-compose.sh ./tests/environment/docker-compose-minimal.yml
         - ./tests/scripts/wait-for-alfresco-start.sh "http://localhost:8082/alfresco"
       script:
@@ -108,7 +108,7 @@ jobs:
     - name: "Integration TAS tests"
       jdk: openjdk11
       install:
-        - travis_retry travis_wait 40 mvn install -q -PenterpriseDocker
+        - travis_retry travis_wait 40 mvn install -q
         - ./tests/scripts/start-compose.sh ./tests/environment/docker-compose-integration-tests.yml
         - ./tests/scripts/wait-for-alfresco-start.sh "http://localhost:8082/alfresco"
       script:
@@ -116,7 +116,7 @@ jobs:
     - name: "Cluster tests"
       jdk: openjdk11
       install:
-        - travis_retry travis_wait 40 mvn install -q -PenterpriseDocker
+        - travis_retry travis_wait 40 mvn install -q
         - ./tests/scripts/start-compose.sh ./tests/environment/docker-compose-cluster.yml
         - ./tests/scripts/wait-for-alfresco-start.sh "http://localhost:8081/alfresco"
         - ./tests/scripts/wait-for-alfresco-start.sh "http://localhost:8082/alfresco"
@@ -125,7 +125,7 @@ jobs:
     - name: "Node restart tests"
       jdk: openjdk11
       install:
-        - travis_retry travis_wait 40 mvn install -q -PenterpriseDocker
+        - travis_retry travis_wait 40 mvn install -q
       script:
         # Start Alfresco and test if it is running
         - ./tests/scripts/start-compose.sh ./tests/environment/docker-compose-node-restart.yml
@@ -140,7 +140,7 @@ jobs:
       jdk: openjdk11
       if: fork = false # AIMS docker image requires access to quay.io
       install:
-        - travis_retry travis_wait 40 mvn install -q -PenterpriseDocker
+        - travis_retry travis_wait 40 mvn install -q
         - docker login quay.io -u ${QUAY_USERNAME} -p ${QUAY_PASSWORD}
         # AIMS cannot be configured via localhost
         - export HOST_IP=$(ip address show | grep -E "([0-9]{1,3}\.){3}[0-9]{1,3}" | grep -v 127.0.0.1 | awk '{ print $2 }' | head -n 1 )
@@ -153,7 +153,7 @@ jobs:
       jdk: openjdk11
       if: fork = false # AIMS docker image requires access to quay.io
       install:
-        - travis_retry travis_wait 40 mvn install -q -PenterpriseDocker
+        - travis_retry travis_wait 40 mvn install -q
         - docker login quay.io -u ${QUAY_USERNAME} -p ${QUAY_PASSWORD}
         # AIMS cannot be configured via localhost
         - export HOST_IP=$(ip address show | grep -E "([0-9]{1,3}\.){3}[0-9]{1,3}" | grep -v 127.0.0.1 | awk '{ print $2 }' | head -n 1 )
@@ -165,7 +165,7 @@ jobs:
     - name: "Sync Service TAS tests"
       jdk: openjdk11
       install:
-        - travis_retry travis_wait 40 mvn install -q -PenterpriseDocker
+        - travis_retry travis_wait 40 mvn install -q
         - docker login quay.io -u ${QUAY_USERNAME} -p ${QUAY_PASSWORD}
         - ./tests/scripts/start-compose.sh ./tests/environment/docker-compose-sync-service.yml
         - ./tests/scripts/wait-for-alfresco-start.sh "http://localhost:8082/alfresco"
@@ -174,8 +174,7 @@ jobs:
     - name: "All AMPs tests"
       jdk: openjdk11
       install:
-        # fullBuild profile builds additional Docker image for all-amps test
-        - travis_retry travis_wait 20 mvn install -q -PenterpriseDocker,fullBuild
+        - travis_retry travis_wait 20 mvn install -q
         - travis_retry travis_wait 20 mvn install -q -f tests/tas-all-amps/pom.xml -DskipTests -Pall-tas-tests,prepare-wars-with-amps
       script:
         - ./tests/scripts/checkLibraryDuplicates.sh ./tests/tas-all-amps/target/war/alfresco/WEB-INF/lib
@@ -187,9 +186,9 @@ jobs:
       if: fork = false AND (branch = master OR branch =~ /support\/.*/) AND type != pull_request
       install:
         # Build additional Docker image for repo and share for CI pipeline
-        - travis_retry travis_wait 20 mvn install -q -PenterpriseDocker
+        - travis_retry travis_wait 20 mvn install -q
         - export TRAVIS_BUILD_NUMBER=${TRAVIS_BUILD_NUMBER}
-        - travis_retry travis_wait 20 mvn install -q -PenterpriseDocker -Dbuild-number=${TRAVIS_BUILD_NUMBER}
+        - travis_retry travis_wait 20 mvn install -q -Dbuild-number=${TRAVIS_BUILD_NUMBER}
         - docker login quay.io -u ${QUAY_USERNAME} -p ${QUAY_PASSWORD}
         - travis_retry travis_wait 20 mvn clean install -Ppipeline
       script:

--- a/docker-alfresco/Dockerfile
+++ b/docker-alfresco/Dockerfile
@@ -21,6 +21,7 @@ ARG JAVA_PROFILER_RUNTIME_DIR=/tmp/Alfresco/yourkit
 RUN mkdir -p ${TOMCAT_DIR}/shared/classes/alfresco/extension/mimetypes && \
     mkdir -p ${TOMCAT_DIR}/shared/classes/alfresco/extension/transform/renditions && \
     mkdir -p ${TOMCAT_DIR}/shared/classes/alfresco/extension/transform/pipelines && \
+    mkdir -p ${TOMCAT_DIR}/shared/classes/alfresco/extension/keystore && \
     mkdir ${TOMCAT_DIR}/alfresco-mmt && \
     touch ${TOMCAT_DIR}/shared/classes/alfresco-global.properties
 
@@ -77,12 +78,8 @@ RUN curl -o /tmp/${JAVA_PROFILER}.zip "https://www.yourkit.com/download/docker/$
     jar xvf /tmp/${JAVA_PROFILER}.zip && \
     rm /tmp/${JAVA_PROFILER}.zip
 
-# Generate default keystore. Please generate new one for production systems
-ARG CERT_DNAME="CN=Alfresco Repository, OU=Unknown, O=Alfresco Software Ltd., L=Maidenhead, ST=UK, C=GB"
-ARG CERT_VALIDITY=36525
-ARG KEYSTORE_PASSWORD=mp6yc0UD9e
-RUN mkdir ${TOMCAT_DIR}/shared/classes/alfresco/keystore && \
-    keytool -genseckey -dname "$CERT_DNAME" -validity ${CERT_VALIDITY} -alias metadata -keyalg AES -keysize 256 -keystore ${TOMCAT_DIR}/shared/classes/alfresco/keystore/keystore -storetype pkcs12 -storepass ${KEYSTORE_PASSWORD}
+# Copy default keystore
+COPY ${resource_path}/distribution/keystore/metadata-keystore/keystore ${TOMCAT_DIR}/shared/classes/alfresco/extension/keystore/
 
 # The standard configuration is to have all Tomcat files owned by root with group GROUPNAME and whilst owner has read/write privileges, 
 # group only has restricted permissions and world has no permissions.

--- a/docker-alfresco/aws/pom.xml
+++ b/docker-alfresco/aws/pom.xml
@@ -93,6 +93,13 @@
                                     <outputDirectory>${project.build.directory}/war/api-explorer</outputDirectory>
                                     <destFileName>api-explorer.war</destFileName>
                                 </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.alfresco</groupId>
+                                    <artifactId>alfresco-content-services-distribution</artifactId>
+                                    <version>${project.version}</version>
+                                    <type>zip</type>
+                                    <outputDirectory>${project.build.directory}/distribution</outputDirectory>
+                                </artifactItem>
                             </artifactItems>
                         </configuration>
                     </execution>
@@ -222,33 +229,20 @@
                         </image>
                     </images>
                 </configuration>
+                <executions>
+                    <execution>
+                        <id>build-image</id>
+                        <phase>install</phase>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>
 
     <profiles>
-        <profile>
-            <id>enterpriseDocker</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>io.fabric8</groupId>
-                        <artifactId>fabric8-maven-plugin</artifactId>
-                        <version>${dependency.fabric8.version}</version>
-                        <executions>
-                            <execution>
-                                <id>build-image</id>
-                                <phase>install</phase>
-                                <goals>
-                                    <goal>build</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-
         <profile>
             <id>internal</id>
             <build>

--- a/docker-alfresco/pom.xml
+++ b/docker-alfresco/pom.xml
@@ -25,6 +25,12 @@
         </dependency>
         <dependency>
             <groupId>org.alfresco</groupId>
+            <artifactId>alfresco-content-services-distribution</artifactId>
+            <version>${project.version}</version>
+            <type>zip</type>
+        </dependency>
+        <dependency>
+            <groupId>org.alfresco</groupId>
             <artifactId>api-explorer</artifactId>
             <version>${dependency.alfresco-api-explorer.version}</version>
             <type>war</type>
@@ -136,6 +142,13 @@
                                     <type>war</type>
                                     <outputDirectory>${project.build.directory}/war/_vti_bin</outputDirectory>
                                 </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.alfresco</groupId>
+                                    <artifactId>alfresco-content-services-distribution</artifactId>
+                                    <version>${project.version}</version>
+                                    <type>zip</type>
+                                    <outputDirectory>${project.build.directory}/distribution</outputDirectory>
+                                </artifactItem>
                             </artifactItems>
                         </configuration>
                     </execution>
@@ -225,33 +238,20 @@
                         </image>
                     </images>
                 </configuration>
+                <executions>
+                    <execution>
+                        <id>build-image</id>
+                        <phase>install</phase>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>
 
     <profiles>
-        <profile>
-            <id>enterpriseDocker</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>io.fabric8</groupId>
-                        <artifactId>fabric8-maven-plugin</artifactId>
-                        <version>${dependency.fabric8.version}</version>
-                        <executions>
-                            <execution>
-                                <id>build-image</id>
-                                <phase>install</phase>
-                                <goals>
-                                    <goal>build</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-
         <profile>
             <id>internal</id>
             <build>

--- a/pom.xml
+++ b/pom.xml
@@ -140,14 +140,6 @@
             </modules>
         </profile>
         <profile>
-            <id>enterpriseDocker</id>
-            <modules>
-                <module>war</module>
-                <module>docker-alfresco</module>
-                <module>docker-alfresco/aws</module>
-            </modules>
-        </profile>
-        <profile>
             <id>fullBuild</id>
             <activation>
                 <activeByDefault>true</activeByDefault>
@@ -177,6 +169,7 @@
             <id>pipeline</id>
             <modules>
                 <module>war</module>
+                <module>distribution</module>
                 <module>docker-alfresco</module>
                 <module>tests/pipeline-all-amps</module>
             </modules>

--- a/tests/environment/docker-compose-aims.yml
+++ b/tests/environment/docker-compose-aims.yml
@@ -27,10 +27,14 @@ services:
       HOST_IP: ${HOST_IP}
       CATALINA_OPTS : "-agentlib:jdwp=transport=dt_socket,address=*:8000,server=y,suspend=n"
       JAVA_TOOL_OPTIONS: "
+        -Dencryption.keystore.type=JCEKS
+        -Dencryption.cipherAlgorithm=DESede/CBC/PKCS5Padding
+        -Dencryption.keyAlgorithm=DESede
+        -Dencryption.keystore.location=/usr/local/tomcat/shared/classes/alfresco/extension/keystore/keystore
         -Dmetadata-keystore.password=mp6yc0UD9e
         -Dmetadata-keystore.aliases=metadata
-        -Dmetadata-keystore.metadata.password=mp6yc0UD9e
-        -Dmetadata-keystore.metadata.algorithm=AES
+        -Dmetadata-keystore.metadata.password=oKIWzVdEdA
+        -Dmetadata-keystore.metadata.algorithm=DESede
       "
       JAVA_OPTS :
         "

--- a/tests/environment/docker-compose-all-amps-test.yml
+++ b/tests/environment/docker-compose-all-amps-test.yml
@@ -16,10 +16,14 @@ services:
     environment:
       CATALINA_OPTS : "-agentlib:jdwp=transport=dt_socket,address=*:8000,server=y,suspend=n"
       JAVA_TOOL_OPTIONS: "
+        -Dencryption.keystore.type=JCEKS
+        -Dencryption.cipherAlgorithm=DESede/CBC/PKCS5Padding
+        -Dencryption.keyAlgorithm=DESede
+        -Dencryption.keystore.location=/usr/local/tomcat/shared/classes/alfresco/extension/keystore/keystore
         -Dmetadata-keystore.password=mp6yc0UD9e
         -Dmetadata-keystore.aliases=metadata
-        -Dmetadata-keystore.metadata.password=mp6yc0UD9e
-        -Dmetadata-keystore.metadata.algorithm=AES
+        -Dmetadata-keystore.metadata.password=oKIWzVdEdA
+        -Dmetadata-keystore.metadata.algorithm=DESede
       "
       JAVA_OPTS :
         "

--- a/tests/environment/docker-compose-cluster.yml
+++ b/tests/environment/docker-compose-cluster.yml
@@ -13,10 +13,14 @@ services:
     environment:
       CATALINA_OPTS : "-agentlib:jdwp=transport=dt_socket,address=*:8000,server=y,suspend=n"
       JAVA_TOOL_OPTIONS: "
+        -Dencryption.keystore.type=JCEKS
+        -Dencryption.cipherAlgorithm=DESede/CBC/PKCS5Padding
+        -Dencryption.keyAlgorithm=DESede
+        -Dencryption.keystore.location=/usr/local/tomcat/shared/classes/alfresco/extension/keystore/keystore
         -Dmetadata-keystore.password=mp6yc0UD9e
         -Dmetadata-keystore.aliases=metadata
-        -Dmetadata-keystore.metadata.password=mp6yc0UD9e
-        -Dmetadata-keystore.metadata.algorithm=AES
+        -Dmetadata-keystore.metadata.password=oKIWzVdEdA
+        -Dmetadata-keystore.metadata.algorithm=DESede
       "
       JAVA_OPTS :
         "
@@ -43,10 +47,14 @@ services:
     environment:
       CATALINA_OPTS : "-agentlib:jdwp=transport=dt_socket,address=*:8000,server=y,suspend=n"
       JAVA_TOOL_OPTIONS: "
+        -Dencryption.keystore.type=JCEKS
+        -Dencryption.cipherAlgorithm=DESede/CBC/PKCS5Padding
+        -Dencryption.keyAlgorithm=DESede
+        -Dencryption.keystore.location=/usr/local/tomcat/shared/classes/alfresco/extension/keystore/keystore
         -Dmetadata-keystore.password=mp6yc0UD9e
         -Dmetadata-keystore.aliases=metadata
-        -Dmetadata-keystore.metadata.password=mp6yc0UD9e
-        -Dmetadata-keystore.metadata.algorithm=AES
+        -Dmetadata-keystore.metadata.password=oKIWzVdEdA
+        -Dmetadata-keystore.metadata.algorithm=DESede
       "
       JAVA_OPTS :
         "

--- a/tests/environment/docker-compose-cmis-tests.yml
+++ b/tests/environment/docker-compose-cmis-tests.yml
@@ -14,10 +14,14 @@ services:
     environment:
       CATALINA_OPTS : "-agentlib:jdwp=transport=dt_socket,address=*:8000,server=y,suspend=n"
       JAVA_TOOL_OPTIONS: "
+        -Dencryption.keystore.type=JCEKS
+        -Dencryption.cipherAlgorithm=DESede/CBC/PKCS5Padding
+        -Dencryption.keyAlgorithm=DESede
+        -Dencryption.keystore.location=/usr/local/tomcat/shared/classes/alfresco/extension/keystore/keystore
         -Dmetadata-keystore.password=mp6yc0UD9e
         -Dmetadata-keystore.aliases=metadata
-        -Dmetadata-keystore.metadata.password=mp6yc0UD9e
-        -Dmetadata-keystore.metadata.algorithm=AES
+        -Dmetadata-keystore.metadata.password=oKIWzVdEdA
+        -Dmetadata-keystore.metadata.algorithm=DESede
       "
       JAVA_OPTS :
         "

--- a/tests/environment/docker-compose-email-tests.yml
+++ b/tests/environment/docker-compose-email-tests.yml
@@ -15,10 +15,14 @@ services:
     environment:
       CATALINA_OPTS : "-agentlib:jdwp=transport=dt_socket,address=*:8000,server=y,suspend=n"
       JAVA_TOOL_OPTIONS: "
+        -Dencryption.keystore.type=JCEKS
+        -Dencryption.cipherAlgorithm=DESede/CBC/PKCS5Padding
+        -Dencryption.keyAlgorithm=DESede
+        -Dencryption.keystore.location=/usr/local/tomcat/shared/classes/alfresco/extension/keystore/keystore
         -Dmetadata-keystore.password=mp6yc0UD9e
         -Dmetadata-keystore.aliases=metadata
-        -Dmetadata-keystore.metadata.password=mp6yc0UD9e
-        -Dmetadata-keystore.metadata.algorithm=AES
+        -Dmetadata-keystore.metadata.password=oKIWzVdEdA
+        -Dmetadata-keystore.metadata.algorithm=DESede
       "
       JAVA_OPTS :
         "

--- a/tests/environment/docker-compose-integration-tests.yml
+++ b/tests/environment/docker-compose-integration-tests.yml
@@ -14,10 +14,14 @@ services:
     environment:
       CATALINA_OPTS : "-agentlib:jdwp=transport=dt_socket,address=*:8000,server=y,suspend=n"
       JAVA_TOOL_OPTIONS: "
+        -Dencryption.keystore.type=JCEKS
+        -Dencryption.cipherAlgorithm=DESede/CBC/PKCS5Padding
+        -Dencryption.keyAlgorithm=DESede
+        -Dencryption.keystore.location=/usr/local/tomcat/shared/classes/alfresco/extension/keystore/keystore
         -Dmetadata-keystore.password=mp6yc0UD9e
         -Dmetadata-keystore.aliases=metadata
-        -Dmetadata-keystore.metadata.password=mp6yc0UD9e
-        -Dmetadata-keystore.metadata.algorithm=AES
+        -Dmetadata-keystore.metadata.password=oKIWzVdEdA
+        -Dmetadata-keystore.metadata.algorithm=DESede
       "
       JAVA_OPTS :
         "

--- a/tests/environment/docker-compose-minimal.yml
+++ b/tests/environment/docker-compose-minimal.yml
@@ -14,10 +14,14 @@ services:
     environment:
       CATALINA_OPTS : "-agentlib:jdwp=transport=dt_socket,address=*:8000,server=y,suspend=n"
       JAVA_TOOL_OPTIONS: "
+        -Dencryption.keystore.type=JCEKS
+        -Dencryption.cipherAlgorithm=DESede/CBC/PKCS5Padding
+        -Dencryption.keyAlgorithm=DESede
+        -Dencryption.keystore.location=/usr/local/tomcat/shared/classes/alfresco/extension/keystore/keystore
         -Dmetadata-keystore.password=mp6yc0UD9e
         -Dmetadata-keystore.aliases=metadata
-        -Dmetadata-keystore.metadata.password=mp6yc0UD9e
-        -Dmetadata-keystore.metadata.algorithm=AES
+        -Dmetadata-keystore.metadata.password=oKIWzVdEdA
+        -Dmetadata-keystore.metadata.algorithm=DESede
       "
       JAVA_OPTS :
         "

--- a/tests/environment/docker-compose-node-restart.yml
+++ b/tests/environment/docker-compose-node-restart.yml
@@ -14,10 +14,14 @@ services:
     environment:
       CATALINA_OPTS : "-agentlib:jdwp=transport=dt_socket,address=*:8000,server=y,suspend=n"
       JAVA_TOOL_OPTIONS: "
+        -Dencryption.keystore.type=JCEKS
+        -Dencryption.cipherAlgorithm=DESede/CBC/PKCS5Padding
+        -Dencryption.keyAlgorithm=DESede
+        -Dencryption.keystore.location=/usr/local/tomcat/shared/classes/alfresco/extension/keystore/keystore
         -Dmetadata-keystore.password=mp6yc0UD9e
         -Dmetadata-keystore.aliases=metadata
-        -Dmetadata-keystore.metadata.password=mp6yc0UD9e
-        -Dmetadata-keystore.metadata.algorithm=AES
+        -Dmetadata-keystore.metadata.password=oKIWzVdEdA
+        -Dmetadata-keystore.metadata.algorithm=DESede
       "
       JAVA_OPTS :
         "

--- a/tests/environment/docker-compose-pipeline-all-amps.yml
+++ b/tests/environment/docker-compose-pipeline-all-amps.yml
@@ -16,10 +16,14 @@ services:
         mem_limit: 1700m
         environment:
             JAVA_TOOL_OPTIONS: "
+                -Dencryption.keystore.type=JCEKS
+                -Dencryption.cipherAlgorithm=DESede/CBC/PKCS5Padding
+                -Dencryption.keyAlgorithm=DESede
+        -Dencryption.keystore.location=/usr/local/tomcat/shared/classes/alfresco/extension/keystore/keystore
                 -Dmetadata-keystore.password=mp6yc0UD9e
                 -Dmetadata-keystore.aliases=metadata
-                -Dmetadata-keystore.metadata.password=mp6yc0UD9e
-                -Dmetadata-keystore.metadata.algorithm=AES
+                -Dmetadata-keystore.metadata.password=oKIWzVdEdA
+                -Dmetadata-keystore.metadata.algorithm=DESede
             "
             JAVA_OPTS: "
                 -Ddb.driver=org.postgresql.Driver

--- a/tests/environment/docker-compose-pipeline-all-amps.yml
+++ b/tests/environment/docker-compose-pipeline-all-amps.yml
@@ -19,7 +19,7 @@ services:
                 -Dencryption.keystore.type=JCEKS
                 -Dencryption.cipherAlgorithm=DESede/CBC/PKCS5Padding
                 -Dencryption.keyAlgorithm=DESede
-        -Dencryption.keystore.location=/usr/local/tomcat/shared/classes/alfresco/extension/keystore/keystore
+                -Dencryption.keystore.location=/usr/local/tomcat/shared/classes/alfresco/extension/keystore/keystore
                 -Dmetadata-keystore.password=mp6yc0UD9e
                 -Dmetadata-keystore.aliases=metadata
                 -Dmetadata-keystore.metadata.password=oKIWzVdEdA

--- a/tests/environment/docker-compose-rest-api-tests.yml
+++ b/tests/environment/docker-compose-rest-api-tests.yml
@@ -16,10 +16,14 @@ services:
       CATALINA_OPTS : "-agentlib:jdwp=transport=dt_socket,address=*:8000,server=y,suspend=n"
       # Some properties are built in Dockerfile because of cron expressions
       JAVA_TOOL_OPTIONS: "
+        -Dencryption.keystore.type=JCEKS
+        -Dencryption.cipherAlgorithm=DESede/CBC/PKCS5Padding
+        -Dencryption.keyAlgorithm=DESede
+        -Dencryption.keystore.location=/usr/local/tomcat/shared/classes/alfresco/extension/keystore/keystore
         -Dmetadata-keystore.password=mp6yc0UD9e
         -Dmetadata-keystore.aliases=metadata
-        -Dmetadata-keystore.metadata.password=mp6yc0UD9e
-        -Dmetadata-keystore.metadata.algorithm=AES
+        -Dmetadata-keystore.metadata.password=oKIWzVdEdA
+        -Dmetadata-keystore.metadata.algorithm=DESede
       "
       JAVA_OPTS :
         "

--- a/tests/environment/docker-compose-sync-service.yml
+++ b/tests/environment/docker-compose-sync-service.yml
@@ -17,10 +17,14 @@ services:
     environment:
       CATALINA_OPTS : "-agentlib:jdwp=transport=dt_socket,address=*:8000,server=y,suspend=n"
       JAVA_TOOL_OPTIONS: "
+        -Dencryption.keystore.type=JCEKS
+        -Dencryption.cipherAlgorithm=DESede/CBC/PKCS5Padding
+        -Dencryption.keyAlgorithm=DESede
+        -Dencryption.keystore.location=/usr/local/tomcat/shared/classes/alfresco/extension/keystore/keystore
         -Dmetadata-keystore.password=mp6yc0UD9e
         -Dmetadata-keystore.aliases=metadata
-        -Dmetadata-keystore.metadata.password=mp6yc0UD9e
-        -Dmetadata-keystore.metadata.algorithm=AES
+        -Dmetadata-keystore.metadata.password=oKIWzVdEdA
+        -Dmetadata-keystore.metadata.algorithm=DESede
       "
       JAVA_OPTS :
         "

--- a/tests/environment/docker-compose-with-ldap.yml
+++ b/tests/environment/docker-compose-with-ldap.yml
@@ -16,10 +16,14 @@ services:
       CATALINA_OPTS : "-agentlib:jdwp=transport=dt_socket,address=*:8000,server=y,suspend=n"
       # Some properties are built in Dockerfile because of cron expressions
       JAVA_TOOL_OPTIONS: "
+        -Dencryption.keystore.type=JCEKS
+        -Dencryption.cipherAlgorithm=DESede/CBC/PKCS5Padding
+        -Dencryption.keyAlgorithm=DESede
+        -Dencryption.keystore.location=/usr/local/tomcat/shared/classes/alfresco/extension/keystore/keystore
         -Dmetadata-keystore.password=mp6yc0UD9e
         -Dmetadata-keystore.aliases=metadata
-        -Dmetadata-keystore.metadata.password=mp6yc0UD9e
-        -Dmetadata-keystore.metadata.algorithm=AES
+        -Dmetadata-keystore.metadata.password=oKIWzVdEdA
+        -Dmetadata-keystore.metadata.algorithm=DESede
       "
       JAVA_OPTS :
         "


### PR DESCRIPTION
Contents of the PR:
* Copy the old keystore into the docker image from distribution zip
* Configure docker environments to use old keystore's config as JAVA_OPTS
* Remove redundant enterpriseDocker maven profile as it is the same as fullBuild because of the dependency on the distribution zip.