### PR TITLE
ACS-525: org.alfresco.surf:spring-webscripts:8.8 & acs-packaging test failure

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
         <dependency.alfresco-enterprise-remote-api.version>8.227</dependency.alfresco-enterprise-remote-api.version>
         <dependency.alfresco-enterprise-repository.version>8.212</dependency.alfresco-enterprise-repository.version>
         <dependency.alfresco-remote-api.version>8.235</dependency.alfresco-remote-api.version>
-        <dependency.alfresco-repository.version>8.279</dependency.alfresco-repository.version>
+        <dependency.alfresco-repository.version>8.283</dependency.alfresco-repository.version>
         <dependency.alfresco-data-model.version>8.153</dependency.alfresco-data-model.version>
         <dependency.alfresco-core.version>8.49</dependency.alfresco-core.version>
 
@@ -46,7 +46,7 @@
 
         <dependency.alfresco-spring-encryptor.version>6.1</dependency.alfresco-spring-encryptor.version>
         <dependency.alfresco-enterprise-crypto.version>6.2</dependency.alfresco-enterprise-crypto.version>
-        <dependency.alfresco-spring-webscripts.version>8.8</dependency.alfresco-spring-webscripts.version>
+        <dependency.alfresco-spring-webscripts.version>8.10</dependency.alfresco-spring-webscripts.version>
         <dependency.alfresco-mmt.version>6.0</dependency.alfresco-mmt.version>
         <dependency.alfresco-pdf-renderer.version>1.1</dependency.alfresco-pdf-renderer.version>
         <dependency.alfresco-trashcan-cleaner.version>2.3</dependency.alfresco-trashcan-cleaner.version>

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
 
         <dependency.alfresco-spring-encryptor.version>6.1</dependency.alfresco-spring-encryptor.version>
         <dependency.alfresco-enterprise-crypto.version>6.2</dependency.alfresco-enterprise-crypto.version>
-        <dependency.alfresco-spring-webscripts.version>8.5</dependency.alfresco-spring-webscripts.version>
+        <dependency.alfresco-spring-webscripts.version>8.8</dependency.alfresco-spring-webscripts.version>
         <dependency.alfresco-mmt.version>6.0</dependency.alfresco-mmt.version>
         <dependency.alfresco-pdf-renderer.version>1.1</dependency.alfresco-pdf-renderer.version>
         <dependency.alfresco-trashcan-cleaner.version>2.3</dependency.alfresco-trashcan-cleaner.version>

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <dependency.alfresco-enterprise-repository.version>8.213</dependency.alfresco-enterprise-repository.version>
         <dependency.alfresco-remote-api.version>8.236</dependency.alfresco-remote-api.version>
         <dependency.alfresco-repository.version>8.283</dependency.alfresco-repository.version>
-        <dependency.alfresco-data-model.version>8.153</dependency.alfresco-data-model.version>
+        <dependency.alfresco-data-model.version>8.154</dependency.alfresco-data-model.version>
         <dependency.alfresco-core.version>8.49</dependency.alfresco-core.version>
 
         <dependency.alfresco-hb-data-sender.version>1.0.12</dependency.alfresco-hb-data-sender.version>

--- a/tests/tas-integration/src/test/java/org/alfresco/tas/integration/IntegrationWithWebScriptsTests.java
+++ b/tests/tas-integration/src/test/java/org/alfresco/tas/integration/IntegrationWithWebScriptsTests.java
@@ -5,6 +5,7 @@ import static org.alfresco.utility.report.log.Step.STEP;
 import io.restassured.RestAssured;
 import io.restassured.http.Cookie;
 import io.restassured.response.Response;
+
 import java.net.URLDecoder;
 import java.util.HashMap;
 
@@ -34,9 +35,9 @@ public class IntegrationWithWebScriptsTests extends IntegrationTest
         STEP("1.Upload the CSV File that contains the users.");
         restAPI.authenticateUser(dataUser.getAdminUser()).configureRequestSpec().addMultiPart("filedata",
                 Utility.getResourceTestDataFile("userCSV.csv"));
-        String fileCreationWebScript = "alfresco/s/api/people/upload";
-        RestAssured.basePath = "";
+        RestAssured.basePath = "alfresco";
         restAPI.configureRequestSpec().setBasePath(RestAssured.basePath);
+        String fileCreationWebScript = "s/api/people/upload";
         RestRequest request = RestRequest.simpleRequest(HttpMethod.POST, fileCreationWebScript);
         restAPI.authenticateUser(dataUser.getAdminUser()).process(request);
         restAPI.assertStatusCodeIs(HttpStatus.OK);
@@ -92,10 +93,10 @@ public class IntegrationWithWebScriptsTests extends IntegrationTest
         restAPI.assertStatusCodeIs(HttpStatus.OK);
 
         STEP("2.Deauthorize the user");
-        String deauthorizeUserWebScript = "alfresco/s/api/deauthorize";
-        String body = JsonBodyGenerator.defineJSON().add("username", user.getUsername()).build().toString();
-        RestAssured.basePath = "";
+        RestAssured.basePath = "alfresco";
         restAPI.configureRequestSpec().setBasePath(RestAssured.basePath);
+        String deauthorizeUserWebScript = "s/api/deauthorize";
+        String body = JsonBodyGenerator.defineJSON().add("username", user.getUsername()).build().toString();
         RestRequest request = RestRequest.requestWithBody(HttpMethod.POST, body, deauthorizeUserWebScript);
         restAPI.authenticateUser(dataUser.getAdminUser()).process(request);
         restAPI.assertStatusCodeIs(HttpStatus.OK);
@@ -115,12 +116,12 @@ public class IntegrationWithWebScriptsTests extends IntegrationTest
             TestGroup.REST_API }, executionType = ExecutionType.REGRESSION, description = "Verify cluster check not blocked by CSRF filter")
     public void verifyClusterCheck() throws Exception
     {
-        RestAssured.basePath = "";
+        RestAssured.basePath = "alfresco";
         restAPI.configureRequestSpec().setBasePath(RestAssured.basePath);
         String csrfCookieName = "alf-csrftoken";
         String jsessionidCookieName = "JSESSIONID";
         STEP("1. Get alf-csrftoken and JSESSIONID cookies");
-        String validateClusterPage = "alfresco/s/enterprise/admin/admin-clustering";
+        String validateClusterPage = "s/enterprise/admin/admin-clustering";
         RestRequest request = RestRequest.simpleRequest(HttpMethod.GET, validateClusterPage);
         Response resp = restAPI.authenticateUser(dataUser.getAdminUser()).process(request).getResponse();
         String jsessionidCookieValue = resp.getCookies().get(jsessionidCookieName);
@@ -129,7 +130,7 @@ public class IntegrationWithWebScriptsTests extends IntegrationTest
         Assert.assertNotNull(jsessionidCookieValue, "JSESSIONID cookie (" + jsessionidCookieName + ") should be present");
 
         STEP("2. Make a POST request to admin console cluster validation");
-        String validateClusterWebscript = "alfresco/s/enterprise/admin/admin-clustering-test";
+        String validateClusterWebscript = "s/enterprise/admin/admin-clustering-test";
         // Post with empty body
         String body = JsonBodyGenerator.defineJSON().build().toString();
         request = RestRequest.requestWithBody(HttpMethod.POST, body, validateClusterWebscript);
@@ -148,7 +149,7 @@ public class IntegrationWithWebScriptsTests extends IntegrationTest
             TestGroup.REST_API }, executionType = ExecutionType.REGRESSION, description = "Verify that JSESSIONID remains the same")
     public void verifySessionPersistence() throws Exception
     {
-        RestAssured.basePath = "";
+        RestAssured.basePath = "alfresco";
         restAPI.configureRequestSpec().setBasePath(RestAssured.basePath);
         String jsessionidCookieName = "JSESSIONID";
         String csrfCookieName = "alf-csrftoken";
@@ -160,7 +161,7 @@ public class IntegrationWithWebScriptsTests extends IntegrationTest
         restAPI.configureRequestSpec()
                 .addHeader("Authorization", String.format("Basic %s", authHeaderEncoded))
                 .build();
-        String clusteringPage = "alfresco/s/enterprise/admin/admin-clustering";
+        String clusteringPage = "s/enterprise/admin/admin-clustering";
         RestRequest request = RestRequest.simpleRequest(HttpMethod.GET, clusteringPage);
         Response resp = restAPI.process(request).getResponse();
         String jsessionidCookieValue = resp.getCookies().get(jsessionidCookieName);
@@ -175,7 +176,7 @@ public class IntegrationWithWebScriptsTests extends IntegrationTest
                 .addHeader(csrfCookieName, URLDecoder.decode(csrfCookieValue, "UTF-8"))
                 .addHeader("Authorization", String.format("Basic %s", authHeaderEncoded))
                 .build();
-        String systemSettingPage = "alfresco/s/enterprise/admin/admin-systemsettings";
+        String systemSettingPage = "s/enterprise/admin/admin-systemsettings";
         request = RestRequest.simpleRequest(HttpMethod.GET, systemSettingPage);
         resp = restAPI.process(request).getResponse();
         List<String> setCookieHeaderValues = resp.getHeaders().getValues("Set-Cookie");


### PR DESCRIPTION
- Bump `alfresco-sprint-webscripts` to `8.10` which contain CSRF filter fix
- `alfresco-repository` to `8.283` which also brings surf-webscripts (`8.10`)
- Remove extra `/` in alfresco URI when `RestAssured.basePath` is set empty
- Bump `alfresco-data-model` to `8.154` which contains the reversion of `opencmis:1.0.0` (to avoid clash/conflicts when `alfresco-repository` and `alfresco-data-model` brings different versions of `opencmis` in this project).