### PR TITLE
MNT-21871: Revert jackson-databind from 2.11.2 back to 2.10.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <dependency.spring.version>5.2.9.RELEASE</dependency.spring.version>
         <dependency.fabric8.version>4.4.0</dependency.fabric8.version>
         <dependency.jackson.version>2.11.2</dependency.jackson.version>
-        <dependency.jackson-databind.version>2.11.2</dependency.jackson-databind.version>
+        <dependency.jackson-databind.version>2.10.1</dependency.jackson-databind.version>
         <dependency.cxf.version>3.3.7</dependency.cxf.version>
         <dependency.axiom.version>1.2.22</dependency.axiom.version>
 


### PR DESCRIPTION
The version in remote-api is still 2.10.1 and the upgrade has failing tests (https://github.com/Alfresco/alfresco-remote-api/pull/776).

The update was originally done by dependabot #1598