### PR TITLE
ACS-857 : Azure Connector 1.2 Alpha Release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ branches:
   only:
     - master
     - /release\/.*/
+    - feature/ACS-986-62N
 
 env:
   global:

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <dependency.fabric8.version>4.4.0</dependency.fabric8.version>
         <alfresco.s3connector.version>3.1.0</alfresco.s3connector.version>
         <alfresco.glacier-connector.version>2.1.0</alfresco.glacier-connector.version>
-        <alfresco.azure-connector.version>1.2.0-A4-SNAPSHOT</alfresco.azure-connector.version>
+        <alfresco.azure-connector.version>1.2.0-A4</alfresco.azure-connector.version>
         <alfresco.centera-connector.version>2.2.1</alfresco.centera-connector.version>
         <alfresco.salesforce-connector.version>2.1.0.1</alfresco.salesforce-connector.version>
         <alfresco.saml.version>1.2.1</alfresco.saml.version>

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <dependency.fabric8.version>4.4.0</dependency.fabric8.version>
         <alfresco.s3connector.version>3.1.0</alfresco.s3connector.version>
         <alfresco.glacier-connector.version>2.1.0</alfresco.glacier-connector.version>
-        <alfresco.azure-connector.version>1.2.1-A1</alfresco.azure-connector.version>
+        <alfresco.azure-connector.version>1.2.0-A3</alfresco.azure-connector.version>
         <alfresco.centera-connector.version>2.2.1</alfresco.centera-connector.version>
         <alfresco.salesforce-connector.version>2.1.0.1</alfresco.salesforce-connector.version>
         <alfresco.saml.version>1.2.1</alfresco.saml.version>

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <dependency.fabric8.version>4.4.0</dependency.fabric8.version>
         <alfresco.s3connector.version>3.1.0</alfresco.s3connector.version>
         <alfresco.glacier-connector.version>2.1.0</alfresco.glacier-connector.version>
-        <alfresco.azure-connector.version>1.2.0-A3</alfresco.azure-connector.version>
+        <alfresco.azure-connector.version>1.2.0-A4-SNAPSHOT</alfresco.azure-connector.version>
         <alfresco.centera-connector.version>2.2.1</alfresco.centera-connector.version>
         <alfresco.salesforce-connector.version>2.1.0.1</alfresco.salesforce-connector.version>
         <alfresco.saml.version>1.2.1</alfresco.saml.version>


### PR DESCRIPTION
- updated `acs-packaging`, for `6.2.N` with `azure-1.2.0-A4` compatible with both ACS 6.2 and 7