### PR TITLE
ACS-857 : Azure Connector 1.2 Alpha Release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <alfresco.rm-enterprise-rest-api-explorer.version>3.0.2</alfresco.rm-enterprise-rest-api-explorer.version>
         <alfresco.s3connector.version>3.1.0</alfresco.s3connector.version>
         <alfresco.glacier-connector.version>2.1.0</alfresco.glacier-connector.version>
-        <alfresco.azure-connector.version>1.2.0-A3</alfresco.azure-connector.version>
+        <alfresco.azure-connector.version>1.2.0-A4-SNAPSHOT</alfresco.azure-connector.version>
         <alfresco.centera-connector.version>2.2.1</alfresco.centera-connector.version>
         <alfresco.salesforce-connector.version>2.2.1-M1</alfresco.salesforce-connector.version>
         <alfresco.saml.version>1.2.1</alfresco.saml.version>

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <alfresco.rm-enterprise-rest-api-explorer.version>3.0.2</alfresco.rm-enterprise-rest-api-explorer.version>
         <alfresco.s3connector.version>3.1.0</alfresco.s3connector.version>
         <alfresco.glacier-connector.version>2.1.0</alfresco.glacier-connector.version>
-        <alfresco.azure-connector.version>1.2.0-A4-SNAPSHOT</alfresco.azure-connector.version>
+        <alfresco.azure-connector.version>1.2.0-A4</alfresco.azure-connector.version>
         <alfresco.centera-connector.version>2.2.1</alfresco.centera-connector.version>
         <alfresco.salesforce-connector.version>2.2.1-M1</alfresco.salesforce-connector.version>
         <alfresco.saml.version>1.2.1</alfresco.saml.version>

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <alfresco.rm-enterprise-rest-api-explorer.version>3.0.2</alfresco.rm-enterprise-rest-api-explorer.version>
         <alfresco.s3connector.version>3.1.0</alfresco.s3connector.version>
         <alfresco.glacier-connector.version>2.1.0</alfresco.glacier-connector.version>
-        <alfresco.azure-connector.version>1.3.0-A2</alfresco.azure-connector.version>
+        <alfresco.azure-connector.version>1.2.0-A3</alfresco.azure-connector.version>
         <alfresco.centera-connector.version>2.2.1</alfresco.centera-connector.version>
         <alfresco.salesforce-connector.version>2.2.1-M1</alfresco.salesforce-connector.version>
         <alfresco.saml.version>1.2.1</alfresco.saml.version>


### PR DESCRIPTION
- updated `acs-packaging`, for `6.2.N` with `azure-1.2.0-A4` compatible with both ACS 6.2 and 7