### PR TITLE
fix share pipeline all amps image exception startup

### DIFF
--- a/tests/pipeline-all-amps/share/Dockerfile
+++ b/tests/pipeline-all-amps/share/Dockerfile
@@ -11,4 +11,4 @@ ENV ALFRESCO_AMPS_DIR=$TOMCAT_DIR/amps_share
 
 COPY docker-entrypoint.sh /
 ENTRYPOINT ["/docker-entrypoint.sh"]
-CMD ["catalina.sh", "run", "-security"]
+CMD ["/usr/local/tomcat/shared/classes/alfresco/substituter.sh", "catalina.sh run"]


### PR DESCRIPTION
Fixes java.security.AccessControlException on GraalDetector at startup of share pipeline all amps docker image