### PR TITLE
ACS-1077 push pipeline images in install phase

### DIFF
--- a/tests/pipeline-all-amps/pom.xml
+++ b/tests/pipeline-all-amps/pom.xml
@@ -37,7 +37,7 @@
                         </execution>
                         <execution>
                             <id>push-image</id>
-                            <phase>deploy</phase>
+                            <phase>install</phase>
                             <goals>
                                 <goal>push</goal>
                             </goals>


### PR DESCRIPTION
As publishing images happens on the maven install phase for all the images but the pipeline ones, moving push from deploy to install would fix ACS-1077