### PR TITLE
ACS-1110 replace fabric8 with docker-maven-plugin

### DIFF
--- a/dev/dev-acs-amps-overlay/pom.xml
+++ b/dev/dev-acs-amps-overlay/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>

--- a/dev/dev-tomcat/pom.xml
+++ b/dev/dev-tomcat/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 

--- a/dev/pom.xml
+++ b/dev/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <artifactId>alfresco-content-services-distribution</artifactId>

--- a/docker-alfresco/aws/pom.xml
+++ b/docker-alfresco/aws/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <artifactId>content-services-docker-aws</artifactId>

--- a/docker-alfresco/pom.xml
+++ b/docker-alfresco/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <artifactId>content-services-docker</artifactId>
@@ -78,17 +79,11 @@
                 <plugins>
                     <plugin>
                         <groupId>io.fabric8</groupId>
-                        <artifactId>fabric8-maven-plugin</artifactId>
+                        <artifactId>docker-maven-plugin</artifactId>
                         <configuration>
                             <images>
                                 <image>
                                     <name>${image.name}:${image.tag}</name>
-                                    <build>
-                                        <dockerFileDir>${project.basedir}/</dockerFileDir>
-                                        <buildOptions>
-                                            <squash>true</squash>
-                                        </buildOptions>
-                                    </build>
                                 </image>
                             </images>
                         </configuration>
@@ -113,29 +108,17 @@
                 <plugins>
                     <plugin>
                         <groupId>io.fabric8</groupId>
-                        <artifactId>fabric8-maven-plugin</artifactId>
+                        <artifactId>docker-maven-plugin</artifactId>
                         <configuration>
                             <images>
                                 <!-- Quay image -->
                                 <image>
                                     <name>${image.name}:${image.tag}</name>
                                     <registry>${image.registry}</registry>
-                                    <build>
-                                        <dockerFileDir>${project.basedir}/</dockerFileDir>
-                                        <buildOptions>
-                                            <squash>true</squash>
-                                        </buildOptions>
-                                    </build>
                                 </image>
                                 <!-- DockerHub image -->
                                 <!--<image>
                                     <name>${image.name}:${image.tag}</name>
-                                    <build>
-                                        <dockerFileDir>${project.basedir}/</dockerFileDir>
-                                        <buildOptions>
-                                            <squash>true</squash>
-                                        </buildOptions>
-                                    </build>
                                 </image>-->
                             </images>
                         </configuration>
@@ -161,29 +144,17 @@
                 <plugins>
                     <plugin>
                         <groupId>io.fabric8</groupId>
-                        <artifactId>fabric8-maven-plugin</artifactId>
+                        <artifactId>docker-maven-plugin</artifactId>
                         <configuration combine.self="override">
                             <images>
                                 <!-- Quay image -->
                                 <image>
                                     <name>${image.name}:${project.version}</name>
                                     <registry>${image.registry}</registry>
-                                    <build>
-                                        <dockerFileDir>${project.basedir}/</dockerFileDir>
-                                        <buildOptions>
-                                            <squash>true</squash>
-                                        </buildOptions>
-                                    </build>
                                 </image>
                                 <!-- DockerHub image -->
                                 <!--<image>
                                     <name>${image.name}:${project.version}</name>
-                                    <build>
-                                        <dockerFileDir>${project.basedir}/</dockerFileDir>
-                                        <buildOptions>
-                                            <squash>true</squash>
-                                        </buildOptions>
-                                    </build>
                                 </image>-->
                             </images>
                         </configuration>

--- a/docs/create-custom-image.md
+++ b/docs/create-custom-image.md
@@ -6,7 +6,7 @@ The recommended way of building extensions is to use [Rest APIs](https://api-exp
 
 ### Applying a custom AMP
 
-This project uses [fabric8](https://github.com/fabric8io/fabric8-maven-plugin) maven plugin to build and push the Alfresco Docker image. The plugin's configuration is stored in this [pom.xml](../docker-alfresco/pom.xml). The following example will illustrate how an additional AMP can be added in the configuration.
+This project uses [fabric8](https://github.com/fabric8io/docker-maven-plugin) maven plugin to build and push the Alfresco Docker image. The plugin's configuration is stored in this [pom.xml](../docker-alfresco/pom.xml). The following example will illustrate how an additional AMP can be added in the configuration.
 
 #### Prerequisites
 
@@ -44,4 +44,4 @@ Maven will use _maven-dependency-plugin_ to download the AMP from Maven reposito
 ```bash
 mvn clean install -Pinternal -Dimage.name=mycompany/alfresco-with-s3 -Dimage.tag=latest -Dimage.registry=quay.io
 ```
-The `internal` profile configures _fabric8-maven-plugin_ to build and push an image. It will use this [Dockerfile](../docker-alfresco/Dockerfile). All the AMPs from the _target/amps_ folder are copied inside the image and then the amps are applied to the standard _alfresco.war_ using [MMT tool](https://github.com/Alfresco/alfresco-mmt). After that the image is pushed to the specified Docker registry.  
+The `internal` profile configures _docker-maven-plugin_ to build and push an image. It will use this [Dockerfile](../docker-alfresco/Dockerfile). All the AMPs from the _target/amps_ folder are copied inside the image and then the amps are applied to the standard _alfresco.war_ using [MMT tool](https://github.com/Alfresco/alfresco-mmt). After that the image is pushed to the specified Docker registry.

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <artifactId>acs-packaging</artifactId>
     <packaging>pom</packaging>
@@ -278,4 +279,5 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
+
 </project>

--- a/scripts/travis/init.sh
+++ b/scripts/travis/init.sh
@@ -12,10 +12,6 @@ find "${HOME}/.m2/repository/" -type d -name "*-SNAPSHOT*" | xargs -r -l rm -rf
 echo "${DOCKERHUB_PASSWORD}" | docker login -u="${DOCKERHUB_USERNAME}" --password-stdin
 echo "${QUAY_PASSWORD}" | docker login -u="${QUAY_USERNAME}" --password-stdin quay.io
 
-# Enable experimental docker features (for the image squash option)
-echo '{"experimental":true}' | sudo tee /etc/docker/daemon.json
-sudo service docker restart
-
 # not helpful in this script
 # export HOST_IP=$(hostname  -I | cut -f1 -d' ')
 

--- a/tests/pipeline-all-amps/pom.xml
+++ b/tests/pipeline-all-amps/pom.xml
@@ -21,7 +21,7 @@
             <plugins>
                 <plugin>
                     <groupId>io.fabric8</groupId>
-                    <artifactId>fabric8-maven-plugin</artifactId>
+                    <artifactId>docker-maven-plugin</artifactId>
                     <configuration combine.self="override">
                         <images>
                             <image>
@@ -52,7 +52,7 @@
                 <plugins>
                     <plugin>
                         <groupId>io.fabric8</groupId>
-                        <artifactId>fabric8-maven-plugin</artifactId>
+                        <artifactId>docker-maven-plugin</artifactId>
                     </plugin>
                 </plugins>
             </build>
@@ -67,7 +67,7 @@
                 <plugins>
                     <plugin>
                         <groupId>io.fabric8</groupId>
-                        <artifactId>fabric8-maven-plugin</artifactId>
+                        <artifactId>docker-maven-plugin</artifactId>
                         <executions>
                             <execution>
                                 <id>push-image</id>
@@ -91,7 +91,7 @@
                 <plugins>
                     <plugin>
                         <groupId>io.fabric8</groupId>
-                        <artifactId>fabric8-maven-plugin</artifactId>
+                        <artifactId>docker-maven-plugin</artifactId>
                         <executions>
                             <execution>
                                 <id>push-image</id>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <artifactId>content-repository-tests</artifactId>

--- a/tests/tas-all-amps/pom.xml
+++ b/tests/tas-all-amps/pom.xml
@@ -364,17 +364,11 @@
                     </plugin>
                     <plugin>
                         <groupId>io.fabric8</groupId>
-                        <artifactId>fabric8-maven-plugin</artifactId>
+                        <artifactId>docker-maven-plugin</artifactId>
                         <configuration>
                             <images>
                                 <image>
                                     <name>alfresco/alfresco-content-repository-all-amps-test:latest</name>
-                                    <build>
-                                        <dockerFileDir>${project.basedir}/</dockerFileDir>
-                                        <buildOptions>
-                                            <squash>true</squash>
-                                        </buildOptions>
-                                    </build>
                                 </image>
                             </images>
                         </configuration>


### PR DESCRIPTION
See ACS-1110, build docker images with docker-maven-plugin so that there are no warnings for rogue connections to a not existing kubernetes cluster

```log
[INFO] --- fabric8-maven-plugin:4.4.0:build (build-image) @ alfresco-pipeline-all-amps-repo ---
[WARNING] Error reading service account token from: [/var/run/secrets/kubernetes.io/serviceaccount/token]. Ignoring.
[WARNING] Error reading service account token from: [/var/run/secrets/kubernetes.io/serviceaccount/token]. Ignoring.
[WARNING] F8: Cannot access cluster for detecting mode: Unknown host kubernetes.default.svc
[INFO] F8: Running in Kubernetes mode
[INFO] F8: Building Container image with Docker in Kubernetes mode
[WARNING] Error reading service account token from: [/var/run/secrets/kubernetes.io/serviceaccount/token]. Ignoring.
[WARNING] F8: Cannot access cluster for detecting mode: Unknown host kubernetes.default.svc
[WARNING] Error reading service account token from: [/var/run/secrets/kubernetes.io/serviceaccount/token]. Ignoring.
[WARNING] F8: Cannot access cluster for detecting mode: Unknown host kubernetes.default.svc
[WARNING] Error reading service account token from: [/var/run/secrets/kubernetes.io/serviceaccount/token]. Ignoring.
[WARNING] Error reading service account token from: [/var/run/secrets/kubernetes.io/serviceaccount/token]. Ignoring.
[WARNING] F8: Cannot access cluster for detecting mode: Unknown host kubernetes.default.svc
[WARNING] Error reading service account token from: [/var/run/secrets/kubernetes.io/serviceaccount/token]. Ignoring.
[WARNING] F8: Cannot access cluster for detecting mode: Unknown host kubernetes.default.svc
[WARNING] Error reading service account token from: [/var/run/secrets/kubernetes.io/serviceaccount/token]. Ignoring.
[INFO] Building tar: /home/travis/build/Alfresco/acs-packaging/tests/pipeline-all-amps/repo/target/docker/alfresco/alfresco-pipeline-all-amps-repo/latest/tmp/docker-build.tar
[INFO] F8: [alfresco/alfresco-pipeline-all-amps-repo:latest]: Created docker-build.tar in 301 milliseconds
[INFO] F8: [alfresco/alfresco-pipeline-all-amps-repo:latest]: Built image sha256:b2eae
```