### PR TITLE
Fix TravisCI deploy options for the S3 Staging bucket upload [skip ci]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -212,7 +212,9 @@ jobs:
           secret_access_key: "${AWS_STAGING_SECRET_KEY}"
           bucket: "alfresco-artefacts-staging"
           region: "eu-west-1"
-          cleanup: false
+          # Once Travis releases their *dpl v2* api (currently in beta, check https://docs.travis-ci.com/user/deployment-v2#how-to-opt-in-to-v2)
+          # the skip_cleanup option will no longer be needed (or valid) and should be removed.
+          skip_cleanup: true
           acl: private
           local_dir: "deploy_dir"
           upload_dir: "alfresco-content-services/release/${TRAVIS_BRANCH}/${TRAVIS_BUILD_NUMBER}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -213,7 +213,7 @@ jobs:
           bucket: "alfresco-artefacts-staging"
           region: "eu-west-1"
           # Once Travis releases their *dpl v2* api (currently in beta, check https://docs.travis-ci.com/user/deployment-v2#how-to-opt-in-to-v2)
-          # the skip_cleanup option will no longer be needed (or valid) and should be removed.
+          # the skip_cleanup option will no longer be needed (or valid) and should be removed (ACS-1155).
           skip_cleanup: true
           acl: private
           local_dir: "deploy_dir"


### PR DESCRIPTION
- add the `skip_cleanup: true` option so that Travis doesn't execute `git stash --all` before the S3 upload