### PR TITLE
The Single pipeline jobs should not have any commented out AMPs.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -265,18 +265,6 @@
                 <type>amp</type>
             </dependency>
             -->
-            <dependency>
-                <groupId>org.alfresco</groupId>
-                <artifactId>alfresco-document-transformation-engine-repo</artifactId>
-                <version>${alfresco.transformation-engine.version}</version>
-                <type>amp</type>
-            </dependency>
-            <dependency>
-                <groupId>org.alfresco</groupId>
-                <artifactId>alfresco-document-transformation-engine-share</artifactId>
-                <version>${alfresco.transformation-engine.version}</version>
-                <type>amp</type>
-            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/tests/pipeline-all-amps/repo/pom.xml
+++ b/tests/pipeline-all-amps/repo/pom.xml
@@ -25,6 +25,7 @@
                         </goals>
                         <configuration>
                             <artifactItems>
+                                <!-- Do not comment out, as this will cause problems in the Single Pipeline. -->
                                 <artifactItem>
                                     <groupId>org.alfresco.saml</groupId>
                                     <artifactId>alfresco-saml-repo</artifactId>
@@ -33,15 +34,17 @@
                                     <overWrite>false</overWrite>
                                     <outputDirectory>${project.build.directory}/amps</outputDirectory>
                                 </artifactItem>
-                                <!-- TODO uncomment this amp once https://alfresco.atlassian.net/browse/APPS-702 is solved -->
-<!--                                <artifactItem>-->
-<!--                                    <groupId>org.alfresco</groupId>-->
-<!--                                    <artifactId>alfresco-governance-services-enterprise-repo</artifactId>-->
-<!--                                    <version>${alfresco.ags.version}</version>-->
-<!--                                    <type>amp</type>-->
-<!--                                    <overWrite>false</overWrite>-->
-<!--                                    <outputDirectory>${project.build.directory}/amps</outputDirectory>-->
-<!--                                </artifactItem>-->
+                                <!-- Do not comment out, as this will cause problems in the Single Pipeline. -->
+                                <!-- TODO fix test failure APPS-702 -->
+                                <artifactItem>
+                                    <groupId>org.alfresco</groupId>
+                                    <artifactId>alfresco-governance-services-enterprise-repo</artifactId>
+                                    <version>${alfresco.ags.version}</version>
+                                    <type>amp</type>
+                                    <overWrite>false</overWrite>
+                                    <outputDirectory>${project.build.directory}/amps</outputDirectory>
+                                </artifactItem>
+                                <!-- Do not comment out, as this will cause problems in the Single Pipeline. -->
                                 <artifactItem>
                                     <groupId>org.alfresco.integrations</groupId>
                                     <artifactId>alfresco-s3-connector</artifactId>
@@ -50,6 +53,7 @@
                                     <overWrite>false</overWrite>
                                     <outputDirectory>${project.build.directory}/amps</outputDirectory>
                                 </artifactItem>
+                                <!-- Do not comment out, as this will cause problems in the Single Pipeline. -->
                                 <artifactItem>
                                     <groupId>org.alfresco</groupId>
                                     <artifactId>alfresco-glacier-connector-repo</artifactId>
@@ -58,6 +62,7 @@
                                     <overWrite>false</overWrite>
                                     <outputDirectory>${project.build.directory}/amps</outputDirectory>
                                 </artifactItem>
+                                <!-- Do not comment out, as this will cause problems in the Single Pipeline. -->
                                 <artifactItem>
                                     <groupId>org.alfresco</groupId>
                                     <artifactId>alfresco-share-services</artifactId>
@@ -66,6 +71,7 @@
                                     <overWrite>false</overWrite>
                                     <outputDirectory>${project.build.directory}/amps</outputDirectory>
                                 </artifactItem>
+                                <!-- Do not comment out, as this will cause problems in the Single Pipeline. -->
                                 <artifactItem>
                                     <groupId>org.alfresco.aos-module</groupId>
                                     <artifactId>alfresco-aos-module</artifactId>
@@ -73,6 +79,7 @@
                                     <overWrite>false</overWrite>
                                     <outputDirectory>${project.build.directory}/amps</outputDirectory>
                                 </artifactItem>
+                                <!-- Do not comment out, as this will cause problems in the Single Pipeline. -->
                                 <artifactItem>
                                     <groupId>org.alfresco.integrations</groupId>
                                     <artifactId>alfresco-googledrive-repo-enterprise</artifactId>
@@ -80,6 +87,7 @@
                                     <overWrite>false</overWrite>
                                     <outputDirectory>${project.build.directory}/amps</outputDirectory>
                                 </artifactItem>
+                                <!-- Do not comment out, as this will cause problems in the Single Pipeline. -->
                                 <artifactItem>
                                     <groupId>org.alfresco</groupId>
                                     <artifactId>alfresco-ai-repo</artifactId>
@@ -88,6 +96,7 @@
                                     <overWrite>false</overWrite>
                                     <outputDirectory>${project.build.directory}/amps</outputDirectory>
                                 </artifactItem>
+                                <!-- Do not comment out, as this will cause problems in the Single Pipeline. -->
                                 <artifactItem>
                                     <groupId>org.alfresco.integrations</groupId>
                                     <artifactId>alfresco-azure-connector</artifactId>
@@ -96,6 +105,7 @@
                                     <overWrite>false</overWrite>
                                     <outputDirectory>${project.build.directory}/amps</outputDirectory>
                                 </artifactItem>
+                                <!-- Do not comment out, as this will cause problems in the Single Pipeline. -->
                                 <artifactItem>
                                     <groupId>org.alfresco</groupId>
                                     <artifactId>alfresco-centera-connector</artifactId>
@@ -104,6 +114,7 @@
                                     <overWrite>false</overWrite>
                                     <outputDirectory>${project.build.directory}/amps</outputDirectory>
                                 </artifactItem>
+                                <!-- Do not comment out, as this will cause problems in the Single Pipeline. -->
                                 <artifactItem>
                                     <groupId>org.alfresco.integrations</groupId>
                                     <artifactId>alfresco-content-connector-for-salesforce-repo</artifactId>
@@ -112,32 +123,25 @@
                                     <overWrite>false</overWrite>
                                     <outputDirectory>${project.build.directory}/amps</outputDirectory>
                                 </artifactItem>
-                                <!--<artifactItem>
+                                <!-- Do not comment out, as this will cause problems in the Single Pipeline. -->
+                                <artifactItem>
                                     <groupId>org.alfresco.services.sync</groupId>
                                     <artifactId>alfresco-device-sync-repo</artifactId>
                                     <version>${alfresco.desktop-sync.version}</version>
                                     <type>amp</type>
                                     <overWrite>false</overWrite>
                                     <outputDirectory>${project.build.directory}/amps</outputDirectory>
-                                </artifactItem>-->
-                                <!-- TODO uncomment this amp once https://issues.alfresco.com/jira/browse/MNT-21648 is solved -->
-<!--                                <artifactItem>-->
-<!--                                    <groupId>org.alfresco</groupId>-->
-<!--                                    <artifactId>alfresco-document-transformation-engine-repo</artifactId>-->
-<!--                                    <version>${alfresco.transformation-engine.version}</version>-->
-<!--                                    <type>amp</type>-->
-<!--                                    <overWrite>false</overWrite>-->
-<!--                                    <outputDirectory>${project.build.directory}/amps</outputDirectory>-->
-<!--                                </artifactItem>-->
-                                <!-- TODO uncomment this amp once https://alfresco.atlassian.net/browse/APPS-702 is solved -->
-<!--                                <artifactItem>-->
-<!--                                    <groupId>org.alfresco</groupId>-->
-<!--                                    <artifactId>alfresco-governance-services-enterprise-repo</artifactId>-->
-<!--                                    <version>${alfresco.ags.version}</version>-->
-<!--                                    <type>amp</type>-->
-<!--                                    <overWrite>false</overWrite>-->
-<!--                                    <outputDirectory>${project.build.directory}/amps</outputDirectory>-->
-<!--                                </artifactItem>-->
+                                </artifactItem>
+                                <!-- Do not comment out, as this will cause problems in the Single Pipeline. -->
+                                <!-- TODO fix test failure APPS-702 -->
+                                <artifactItem>
+                                    <groupId>org.alfresco</groupId>
+                                    <artifactId>alfresco-governance-services-enterprise-repo</artifactId>
+                                    <version>${alfresco.ags.version}</version>
+                                    <type>amp</type>
+                                    <overWrite>false</overWrite>
+                                    <outputDirectory>${project.build.directory}/amps</outputDirectory>
+                                </artifactItem>
                             </artifactItems>
                         </configuration>
                     </execution>
@@ -149,6 +153,7 @@
                         </goals>
                         <configuration>
                             <artifactItems>
+                                <!-- Do not comment out, as this will cause problems in the Single Pipeline. -->
                                 <artifactItem>
                                     <groupId>org.alfresco</groupId>
                                     <artifactId>alfresco-rm-enterprise-rest-api-explorer</artifactId>
@@ -158,6 +163,7 @@
                                     <destFileName>rm-api-explorer.war</destFileName>
                                     <outputDirectory>${project.build.directory}/wars</outputDirectory>
                                 </artifactItem>
+                                <!-- Do not comment out, as this will cause problems in the Single Pipeline. -->
                                 <artifactItem>
                                     <groupId>org.alfresco</groupId>
                                     <artifactId>api-explorer</artifactId>
@@ -174,5 +180,4 @@
             </plugin>
         </plugins>
     </build>
-
 </project>

--- a/tests/pipeline-all-amps/share/pom.xml
+++ b/tests/pipeline-all-amps/share/pom.xml
@@ -25,6 +25,7 @@
                         </goals>
                         <configuration>
                             <artifactItems>
+                                <!-- Do not comment out, as this will cause problems in the Single Pipeline. -->
                                 <artifactItem>
                                     <groupId>org.alfresco.integrations</groupId>
                                     <artifactId>alfresco-googledrive-share</artifactId>
@@ -33,6 +34,7 @@
                                     <overWrite>false</overWrite>
                                     <outputDirectory>${project.build.directory}/amps_share</outputDirectory>
                                 </artifactItem>
+                                <!-- Do not comment out, as this will cause problems in the Single Pipeline. -->
                                 <artifactItem>
                                     <groupId>org.alfresco</groupId>
                                     <artifactId>alfresco-ai-share</artifactId>
@@ -41,6 +43,7 @@
                                     <overWrite>false</overWrite>
                                     <outputDirectory>${project.build.directory}/amps_share</outputDirectory>
                                 </artifactItem>
+                                <!-- Do not comment out, as this will cause problems in the Single Pipeline. -->
                                 <artifactItem>
                                     <groupId>org.alfresco.integrations</groupId>
                                     <artifactId>alfresco-content-connector-for-salesforce-share</artifactId>
@@ -49,6 +52,7 @@
                                     <overWrite>false</overWrite>
                                     <outputDirectory>${project.build.directory}/amps_share</outputDirectory>
                                 </artifactItem>
+                                <!-- Do not comment out, as this will cause problems in the Single Pipeline. -->
                                 <artifactItem>
                                     <groupId>org.alfresco.saml</groupId>
                                     <artifactId>alfresco-saml-share</artifactId>
@@ -57,24 +61,16 @@
                                     <overWrite>false</overWrite>
                                     <outputDirectory>${project.build.directory}/amps_share</outputDirectory>
                                 </artifactItem>
-                                <!-- TODO uncomment this amp once https://issues.alfresco.com/jira/browse/MNT-21648 is solved -->
-<!--                                <artifactItem>-->
-<!--                                    <groupId>org.alfresco</groupId>-->
-<!--                                    <artifactId>alfresco-document-transformation-engine-share</artifactId>-->
-<!--                                    <version>${alfresco.transformation-engine.version}</version>-->
-<!--                                    <type>amp</type>-->
-<!--                                    <overWrite>false</overWrite>-->
-<!--                                    <outputDirectory>${project.build.directory}/amps_share</outputDirectory>-->
-<!--                                </artifactItem>-->
-                                <!-- TODO uncomment this amp once https://alfresco.atlassian.net/browse/APPS-702 is solved -->
-<!--                                <artifactItem>-->
-<!--                                    <groupId>org.alfresco</groupId>-->
-<!--                                    <artifactId>alfresco-governance-services-enterprise-share</artifactId>-->
-<!--                                    <version>${alfresco.ags.version}</version>-->
-<!--                                    <type>amp</type>-->
-<!--                                    <overWrite>false</overWrite>-->
-<!--                                    <outputDirectory>${project.build.directory}/amps_share</outputDirectory>-->
-<!--                                </artifactItem>-->
+                                <!-- Do not comment out, as this will cause problems in the Single Pipeline. -->
+                                <!-- TODO fix test failure APPS-702 -->
+                                <artifactItem>
+                                    <groupId>org.alfresco</groupId>
+                                    <artifactId>alfresco-governance-services-enterprise-share</artifactId>
+                                    <version>${alfresco.ags.version}</version>
+                                    <type>amp</type>
+                                    <overWrite>false</overWrite>
+                                    <outputDirectory>${project.build.directory}/amps_share</outputDirectory>
+                                </artifactItem>
                             </artifactItems>
                         </configuration>
                     </execution>
@@ -82,5 +78,4 @@
             </plugin>
         </plugins>
     </build>
-
 </project>

--- a/tests/tas-all-amps/pom.xml
+++ b/tests/tas-all-amps/pom.xml
@@ -253,14 +253,14 @@
                                             <overWrite>false</overWrite>
                                             <outputDirectory>${project.build.directory}/amps_share</outputDirectory>
                                         </artifactItem>
-                                        <!--<artifactItem>
+                                        <artifactItem>
                                             <groupId>org.alfresco.services.sync</groupId>
                                             <artifactId>alfresco-device-sync-repo</artifactId>
                                             <version>${alfresco.desktop-sync.version}</version>
                                             <type>amp</type>
                                             <overWrite>false</overWrite>
                                             <outputDirectory>${project.build.directory}/amps</outputDirectory>
-                                        </artifactItem>-->
+                                        </artifactItem>
                                         <artifactItem>
                                             <groupId>org.alfresco.saml</groupId>
                                             <artifactId>alfresco-saml-repo</artifactId>
@@ -277,23 +277,22 @@
                                             <overWrite>false</overWrite>
                                             <outputDirectory>${project.build.directory}/amps_share</outputDirectory>
                                         </artifactItem>
-                                        <!-- TODO uncomment this amp once https://alfresco.atlassian.net/browse/APPS-702 is solved -->
-<!--                                        <artifactItem>-->
-<!--                                            <groupId>org.alfresco</groupId>-->
-<!--                                            <artifactId>alfresco-governance-services-enterprise-repo</artifactId>-->
-<!--                                            <version>${alfresco.ags.version}</version>-->
-<!--                                            <type>amp</type>-->
-<!--                                            <overWrite>false</overWrite>-->
-<!--                                            <outputDirectory>${project.build.directory}/amps</outputDirectory>-->
-<!--                                        </artifactItem>-->
-<!--                                        <artifactItem>-->
-<!--                                            <groupId>org.alfresco</groupId>-->
-<!--                                            <artifactId>alfresco-governance-services-enterprise-share</artifactId>-->
-<!--                                            <version>${alfresco.ags.version}</version>-->
-<!--                                            <type>amp</type>-->
-<!--                                            <overWrite>false</overWrite>-->
-<!--                                            <outputDirectory>${project.build.directory}/amps_share</outputDirectory>-->
-<!--                                        </artifactItem>-->
+                                        <artifactItem>
+                                            <groupId>org.alfresco</groupId>
+                                            <artifactId>alfresco-governance-services-enterprise-repo</artifactId>
+                                            <version>${alfresco.ags.version}</version>
+                                            <type>amp</type>
+                                            <overWrite>false</overWrite>
+                                            <outputDirectory>${project.build.directory}/amps</outputDirectory>
+                                        </artifactItem>
+                                        <artifactItem>
+                                            <groupId>org.alfresco</groupId>
+                                            <artifactId>alfresco-governance-services-enterprise-share</artifactId>
+                                            <version>${alfresco.ags.version}</version>
+                                            <type>amp</type>
+                                            <overWrite>false</overWrite>
+                                            <outputDirectory>${project.build.directory}/amps_share</outputDirectory>
+                                        </artifactItem>
                                     </artifactItems>
                                 </configuration>
                             </execution>

--- a/tests/tas-all-amps/pom.xml
+++ b/tests/tas-all-amps/pom.xml
@@ -277,23 +277,6 @@
                                             <overWrite>false</overWrite>
                                             <outputDirectory>${project.build.directory}/amps_share</outputDirectory>
                                         </artifactItem>
-                                        <!-- TODO uncomment this amp once https://issues.alfresco.com/jira/browse/MNT-21648 is solved -->
-<!--                                        <artifactItem>
-                                            <groupId>org.alfresco</groupId>
-                                            <artifactId>alfresco-document-transformation-engine-repo</artifactId>
-                                            <version>${alfresco.transformation-engine.version}</version>
-                                            <type>amp</type>
-                                            <overWrite>false</overWrite>
-                                            <outputDirectory>${project.build.directory}/amps</outputDirectory>
-                                        </artifactItem>
-                                        <artifactItem>
-                                            <groupId>org.alfresco</groupId>
-                                            <artifactId>alfresco-document-transformation-engine-share</artifactId>
-                                            <version>${alfresco.transformation-engine.version}</version>
-                                            <type>amp</type>
-                                            <overWrite>false</overWrite>
-                                            <outputDirectory>${project.build.directory}/amps_share</outputDirectory>
-                                        </artifactItem>-->
                                         <!-- TODO uncomment this amp once https://alfresco.atlassian.net/browse/APPS-702 is solved -->
 <!--                                        <artifactItem>-->
 <!--                                            <groupId>org.alfresco</groupId>-->

--- a/tests/tas-all-amps/src/test/java/org/alfresco/rest/discovery/DiscoveryTests.java
+++ b/tests/tas-all-amps/src/test/java/org/alfresco/rest/discovery/DiscoveryTests.java
@@ -76,13 +76,10 @@ public class DiscoveryTests extends RestTest
                 "alfresco-content-connector-for-salesforce-repo",
                 "alfresco-share-services",
                 "alfresco-saml-repo",
-                // Uncomment after Camel upgrade -> https://alfresco.atlassian.net/browse/DESKTOPAPP-539
-                //"org_alfresco_device_sync_repo",
+                "org_alfresco_device_sync_repo",
                 "alfresco-ai-repo",
-                //"org_alfresco_module_rm", "alfresco-rm-enterprise-repo",
+                "org_alfresco_module_rm", "alfresco-rm-enterprise-repo",
                 "alfresco-glacier-connector-repo"
-                // TODO uncomment this amp once https://issues.alfresco.com/jira/browse/MNT-21648 is done
-                //"org.alfresco.module.TransformationServer" // this is the DTE not ATS
         );
 
         expectedModules.forEach(module ->


### PR DESCRIPTION
Also removed the DTE AMPs as there should not be a Repo on in 7.0.0 and we don't know about Share.

As a result of comments of this PR, desktop sync and AGS (rm) have been reintroduced to the DiscoveryTests and removed the commented out DTE. More tests will fail, but the code is more complete once these AMPs are fixed.