### PR TITLE
OPSEXP-718: Use DTAS for smoke testing the pipeline-all-amps-repo image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -193,7 +193,7 @@ jobs:
         - git clone --depth 1 --branch v1.0-M1 https://${GIT_USERNAME}:${GIT_PASSWORD}@github.com/Alfresco/alfresco-deployment-test-automation-scripts.git dtas
       script:
         - ${TAS_SCRIPTS}/start-compose.sh ${TAS_ENVIRONMENT}/docker-compose-pipeline-all-amps.yml
-        - ${TAS_SCRIPTS}/wait-for-alfresco-start.sh "http://localhost:8080/alfresco"
+        - ${TAS_SCRIPTS}/wait-for-alfresco-start.sh "http://localhost:8080/alfresco" 180
         - docker ps
         # Run smoke tests against the system using DTAS
         - cd dtas

--- a/.travis.yml
+++ b/.travis.yml
@@ -189,10 +189,9 @@ jobs:
         - travis_retry travis_wait 20 mvn -B clean install -Ppipeline,local $(mvn -B -q help:evaluate "-Dexpression=dependency.alfresco-enterprise-repo.version" -DforceStdout | grep -q '\-SNAPSHOT$' && echo '-Drepo.image.tag=latest')
         - pyenv versions
         - pyenv global 3.7.1
-        - pip install pytest
+        - pip install requests pytest
         - git clone --depth 1 --branch v1.0-M1 https://${GIT_USERNAME}:${GIT_PASSWORD}@github.com/Alfresco/alfresco-deployment-test-automation-scripts.git dtas
       script:
-        - ls -hal
         - ${TAS_SCRIPTS}/start-compose.sh ${TAS_ENVIRONMENT}/docker-compose-pipeline-all-amps.yml
         - ${TAS_SCRIPTS}/wait-for-alfresco-start.sh "http://localhost:8080/alfresco"
         - docker ps

--- a/.travis.yml
+++ b/.travis.yml
@@ -190,16 +190,13 @@ jobs:
         - pyenv versions
         - pyenv global 3.7.1
         - pip install requests pytest
-        - git clone --depth 1 --branch v1.0-M1 https://${GIT_USERNAME}:${GIT_PASSWORD}@github.com/Alfresco/alfresco-deployment-test-automation-scripts.git dtas
+        - git clone --depth 1 --branch OPSEXP-718 https://${GIT_USERNAME}:${GIT_PASSWORD}@github.com/Alfresco/alfresco-deployment-test-automation-scripts.git dtas
+        - docker images | grep pipeline
       script:
         - ${TAS_SCRIPTS}/start-compose.sh ${TAS_ENVIRONMENT}/docker-compose-pipeline-all-amps.yml
-        - ${TAS_SCRIPTS}/wait-for-alfresco-start.sh "http://localhost:8080/alfresco/api/-default-/public/alfresco/versions/1/probes/-live-"
-        # - docker ps
-        # - ALFCONTAINER=`docker ps -a | grep _alfresco | awk '{ print $1 }'`
-        # - echo "Last 300 lines from alfresco.log on container $ALFCONTAINER:"
-        # - docker logs --tail=300 $ALFCONTAINER
-        # Run smoke tests against the system using DTAS
-        # - ls -hal
+        - ${TAS_SCRIPTS}/wait-for-alfresco-start.sh "http://localhost:8080/alfresco/" 180
+        - docker ps
+        - curl -v --user admin.pipeline@alfresco.com:admin http://localhost:8080/alfresco/api/discovery
         - cd dtas
         - pytest --configuration ../tests/environment/dtas-config.json tests/ -s
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -187,6 +187,8 @@ jobs:
       if: fork = false AND type != pull_request
       before_script:
         - travis_retry travis_wait 20 mvn -B clean install -Ppipeline,local $(mvn -B -q help:evaluate "-Dexpression=dependency.alfresco-enterprise-repo.version" -DforceStdout | grep -q '\-SNAPSHOT$' && echo '-Drepo.image.tag=latest')
+        # Show what DTAS will be looking for
+        - cat tests/pipeline-all-amps/repo/target/dtas/dtas-config.json
         - pyenv versions
         - pyenv global 3.7.1
         - pip install requests pytest
@@ -196,9 +198,10 @@ jobs:
         - ${TAS_SCRIPTS}/start-compose.sh ${TAS_ENVIRONMENT}/docker-compose-pipeline-all-amps.yml
         - ${TAS_SCRIPTS}/wait-for-alfresco-start.sh "http://localhost:8080/alfresco/" 180
         - docker ps
+        # Show what AMPs the repo has installed
         - curl -v --user admin.pipeline@alfresco.com:admin http://localhost:8080/alfresco/api/discovery
         - cd dtas
-        - pytest --configuration ../tests/environment/dtas-config.json tests/ -s
+        - pytest --configuration ../tests/pipeline-all-amps/repo/target/dtas/dtas-config.json tests/ -s
 
     # - name: "Update latest and Single Pipeline <acs>-<build> images"
     #   stage: docker_latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -195,10 +195,14 @@ jobs:
         - ${TAS_SCRIPTS}/start-compose.sh ${TAS_ENVIRONMENT}/docker-compose-pipeline-all-amps.yml
         - ${TAS_SCRIPTS}/wait-for-alfresco-start.sh "http://localhost:8080/alfresco" 180
         - docker ps
+        - ALFCONTAINER=`docker ps -a | grep _alfresco | awk '{ print $1 }'`
+        - echo "Last 200 lines from alfresco.log on container $ALFCONTAINER:"
+        - docker logs --tail=200 $ALFCONTAINER
         # Run smoke tests against the system using DTAS
         - ls -hal
         - cd dtas
-        - curl -v http://localhost:8080/alfresco/api/-default-/public/alfresco/versions/1/probes/-live-
+        # - curl -v http://localhost:8080/alfresco/api/-default-/public/alfresco/versions/1/probes/-live-
+        - curl -v http://localhost:8080/alfresco
         - pytest --verbose --configuration ../tests/environment/dtas-config.json tests/ -s
 
     # - name: "Update latest and Single Pipeline <acs>-<build> images"

--- a/.travis.yml
+++ b/.travis.yml
@@ -192,7 +192,7 @@ jobs:
         - pyenv versions
         - pyenv global 3.7.1
         - pip install requests pytest
-        - git clone --depth 1 --branch OPSEXP-718 https://${GIT_USERNAME}:${GIT_PASSWORD}@github.com/Alfresco/alfresco-deployment-test-automation-scripts.git dtas
+        - git clone --depth 1 --branch v1.0-M2 https://${GIT_USERNAME}:${GIT_PASSWORD}@github.com/Alfresco/alfresco-deployment-test-automation-scripts.git dtas
         - docker images | grep pipeline
       script:
         - ${TAS_SCRIPTS}/start-compose.sh ${TAS_ENVIRONMENT}/docker-compose-pipeline-all-amps.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -196,7 +196,9 @@ jobs:
         - ${TAS_SCRIPTS}/wait-for-alfresco-start.sh "http://localhost:8080/alfresco" 180
         - docker ps
         # Run smoke tests against the system using DTAS
+        - ls -hal
         - cd dtas
+        - curl -v http://localhost:8080/alfresco/api/-default-/public/alfresco/versions/1/probes/-live-
         - pytest --verbose --configuration ../tests/environment/dtas-config.json tests/ -s
 
     # - name: "Update latest and Single Pipeline <acs>-<build> images"

--- a/.travis.yml
+++ b/.travis.yml
@@ -193,16 +193,16 @@ jobs:
         - git clone --depth 1 --branch v1.0-M1 https://${GIT_USERNAME}:${GIT_PASSWORD}@github.com/Alfresco/alfresco-deployment-test-automation-scripts.git dtas
       script:
         - ${TAS_SCRIPTS}/start-compose.sh ${TAS_ENVIRONMENT}/docker-compose-pipeline-all-amps.yml
-        - ${TAS_SCRIPTS}/wait-for-alfresco-start.sh "http://localhost:8080/alfresco" 180
+        - ${TAS_SCRIPTS}/wait-for-alfresco-start.sh "http://localhost:8080/alfresco/api/-default-/public/alfresco/versions/1/probes/-live-"
         - docker ps
         - ALFCONTAINER=`docker ps -a | grep _alfresco | awk '{ print $1 }'`
-        - echo "Last 200 lines from alfresco.log on container $ALFCONTAINER:"
-        - docker logs --tail=200 $ALFCONTAINER
+        - echo "Last 300 lines from alfresco.log on container $ALFCONTAINER:"
+        - docker logs --tail=300 $ALFCONTAINER
         # Run smoke tests against the system using DTAS
         - ls -hal
         - cd dtas
         # - curl -v http://localhost:8080/alfresco/api/-default-/public/alfresco/versions/1/probes/-live-
-        - curl -v http://localhost:8080/alfresco
+        - curl -v http://localhost:8080/alfresco/
         - pytest --verbose --configuration ../tests/environment/dtas-config.json tests/ -s
 
     # - name: "Update latest and Single Pipeline <acs>-<build> images"

--- a/.travis.yml
+++ b/.travis.yml
@@ -201,7 +201,7 @@ jobs:
         # Run smoke tests against the system using DTAS
         # - ls -hal
         - cd dtas
-        - pytest --verbose --configuration ../tests/environment/dtas-config.json tests/ -s
+        - pytest --configuration ../tests/environment/dtas-config.json tests/ -s
 
     # - name: "Update latest and Single Pipeline <acs>-<build> images"
     #   stage: docker_latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -185,14 +185,12 @@ jobs:
     # Test local repo and share docker images that will be used in the single pipeline. Tag:latest
     - name: "Single Pipeline image tests"
       if: fork = false AND type != pull_request
-      before_install:
-        - git clone --depth 1 --branch v1.0-M1 https://${GIT_USERNAME}:${GIT_PASSWORD}@github.com/Alfresco/alfresco-deployment-test-automation-scripts.git dtas
       before_script:
         - travis_retry travis_wait 20 mvn -B clean install -Ppipeline,local $(mvn -B -q help:evaluate "-Dexpression=dependency.alfresco-enterprise-repo.version" -DforceStdout | grep -q '\-SNAPSHOT$' && echo '-Drepo.image.tag=latest')
-      install:
         - pyenv versions
         - pyenv global 3.7.1
         - pip install pytest
+        - git clone --depth 1 --branch v1.0-M1 https://${GIT_USERNAME}:${GIT_PASSWORD}@github.com/Alfresco/alfresco-deployment-test-automation-scripts.git dtas
       script:
         - ls -hal
         - ${TAS_SCRIPTS}/start-compose.sh ${TAS_ENVIRONMENT}/docker-compose-pipeline-all-amps.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,116 +47,116 @@ install: travis_retry travis_wait 40 bash scripts/travis/build.sh
 
 jobs:
   include:
-    - name: "REST API TAS tests part1"
-      if: commit_message =~ /\[tas\]/
-      before_script:
-        - ${TAS_SCRIPTS}/start-compose.sh ${TAS_ENVIRONMENT}/docker-compose-rest-api-tests.yml
-        - ${TAS_SCRIPTS}/wait-for-alfresco-start.sh "http://localhost:8082/alfresco"
-      script:
-        - travis_wait 60 mvn -B install -f tests/tas-restapi/pom.xml -Pall-tas-tests,run-restapi-part1 -Denvironment=default -DrunBugs=false
+    # - name: "REST API TAS tests part1"
+    #   if: commit_message =~ /\[tas\]/
+    #   before_script:
+    #     - ${TAS_SCRIPTS}/start-compose.sh ${TAS_ENVIRONMENT}/docker-compose-rest-api-tests.yml
+    #     - ${TAS_SCRIPTS}/wait-for-alfresco-start.sh "http://localhost:8082/alfresco"
+    #   script:
+    #     - travis_wait 60 mvn -B install -f tests/tas-restapi/pom.xml -Pall-tas-tests,run-restapi-part1 -Denvironment=default -DrunBugs=false
 
-    - name: "REST API TAS tests part2"
-      if: commit_message =~ /\[tas\]/
-      before_script:
-        - ${TAS_SCRIPTS}/start-compose.sh ${TAS_ENVIRONMENT}/docker-compose-rest-api-tests.yml
-        - ${TAS_SCRIPTS}/wait-for-alfresco-start.sh "http://localhost:8082/alfresco"
-      script:
-        - travis_wait 60 mvn -B install -f tests/tas-restapi/pom.xml -Pall-tas-tests,run-restapi-part2 -Denvironment=default -DrunBugs=false
+    # - name: "REST API TAS tests part2"
+    #   if: commit_message =~ /\[tas\]/
+    #   before_script:
+    #     - ${TAS_SCRIPTS}/start-compose.sh ${TAS_ENVIRONMENT}/docker-compose-rest-api-tests.yml
+    #     - ${TAS_SCRIPTS}/wait-for-alfresco-start.sh "http://localhost:8082/alfresco"
+    #   script:
+    #     - travis_wait 60 mvn -B install -f tests/tas-restapi/pom.xml -Pall-tas-tests,run-restapi-part2 -Denvironment=default -DrunBugs=false
 
-    - name: "REST API TAS tests part3"
-      if: commit_message =~ /\[tas\]/
-      before_script:
-        - ${TAS_SCRIPTS}/start-compose.sh ${TAS_ENVIRONMENT}/docker-compose-rest-api-tests.yml
-        - ${TAS_SCRIPTS}/wait-for-alfresco-start.sh "http://localhost:8082/alfresco"
-      script:
-        - travis_wait 60 mvn -B install -f tests/tas-restapi/pom.xml -Pall-tas-tests,run-restapi-part3 -Denvironment=default -DrunBugs=false
+    # - name: "REST API TAS tests part3"
+    #   if: commit_message =~ /\[tas\]/
+    #   before_script:
+    #     - ${TAS_SCRIPTS}/start-compose.sh ${TAS_ENVIRONMENT}/docker-compose-rest-api-tests.yml
+    #     - ${TAS_SCRIPTS}/wait-for-alfresco-start.sh "http://localhost:8082/alfresco"
+    #   script:
+    #     - travis_wait 60 mvn -B install -f tests/tas-restapi/pom.xml -Pall-tas-tests,run-restapi-part3 -Denvironment=default -DrunBugs=false
 
-    - name: "CMIS TAS tests - BROWSER binding"
-      if: commit_message =~ /\[tas\]/
-      before_script:
-        - ${TAS_SCRIPTS}/start-compose.sh ${TAS_ENVIRONMENT}/docker-compose-cmis-tests.yml
-        - ${TAS_SCRIPTS}/wait-for-alfresco-start.sh "http://localhost:8082/alfresco"
-      script:
-        - travis_wait 40 mvn -B install -f tests/tas-cmis/pom.xml -Pall-tas-tests,run-cmis-browser -Denvironment=default -DrunBugs=false
+    # - name: "CMIS TAS tests - BROWSER binding"
+    #   if: commit_message =~ /\[tas\]/
+    #   before_script:
+    #     - ${TAS_SCRIPTS}/start-compose.sh ${TAS_ENVIRONMENT}/docker-compose-cmis-tests.yml
+    #     - ${TAS_SCRIPTS}/wait-for-alfresco-start.sh "http://localhost:8082/alfresco"
+    #   script:
+    #     - travis_wait 40 mvn -B install -f tests/tas-cmis/pom.xml -Pall-tas-tests,run-cmis-browser -Denvironment=default -DrunBugs=false
 
-    - name: "CMIS TAS tests - ATOM binding"
-      if: commit_message =~ /\[tas\]/
-      before_script:
-        - ${TAS_SCRIPTS}/start-compose.sh ${TAS_ENVIRONMENT}/docker-compose-cmis-tests.yml
-        - ${TAS_SCRIPTS}/wait-for-alfresco-start.sh "http://localhost:8082/alfresco"
-      script:
-        - travis_wait 40 mvn -B install -f tests/tas-cmis/pom.xml -Pall-tas-tests,run-cmis-atom -Denvironment=default -DrunBugs=false
+    # - name: "CMIS TAS tests - ATOM binding"
+    #   if: commit_message =~ /\[tas\]/
+    #   before_script:
+    #     - ${TAS_SCRIPTS}/start-compose.sh ${TAS_ENVIRONMENT}/docker-compose-cmis-tests.yml
+    #     - ${TAS_SCRIPTS}/wait-for-alfresco-start.sh "http://localhost:8082/alfresco"
+    #   script:
+    #     - travis_wait 40 mvn -B install -f tests/tas-cmis/pom.xml -Pall-tas-tests,run-cmis-atom -Denvironment=default -DrunBugs=false
 
-    - name: "CMIS TAS tests - WEBSERVICES binding"
-      if: commit_message =~ /\[tas\]/
-      before_script:
-        - ${TAS_SCRIPTS}/start-compose.sh ${TAS_ENVIRONMENT}/docker-compose-cmis-tests.yml
-        - ${TAS_SCRIPTS}/wait-for-alfresco-start.sh "http://localhost:8082/alfresco"
-      script:
-        - travis_wait 40 mvn -B install -f tests/tas-cmis/pom.xml -Pall-tas-tests,run-cmis-webservices -Denvironment=default -DrunBugs=false
+    # - name: "CMIS TAS tests - WEBSERVICES binding"
+    #   if: commit_message =~ /\[tas\]/
+    #   before_script:
+    #     - ${TAS_SCRIPTS}/start-compose.sh ${TAS_ENVIRONMENT}/docker-compose-cmis-tests.yml
+    #     - ${TAS_SCRIPTS}/wait-for-alfresco-start.sh "http://localhost:8082/alfresco"
+    #   script:
+    #     - travis_wait 40 mvn -B install -f tests/tas-cmis/pom.xml -Pall-tas-tests,run-cmis-webservices -Denvironment=default -DrunBugs=false
 
-    - name: "Email TAS tests"
-      if: commit_message =~ /\[tas\]/
-      before_script:
-        - ${TAS_SCRIPTS}/start-compose.sh ${TAS_ENVIRONMENT}/docker-compose-email-tests.yml
-        - ${TAS_SCRIPTS}/wait-for-alfresco-start.sh "http://localhost:8082/alfresco"
-      script:
-        - travis_wait 30 mvn -B install -f tests/tas-email/pom.xml -Pall-tas-tests -Denvironment=default -DrunBugs=false
+    # - name: "Email TAS tests"
+    #   if: commit_message =~ /\[tas\]/
+    #   before_script:
+    #     - ${TAS_SCRIPTS}/start-compose.sh ${TAS_ENVIRONMENT}/docker-compose-email-tests.yml
+    #     - ${TAS_SCRIPTS}/wait-for-alfresco-start.sh "http://localhost:8082/alfresco"
+    #   script:
+    #     - travis_wait 30 mvn -B install -f tests/tas-email/pom.xml -Pall-tas-tests -Denvironment=default -DrunBugs=false
 
-    - name: "WebDAV TAS tests"
-      if: commit_message =~ /\[tas\]/
-      before_script:
-        - ${TAS_SCRIPTS}/start-compose.sh ${TAS_ENVIRONMENT}/docker-compose-minimal.yml
-        - ${TAS_SCRIPTS}/wait-for-alfresco-start.sh "http://localhost:8082/alfresco"
-      script:
-        - travis_wait 20 mvn -B install -f tests/tas-webdav/pom.xml -Pall-tas-tests -Denvironment=default -DrunBugs=false
+    # - name: "WebDAV TAS tests"
+    #   if: commit_message =~ /\[tas\]/
+    #   before_script:
+    #     - ${TAS_SCRIPTS}/start-compose.sh ${TAS_ENVIRONMENT}/docker-compose-minimal.yml
+    #     - ${TAS_SCRIPTS}/wait-for-alfresco-start.sh "http://localhost:8082/alfresco"
+    #   script:
+    #     - travis_wait 20 mvn -B install -f tests/tas-webdav/pom.xml -Pall-tas-tests -Denvironment=default -DrunBugs=false
 
-    - name: "Integration TAS tests"
-      if: commit_message =~ /\[tas\]/
-      before_script:
-        - ${TAS_SCRIPTS}/start-compose.sh ${TAS_ENVIRONMENT}/docker-compose-integration-tests.yml
-        - ${TAS_SCRIPTS}/wait-for-alfresco-start.sh "http://localhost:8082/alfresco"
-      script:
-        - travis_wait 30 mvn -B install -f tests/tas-integration/pom.xml -Pall-tas-tests -Denvironment=default -DrunBugs=false
+    # - name: "Integration TAS tests"
+    #   if: commit_message =~ /\[tas\]/
+    #   before_script:
+    #     - ${TAS_SCRIPTS}/start-compose.sh ${TAS_ENVIRONMENT}/docker-compose-integration-tests.yml
+    #     - ${TAS_SCRIPTS}/wait-for-alfresco-start.sh "http://localhost:8082/alfresco"
+    #   script:
+    #     - travis_wait 30 mvn -B install -f tests/tas-integration/pom.xml -Pall-tas-tests -Denvironment=default -DrunBugs=false
 
-    - name: "LDAP TAS tests"
-      if: commit_message =~ /\[tas\]/
-      before_script:
-        - ${TAS_SCRIPTS}/start-compose.sh ${TAS_ENVIRONMENT}/docker-compose-with-ldap.yml
-        - ${TAS_SCRIPTS}/wait-for-alfresco-start.sh "http://localhost:8082/alfresco"
-      script:
-        - travis_wait 60 mvn -B install -f tests/tas-restapi/pom.xml -Pall-tas-tests,run-restapi-ldap -Denvironment=default -DrunBugs=false
-        - travis_wait 10 mvn -B install -f tests/tas-integration/pom.xml -Prun-ldap -Denvironment=default -DrunBugs=false
+    # - name: "LDAP TAS tests"
+    #   if: commit_message =~ /\[tas\]/
+    #   before_script:
+    #     - ${TAS_SCRIPTS}/start-compose.sh ${TAS_ENVIRONMENT}/docker-compose-with-ldap.yml
+    #     - ${TAS_SCRIPTS}/wait-for-alfresco-start.sh "http://localhost:8082/alfresco"
+    #   script:
+    #     - travis_wait 60 mvn -B install -f tests/tas-restapi/pom.xml -Pall-tas-tests,run-restapi-ldap -Denvironment=default -DrunBugs=false
+    #     - travis_wait 10 mvn -B install -f tests/tas-integration/pom.xml -Prun-ldap -Denvironment=default -DrunBugs=false
 
-    - name: "REST API TAS tests with AIMS"
-      if: fork = false # AIMS docker image requires access to quay.io
-      before_script:
-        # AIMS cannot be configured via localhost
-        - export HOST_IP=$(hostname  -I | cut -f1 -d' ')
-        - ${TAS_SCRIPTS}/start-compose.sh ${TAS_ENVIRONMENT}/docker-compose-aims.yml
-        - ${TAS_SCRIPTS}/wait-for-alfresco-start.sh "http://localhost:8082/alfresco" 180
-      script:
-        - travis_wait 60 mvn -B install -f tests/tas-restapi/pom.xml -Pall-tas-tests,run-restapi-aims -Denvironment=aims-environment -DrunBugs=false "-Didentity-service.auth-server-url=http://${HOST_IP}:8999/auth"
+    # - name: "REST API TAS tests with AIMS"
+    #   if: fork = false # AIMS docker image requires access to quay.io
+    #   before_script:
+    #     # AIMS cannot be configured via localhost
+    #     - export HOST_IP=$(hostname  -I | cut -f1 -d' ')
+    #     - ${TAS_SCRIPTS}/start-compose.sh ${TAS_ENVIRONMENT}/docker-compose-aims.yml
+    #     - ${TAS_SCRIPTS}/wait-for-alfresco-start.sh "http://localhost:8082/alfresco" 180
+    #   script:
+    #     - travis_wait 60 mvn -B install -f tests/tas-restapi/pom.xml -Pall-tas-tests,run-restapi-aims -Denvironment=aims-environment -DrunBugs=false "-Didentity-service.auth-server-url=http://${HOST_IP}:8999/auth"
 
-    - name: "CMIS TAS tests with AIMS - BROWSER binding"
-      if: fork = false # AIMS docker image requires access to quay.io
-      before_script:
-        # AIMS cannot be configured via localhost
-        - export HOST_IP=$(hostname  -I | cut -f1 -d' ')
-        - ${TAS_SCRIPTS}/start-compose.sh ${TAS_ENVIRONMENT}/docker-compose-aims.yml
-        - ${TAS_SCRIPTS}/wait-for-alfresco-start.sh "http://localhost:8082/alfresco" 180
-      script:
-        - travis_wait 40 mvn -B install -f tests/tas-cmis/pom.xml -Pall-tas-tests,run-cmis-browser-with-aims -Denvironment=aims-environment -DrunBugs=false "-Didentity-service.auth-server-url=http://${HOST_IP}:8999/auth"
+    # - name: "CMIS TAS tests with AIMS - BROWSER binding"
+    #   if: fork = false # AIMS docker image requires access to quay.io
+    #   before_script:
+    #     # AIMS cannot be configured via localhost
+    #     - export HOST_IP=$(hostname  -I | cut -f1 -d' ')
+    #     - ${TAS_SCRIPTS}/start-compose.sh ${TAS_ENVIRONMENT}/docker-compose-aims.yml
+    #     - ${TAS_SCRIPTS}/wait-for-alfresco-start.sh "http://localhost:8082/alfresco" 180
+    #   script:
+    #     - travis_wait 40 mvn -B install -f tests/tas-cmis/pom.xml -Pall-tas-tests,run-cmis-browser-with-aims -Denvironment=aims-environment -DrunBugs=false "-Didentity-service.auth-server-url=http://${HOST_IP}:8999/auth"
 
-    - name: "CMIS TAS tests with AIMS - ATOM binding"
-      if: fork = false # AIMS docker image requires access to quay.io
-      before_script:
-        # AIMS cannot be configured via localhost
-        - export HOST_IP=$(hostname  -I | cut -f1 -d' ')
-        - ${TAS_SCRIPTS}/start-compose.sh ${TAS_ENVIRONMENT}/docker-compose-aims.yml
-        - ${TAS_SCRIPTS}/wait-for-alfresco-start.sh "http://localhost:8082/alfresco" 180
-      script:
-        - travis_wait 40 mvn -B install -f tests/tas-cmis/pom.xml -Pall-tas-tests,run-cmis-atom-with-aims -Denvironment=aims-environment -DrunBugs=false "-Didentity-service.auth-server-url=http://${HOST_IP}:8999/auth"
+    # - name: "CMIS TAS tests with AIMS - ATOM binding"
+    #   if: fork = false # AIMS docker image requires access to quay.io
+    #   before_script:
+    #     # AIMS cannot be configured via localhost
+    #     - export HOST_IP=$(hostname  -I | cut -f1 -d' ')
+    #     - ${TAS_SCRIPTS}/start-compose.sh ${TAS_ENVIRONMENT}/docker-compose-aims.yml
+    #     - ${TAS_SCRIPTS}/wait-for-alfresco-start.sh "http://localhost:8082/alfresco" 180
+    #   script:
+    #     - travis_wait 40 mvn -B install -f tests/tas-cmis/pom.xml -Pall-tas-tests,run-cmis-atom-with-aims -Denvironment=aims-environment -DrunBugs=false "-Didentity-service.auth-server-url=http://${HOST_IP}:8999/auth"
 
 #    Enable job after Camel upgrade -> https://alfresco.atlassian.net/browse/DESKTOPAPP-539
 #    - name: "Sync Service TAS tests"
@@ -166,72 +166,76 @@ jobs:
 #      script:
 #        - travis_wait 20 mvn -B install -f tests/tas-sync-service/pom.xml -Pall-tas-tests -Denvironment=default -DrunBugs=false
 
-    - name: "Elasticsearch TAS tests"
-      before_script:
-        - ${TAS_SCRIPTS}/start-compose.sh ${TAS_ENVIRONMENT}/docker-compose-elasticsearch.yml
-        - ${TAS_SCRIPTS}/wait-for-alfresco-start.sh "http://localhost:8082/alfresco"
-      script:
-        - travis_wait 30 mvn -B install -f tests/tas-elasticsearch/pom.xml -Pall-tas-tests -Denvironment=default -DrunBugs=false
+    # - name: "Elasticsearch TAS tests"
+    #   before_script:
+    #     - ${TAS_SCRIPTS}/start-compose.sh ${TAS_ENVIRONMENT}/docker-compose-elasticsearch.yml
+    #     - ${TAS_SCRIPTS}/wait-for-alfresco-start.sh "http://localhost:8082/alfresco"
+    #   script:
+    #     - travis_wait 30 mvn -B install -f tests/tas-elasticsearch/pom.xml -Pall-tas-tests -Denvironment=default -DrunBugs=false
 
-    - name: "All AMPs tests"
-      before_script:
-        - travis_retry travis_wait 20 mvn -B -q install -f tests/tas-all-amps/pom.xml -DskipTests -Pall-tas-tests,prepare-wars-with-amps
-      script:
-        - ./tests/scripts/checkLibraryDuplicates.sh ./tests/tas-all-amps/target/war/alfresco/WEB-INF/lib
-        - ${TAS_SCRIPTS}/start-compose.sh ${TAS_ENVIRONMENT}/docker-compose-all-amps-test.yml
-        - ${TAS_SCRIPTS}/wait-for-alfresco-start.sh "http://localhost:8082/alfresco"
-        - travis_wait 20 mvn -B install -f tests/tas-all-amps/pom.xml -Pall-tas-tests -Denvironment=default -DrunBugs=false
+    # - name: "All AMPs tests"
+    #   before_script:
+    #     - travis_retry travis_wait 20 mvn -B -q install -f tests/tas-all-amps/pom.xml -DskipTests -Pall-tas-tests,prepare-wars-with-amps
+    #   script:
+    #     - ./tests/scripts/checkLibraryDuplicates.sh ./tests/tas-all-amps/target/war/alfresco/WEB-INF/lib
+    #     - ${TAS_SCRIPTS}/start-compose.sh ${TAS_ENVIRONMENT}/docker-compose-all-amps-test.yml
+    #     - ${TAS_SCRIPTS}/wait-for-alfresco-start.sh "http://localhost:8082/alfresco"
+    #     - travis_wait 20 mvn -B install -f tests/tas-all-amps/pom.xml -Pall-tas-tests -Denvironment=default -DrunBugs=false
 
     # Test local repo and share docker images that will be used in the single pipeline. Tag:latest
     - name: "Single Pipeline image tests"
       if: fork = false AND type != pull_request
+      # before_install:
+      #   - git clone --depth 1 --branch v1.0-M1 https://${GIT_USERNAME}:${GIT_PASSWORD}@github.com/Alfresco/alfresco-deployment-test-automation-scripts.git dtas
       before_script:
         - travis_retry travis_wait 20 mvn -B clean install -Ppipeline,local $(mvn -B -q help:evaluate "-Dexpression=dependency.alfresco-enterprise-repo.version" -DforceStdout | grep -q '\-SNAPSHOT$' && echo '-Drepo.image.tag=latest')
       script:
+        - cloneRepo "github.com/Alfresco/alfresco-deployment-test-automation-scripts.git" "v1.0-M1"
+        - ls -hal
         - ${TAS_SCRIPTS}/start-compose.sh ${TAS_ENVIRONMENT}/docker-compose-pipeline-all-amps.yml
         - ${TAS_SCRIPTS}/wait-for-alfresco-start.sh "http://localhost:8080/alfresco"
         - docker ps
 
-    - name: "Update latest and Single Pipeline <acs>-<build> images"
-      stage: docker_latest
-      # Remove the pipeline profile to avoid sending an image tagged with the build number to the single pipeline
-      script: travis_retry travis_wait 30 mvn -B -V clean install -DskipTests -Dmaven.javadoc.skip=true -Dbuild-number=${TRAVIS_BUILD_NUMBER} -Pinternal,pipeline
+    # - name: "Update latest and Single Pipeline <acs>-<build> images"
+    #   stage: docker_latest
+    #   # Remove the pipeline profile to avoid sending an image tagged with the build number to the single pipeline
+    #   script: travis_retry travis_wait 30 mvn -B -V clean install -DskipTests -Dmaven.javadoc.skip=true -Dbuild-number=${TRAVIS_BUILD_NUMBER} -Pinternal,pipeline
 
-    - name: "Release and Copy to S3 Staging Bucket"
-      stage: release
-      before_script: bash scripts/travis/verify_release_tag.sh
-      script: travis_wait 60 bash scripts/travis/maven_release.sh
-      before_deploy:
-        # Move the final artifacts to a single folder (deploy_dir) to be copied to S3
-        - mkdir -p deploy_dir
-        - cp distribution/target/alfresco.war deploy_dir
-        - cp distribution/target/*-distribution*.zip deploy_dir
-        - ls -lA deploy_dir
-      deploy:
-        - provider: s3
-          access_key_id: "${AWS_STAGING_ACCESS_KEY}"
-          secret_access_key: "${AWS_STAGING_SECRET_KEY}"
-          bucket: "alfresco-artefacts-staging"
-          region: "eu-west-1"
-          # Once Travis releases their *dpl v2* api (currently in beta, check https://docs.travis-ci.com/user/deployment-v2#how-to-opt-in-to-v2)
-          # the skip_cleanup option will no longer be needed (or valid) and should be removed (ACS-1155).
-          skip_cleanup: true
-          acl: private
-          local_dir: "deploy_dir"
-          upload_dir: "alfresco-content-services/release/${TRAVIS_BRANCH}/${TRAVIS_BUILD_NUMBER}"
-          on:
-            all_branches: true
-      after_deploy:
-        - echo "Finished release and deployed to https://s3.console.aws.amazon.com/s3/buckets/alfresco-artefacts-staging/alfresco-content-services/release/${TRAVIS_BRANCH}/${TRAVIS_BUILD_NUMBER}"
+    # - name: "Release and Copy to S3 Staging Bucket"
+    #   stage: release
+    #   before_script: bash scripts/travis/verify_release_tag.sh
+    #   script: travis_wait 60 bash scripts/travis/maven_release.sh
+    #   before_deploy:
+    #     # Move the final artifacts to a single folder (deploy_dir) to be copied to S3
+    #     - mkdir -p deploy_dir
+    #     - cp distribution/target/alfresco.war deploy_dir
+    #     - cp distribution/target/*-distribution*.zip deploy_dir
+    #     - ls -lA deploy_dir
+    #   deploy:
+    #     - provider: s3
+    #       access_key_id: "${AWS_STAGING_ACCESS_KEY}"
+    #       secret_access_key: "${AWS_STAGING_SECRET_KEY}"
+    #       bucket: "alfresco-artefacts-staging"
+    #       region: "eu-west-1"
+    #       # Once Travis releases their *dpl v2* api (currently in beta, check https://docs.travis-ci.com/user/deployment-v2#how-to-opt-in-to-v2)
+    #       # the skip_cleanup option will no longer be needed (or valid) and should be removed (ACS-1155).
+    #       skip_cleanup: true
+    #       acl: private
+    #       local_dir: "deploy_dir"
+    #       upload_dir: "alfresco-content-services/release/${TRAVIS_BRANCH}/${TRAVIS_BUILD_NUMBER}"
+    #       on:
+    #         all_branches: true
+    #   after_deploy:
+    #     - echo "Finished release and deployed to https://s3.console.aws.amazon.com/s3/buckets/alfresco-artefacts-staging/alfresco-content-services/release/${TRAVIS_BRANCH}/${TRAVIS_BUILD_NUMBER}"
 
-    - name: "Copy to S3 Release Bucket"
-      stage: publish
-      # Nothing to build/install as we are just copying from S3 buckets
-      install: skip
-      script: skip
-      before_deploy: pip install awscli
-      deploy:
-        - provider: script
-          script: bash scripts/travis/copy_to_release_bucket.sh
-          on:
-            all_branches: true
+    # - name: "Copy to S3 Release Bucket"
+    #   stage: publish
+    #   # Nothing to build/install as we are just copying from S3 buckets
+    #   install: skip
+    #   script: skip
+    #   before_deploy: pip install awscli
+    #   deploy:
+    #     - provider: script
+    #       script: bash scripts/travis/copy_to_release_bucket.sh
+    #       on:
+    #         all_branches: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,116 +47,116 @@ install: travis_retry travis_wait 40 bash scripts/travis/build.sh
 
 jobs:
   include:
-    # - name: "REST API TAS tests part1"
-    #   if: commit_message =~ /\[tas\]/
-    #   before_script:
-    #     - ${TAS_SCRIPTS}/start-compose.sh ${TAS_ENVIRONMENT}/docker-compose-rest-api-tests.yml
-    #     - ${TAS_SCRIPTS}/wait-for-alfresco-start.sh "http://localhost:8082/alfresco"
-    #   script:
-    #     - travis_wait 60 mvn -B install -f tests/tas-restapi/pom.xml -Pall-tas-tests,run-restapi-part1 -Denvironment=default -DrunBugs=false
+    - name: "REST API TAS tests part1"
+      if: commit_message =~ /\[tas\]/
+      before_script:
+        - ${TAS_SCRIPTS}/start-compose.sh ${TAS_ENVIRONMENT}/docker-compose-rest-api-tests.yml
+        - ${TAS_SCRIPTS}/wait-for-alfresco-start.sh "http://localhost:8082/alfresco"
+      script:
+        - travis_wait 60 mvn -B install -f tests/tas-restapi/pom.xml -Pall-tas-tests,run-restapi-part1 -Denvironment=default -DrunBugs=false
 
-    # - name: "REST API TAS tests part2"
-    #   if: commit_message =~ /\[tas\]/
-    #   before_script:
-    #     - ${TAS_SCRIPTS}/start-compose.sh ${TAS_ENVIRONMENT}/docker-compose-rest-api-tests.yml
-    #     - ${TAS_SCRIPTS}/wait-for-alfresco-start.sh "http://localhost:8082/alfresco"
-    #   script:
-    #     - travis_wait 60 mvn -B install -f tests/tas-restapi/pom.xml -Pall-tas-tests,run-restapi-part2 -Denvironment=default -DrunBugs=false
+    - name: "REST API TAS tests part2"
+      if: commit_message =~ /\[tas\]/
+      before_script:
+        - ${TAS_SCRIPTS}/start-compose.sh ${TAS_ENVIRONMENT}/docker-compose-rest-api-tests.yml
+        - ${TAS_SCRIPTS}/wait-for-alfresco-start.sh "http://localhost:8082/alfresco"
+      script:
+        - travis_wait 60 mvn -B install -f tests/tas-restapi/pom.xml -Pall-tas-tests,run-restapi-part2 -Denvironment=default -DrunBugs=false
 
-    # - name: "REST API TAS tests part3"
-    #   if: commit_message =~ /\[tas\]/
-    #   before_script:
-    #     - ${TAS_SCRIPTS}/start-compose.sh ${TAS_ENVIRONMENT}/docker-compose-rest-api-tests.yml
-    #     - ${TAS_SCRIPTS}/wait-for-alfresco-start.sh "http://localhost:8082/alfresco"
-    #   script:
-    #     - travis_wait 60 mvn -B install -f tests/tas-restapi/pom.xml -Pall-tas-tests,run-restapi-part3 -Denvironment=default -DrunBugs=false
+    - name: "REST API TAS tests part3"
+      if: commit_message =~ /\[tas\]/
+      before_script:
+        - ${TAS_SCRIPTS}/start-compose.sh ${TAS_ENVIRONMENT}/docker-compose-rest-api-tests.yml
+        - ${TAS_SCRIPTS}/wait-for-alfresco-start.sh "http://localhost:8082/alfresco"
+      script:
+        - travis_wait 60 mvn -B install -f tests/tas-restapi/pom.xml -Pall-tas-tests,run-restapi-part3 -Denvironment=default -DrunBugs=false
 
-    # - name: "CMIS TAS tests - BROWSER binding"
-    #   if: commit_message =~ /\[tas\]/
-    #   before_script:
-    #     - ${TAS_SCRIPTS}/start-compose.sh ${TAS_ENVIRONMENT}/docker-compose-cmis-tests.yml
-    #     - ${TAS_SCRIPTS}/wait-for-alfresco-start.sh "http://localhost:8082/alfresco"
-    #   script:
-    #     - travis_wait 40 mvn -B install -f tests/tas-cmis/pom.xml -Pall-tas-tests,run-cmis-browser -Denvironment=default -DrunBugs=false
+    - name: "CMIS TAS tests - BROWSER binding"
+      if: commit_message =~ /\[tas\]/
+      before_script:
+        - ${TAS_SCRIPTS}/start-compose.sh ${TAS_ENVIRONMENT}/docker-compose-cmis-tests.yml
+        - ${TAS_SCRIPTS}/wait-for-alfresco-start.sh "http://localhost:8082/alfresco"
+      script:
+        - travis_wait 40 mvn -B install -f tests/tas-cmis/pom.xml -Pall-tas-tests,run-cmis-browser -Denvironment=default -DrunBugs=false
 
-    # - name: "CMIS TAS tests - ATOM binding"
-    #   if: commit_message =~ /\[tas\]/
-    #   before_script:
-    #     - ${TAS_SCRIPTS}/start-compose.sh ${TAS_ENVIRONMENT}/docker-compose-cmis-tests.yml
-    #     - ${TAS_SCRIPTS}/wait-for-alfresco-start.sh "http://localhost:8082/alfresco"
-    #   script:
-    #     - travis_wait 40 mvn -B install -f tests/tas-cmis/pom.xml -Pall-tas-tests,run-cmis-atom -Denvironment=default -DrunBugs=false
+    - name: "CMIS TAS tests - ATOM binding"
+      if: commit_message =~ /\[tas\]/
+      before_script:
+        - ${TAS_SCRIPTS}/start-compose.sh ${TAS_ENVIRONMENT}/docker-compose-cmis-tests.yml
+        - ${TAS_SCRIPTS}/wait-for-alfresco-start.sh "http://localhost:8082/alfresco"
+      script:
+        - travis_wait 40 mvn -B install -f tests/tas-cmis/pom.xml -Pall-tas-tests,run-cmis-atom -Denvironment=default -DrunBugs=false
 
-    # - name: "CMIS TAS tests - WEBSERVICES binding"
-    #   if: commit_message =~ /\[tas\]/
-    #   before_script:
-    #     - ${TAS_SCRIPTS}/start-compose.sh ${TAS_ENVIRONMENT}/docker-compose-cmis-tests.yml
-    #     - ${TAS_SCRIPTS}/wait-for-alfresco-start.sh "http://localhost:8082/alfresco"
-    #   script:
-    #     - travis_wait 40 mvn -B install -f tests/tas-cmis/pom.xml -Pall-tas-tests,run-cmis-webservices -Denvironment=default -DrunBugs=false
+    - name: "CMIS TAS tests - WEBSERVICES binding"
+      if: commit_message =~ /\[tas\]/
+      before_script:
+        - ${TAS_SCRIPTS}/start-compose.sh ${TAS_ENVIRONMENT}/docker-compose-cmis-tests.yml
+        - ${TAS_SCRIPTS}/wait-for-alfresco-start.sh "http://localhost:8082/alfresco"
+      script:
+        - travis_wait 40 mvn -B install -f tests/tas-cmis/pom.xml -Pall-tas-tests,run-cmis-webservices -Denvironment=default -DrunBugs=false
 
-    # - name: "Email TAS tests"
-    #   if: commit_message =~ /\[tas\]/
-    #   before_script:
-    #     - ${TAS_SCRIPTS}/start-compose.sh ${TAS_ENVIRONMENT}/docker-compose-email-tests.yml
-    #     - ${TAS_SCRIPTS}/wait-for-alfresco-start.sh "http://localhost:8082/alfresco"
-    #   script:
-    #     - travis_wait 30 mvn -B install -f tests/tas-email/pom.xml -Pall-tas-tests -Denvironment=default -DrunBugs=false
+    - name: "Email TAS tests"
+      if: commit_message =~ /\[tas\]/
+      before_script:
+        - ${TAS_SCRIPTS}/start-compose.sh ${TAS_ENVIRONMENT}/docker-compose-email-tests.yml
+        - ${TAS_SCRIPTS}/wait-for-alfresco-start.sh "http://localhost:8082/alfresco"
+      script:
+        - travis_wait 30 mvn -B install -f tests/tas-email/pom.xml -Pall-tas-tests -Denvironment=default -DrunBugs=false
 
-    # - name: "WebDAV TAS tests"
-    #   if: commit_message =~ /\[tas\]/
-    #   before_script:
-    #     - ${TAS_SCRIPTS}/start-compose.sh ${TAS_ENVIRONMENT}/docker-compose-minimal.yml
-    #     - ${TAS_SCRIPTS}/wait-for-alfresco-start.sh "http://localhost:8082/alfresco"
-    #   script:
-    #     - travis_wait 20 mvn -B install -f tests/tas-webdav/pom.xml -Pall-tas-tests -Denvironment=default -DrunBugs=false
+    - name: "WebDAV TAS tests"
+      if: commit_message =~ /\[tas\]/
+      before_script:
+        - ${TAS_SCRIPTS}/start-compose.sh ${TAS_ENVIRONMENT}/docker-compose-minimal.yml
+        - ${TAS_SCRIPTS}/wait-for-alfresco-start.sh "http://localhost:8082/alfresco"
+      script:
+        - travis_wait 20 mvn -B install -f tests/tas-webdav/pom.xml -Pall-tas-tests -Denvironment=default -DrunBugs=false
 
-    # - name: "Integration TAS tests"
-    #   if: commit_message =~ /\[tas\]/
-    #   before_script:
-    #     - ${TAS_SCRIPTS}/start-compose.sh ${TAS_ENVIRONMENT}/docker-compose-integration-tests.yml
-    #     - ${TAS_SCRIPTS}/wait-for-alfresco-start.sh "http://localhost:8082/alfresco"
-    #   script:
-    #     - travis_wait 30 mvn -B install -f tests/tas-integration/pom.xml -Pall-tas-tests -Denvironment=default -DrunBugs=false
+    - name: "Integration TAS tests"
+      if: commit_message =~ /\[tas\]/
+      before_script:
+        - ${TAS_SCRIPTS}/start-compose.sh ${TAS_ENVIRONMENT}/docker-compose-integration-tests.yml
+        - ${TAS_SCRIPTS}/wait-for-alfresco-start.sh "http://localhost:8082/alfresco"
+      script:
+        - travis_wait 30 mvn -B install -f tests/tas-integration/pom.xml -Pall-tas-tests -Denvironment=default -DrunBugs=false
 
-    # - name: "LDAP TAS tests"
-    #   if: commit_message =~ /\[tas\]/
-    #   before_script:
-    #     - ${TAS_SCRIPTS}/start-compose.sh ${TAS_ENVIRONMENT}/docker-compose-with-ldap.yml
-    #     - ${TAS_SCRIPTS}/wait-for-alfresco-start.sh "http://localhost:8082/alfresco"
-    #   script:
-    #     - travis_wait 60 mvn -B install -f tests/tas-restapi/pom.xml -Pall-tas-tests,run-restapi-ldap -Denvironment=default -DrunBugs=false
-    #     - travis_wait 10 mvn -B install -f tests/tas-integration/pom.xml -Prun-ldap -Denvironment=default -DrunBugs=false
+    - name: "LDAP TAS tests"
+      if: commit_message =~ /\[tas\]/
+      before_script:
+        - ${TAS_SCRIPTS}/start-compose.sh ${TAS_ENVIRONMENT}/docker-compose-with-ldap.yml
+        - ${TAS_SCRIPTS}/wait-for-alfresco-start.sh "http://localhost:8082/alfresco"
+      script:
+        - travis_wait 60 mvn -B install -f tests/tas-restapi/pom.xml -Pall-tas-tests,run-restapi-ldap -Denvironment=default -DrunBugs=false
+        - travis_wait 10 mvn -B install -f tests/tas-integration/pom.xml -Prun-ldap -Denvironment=default -DrunBugs=false
 
-    # - name: "REST API TAS tests with AIMS"
-    #   if: fork = false # AIMS docker image requires access to quay.io
-    #   before_script:
-    #     # AIMS cannot be configured via localhost
-    #     - export HOST_IP=$(hostname  -I | cut -f1 -d' ')
-    #     - ${TAS_SCRIPTS}/start-compose.sh ${TAS_ENVIRONMENT}/docker-compose-aims.yml
-    #     - ${TAS_SCRIPTS}/wait-for-alfresco-start.sh "http://localhost:8082/alfresco" 180
-    #   script:
-    #     - travis_wait 60 mvn -B install -f tests/tas-restapi/pom.xml -Pall-tas-tests,run-restapi-aims -Denvironment=aims-environment -DrunBugs=false "-Didentity-service.auth-server-url=http://${HOST_IP}:8999/auth"
+    - name: "REST API TAS tests with AIMS"
+      if: fork = false # AIMS docker image requires access to quay.io
+      before_script:
+        # AIMS cannot be configured via localhost
+        - export HOST_IP=$(hostname  -I | cut -f1 -d' ')
+        - ${TAS_SCRIPTS}/start-compose.sh ${TAS_ENVIRONMENT}/docker-compose-aims.yml
+        - ${TAS_SCRIPTS}/wait-for-alfresco-start.sh "http://localhost:8082/alfresco" 180
+      script:
+        - travis_wait 60 mvn -B install -f tests/tas-restapi/pom.xml -Pall-tas-tests,run-restapi-aims -Denvironment=aims-environment -DrunBugs=false "-Didentity-service.auth-server-url=http://${HOST_IP}:8999/auth"
 
-    # - name: "CMIS TAS tests with AIMS - BROWSER binding"
-    #   if: fork = false # AIMS docker image requires access to quay.io
-    #   before_script:
-    #     # AIMS cannot be configured via localhost
-    #     - export HOST_IP=$(hostname  -I | cut -f1 -d' ')
-    #     - ${TAS_SCRIPTS}/start-compose.sh ${TAS_ENVIRONMENT}/docker-compose-aims.yml
-    #     - ${TAS_SCRIPTS}/wait-for-alfresco-start.sh "http://localhost:8082/alfresco" 180
-    #   script:
-    #     - travis_wait 40 mvn -B install -f tests/tas-cmis/pom.xml -Pall-tas-tests,run-cmis-browser-with-aims -Denvironment=aims-environment -DrunBugs=false "-Didentity-service.auth-server-url=http://${HOST_IP}:8999/auth"
+    - name: "CMIS TAS tests with AIMS - BROWSER binding"
+      if: fork = false # AIMS docker image requires access to quay.io
+      before_script:
+        # AIMS cannot be configured via localhost
+        - export HOST_IP=$(hostname  -I | cut -f1 -d' ')
+        - ${TAS_SCRIPTS}/start-compose.sh ${TAS_ENVIRONMENT}/docker-compose-aims.yml
+        - ${TAS_SCRIPTS}/wait-for-alfresco-start.sh "http://localhost:8082/alfresco" 180
+      script:
+        - travis_wait 40 mvn -B install -f tests/tas-cmis/pom.xml -Pall-tas-tests,run-cmis-browser-with-aims -Denvironment=aims-environment -DrunBugs=false "-Didentity-service.auth-server-url=http://${HOST_IP}:8999/auth"
 
-    # - name: "CMIS TAS tests with AIMS - ATOM binding"
-    #   if: fork = false # AIMS docker image requires access to quay.io
-    #   before_script:
-    #     # AIMS cannot be configured via localhost
-    #     - export HOST_IP=$(hostname  -I | cut -f1 -d' ')
-    #     - ${TAS_SCRIPTS}/start-compose.sh ${TAS_ENVIRONMENT}/docker-compose-aims.yml
-    #     - ${TAS_SCRIPTS}/wait-for-alfresco-start.sh "http://localhost:8082/alfresco" 180
-    #   script:
-    #     - travis_wait 40 mvn -B install -f tests/tas-cmis/pom.xml -Pall-tas-tests,run-cmis-atom-with-aims -Denvironment=aims-environment -DrunBugs=false "-Didentity-service.auth-server-url=http://${HOST_IP}:8999/auth"
+    - name: "CMIS TAS tests with AIMS - ATOM binding"
+      if: fork = false # AIMS docker image requires access to quay.io
+      before_script:
+        # AIMS cannot be configured via localhost
+        - export HOST_IP=$(hostname  -I | cut -f1 -d' ')
+        - ${TAS_SCRIPTS}/start-compose.sh ${TAS_ENVIRONMENT}/docker-compose-aims.yml
+        - ${TAS_SCRIPTS}/wait-for-alfresco-start.sh "http://localhost:8082/alfresco" 180
+      script:
+        - travis_wait 40 mvn -B install -f tests/tas-cmis/pom.xml -Pall-tas-tests,run-cmis-atom-with-aims -Denvironment=aims-environment -DrunBugs=false "-Didentity-service.auth-server-url=http://${HOST_IP}:8999/auth"
 
 #    Enable job after Camel upgrade -> https://alfresco.atlassian.net/browse/DESKTOPAPP-539
 #    - name: "Sync Service TAS tests"
@@ -166,21 +166,21 @@ jobs:
 #      script:
 #        - travis_wait 20 mvn -B install -f tests/tas-sync-service/pom.xml -Pall-tas-tests -Denvironment=default -DrunBugs=false
 
-    # - name: "Elasticsearch TAS tests"
-    #   before_script:
-    #     - ${TAS_SCRIPTS}/start-compose.sh ${TAS_ENVIRONMENT}/docker-compose-elasticsearch.yml
-    #     - ${TAS_SCRIPTS}/wait-for-alfresco-start.sh "http://localhost:8082/alfresco"
-    #   script:
-    #     - travis_wait 30 mvn -B install -f tests/tas-elasticsearch/pom.xml -Pall-tas-tests -Denvironment=default -DrunBugs=false
+    - name: "Elasticsearch TAS tests"
+      before_script:
+        - ${TAS_SCRIPTS}/start-compose.sh ${TAS_ENVIRONMENT}/docker-compose-elasticsearch.yml
+        - ${TAS_SCRIPTS}/wait-for-alfresco-start.sh "http://localhost:8082/alfresco"
+      script:
+        - travis_wait 30 mvn -B install -f tests/tas-elasticsearch/pom.xml -Pall-tas-tests -Denvironment=default -DrunBugs=false
 
-    # - name: "All AMPs tests"
-    #   before_script:
-    #     - travis_retry travis_wait 20 mvn -B -q install -f tests/tas-all-amps/pom.xml -DskipTests -Pall-tas-tests,prepare-wars-with-amps
-    #   script:
-    #     - ./tests/scripts/checkLibraryDuplicates.sh ./tests/tas-all-amps/target/war/alfresco/WEB-INF/lib
-    #     - ${TAS_SCRIPTS}/start-compose.sh ${TAS_ENVIRONMENT}/docker-compose-all-amps-test.yml
-    #     - ${TAS_SCRIPTS}/wait-for-alfresco-start.sh "http://localhost:8082/alfresco"
-    #     - travis_wait 20 mvn -B install -f tests/tas-all-amps/pom.xml -Pall-tas-tests -Denvironment=default -DrunBugs=false
+    - name: "All AMPs tests"
+      before_script:
+        - travis_retry travis_wait 20 mvn -B -q install -f tests/tas-all-amps/pom.xml -DskipTests -Pall-tas-tests,prepare-wars-with-amps
+      script:
+        - ./tests/scripts/checkLibraryDuplicates.sh ./tests/tas-all-amps/target/war/alfresco/WEB-INF/lib
+        - ${TAS_SCRIPTS}/start-compose.sh ${TAS_ENVIRONMENT}/docker-compose-all-amps-test.yml
+        - ${TAS_SCRIPTS}/wait-for-alfresco-start.sh "http://localhost:8082/alfresco"
+        - travis_wait 20 mvn -B install -f tests/tas-all-amps/pom.xml -Pall-tas-tests -Denvironment=default -DrunBugs=false
 
     # Test local repo and share docker images that will be used in the single pipeline. Tag:latest
     - name: "Single Pipeline image tests"
@@ -203,46 +203,46 @@ jobs:
         - cd dtas
         - pytest --configuration ../tests/pipeline-all-amps/repo/target/dtas/dtas-config.json tests/ -s
 
-    # - name: "Update latest and Single Pipeline <acs>-<build> images"
-    #   stage: docker_latest
-    #   # Remove the pipeline profile to avoid sending an image tagged with the build number to the single pipeline
-    #   script: travis_retry travis_wait 30 mvn -B -V clean install -DskipTests -Dmaven.javadoc.skip=true -Dbuild-number=${TRAVIS_BUILD_NUMBER} -Pinternal,pipeline
+    - name: "Update latest and Single Pipeline <acs>-<build> images"
+      stage: docker_latest
+      # Remove the pipeline profile to avoid sending an image tagged with the build number to the single pipeline
+      script: travis_retry travis_wait 30 mvn -B -V clean install -DskipTests -Dmaven.javadoc.skip=true -Dbuild-number=${TRAVIS_BUILD_NUMBER} -Pinternal,pipeline
 
-    # - name: "Release and Copy to S3 Staging Bucket"
-    #   stage: release
-    #   before_script: bash scripts/travis/verify_release_tag.sh
-    #   script: travis_wait 60 bash scripts/travis/maven_release.sh
-    #   before_deploy:
-    #     # Move the final artifacts to a single folder (deploy_dir) to be copied to S3
-    #     - mkdir -p deploy_dir
-    #     - cp distribution/target/alfresco.war deploy_dir
-    #     - cp distribution/target/*-distribution*.zip deploy_dir
-    #     - ls -lA deploy_dir
-    #   deploy:
-    #     - provider: s3
-    #       access_key_id: "${AWS_STAGING_ACCESS_KEY}"
-    #       secret_access_key: "${AWS_STAGING_SECRET_KEY}"
-    #       bucket: "alfresco-artefacts-staging"
-    #       region: "eu-west-1"
-    #       # Once Travis releases their *dpl v2* api (currently in beta, check https://docs.travis-ci.com/user/deployment-v2#how-to-opt-in-to-v2)
-    #       # the skip_cleanup option will no longer be needed (or valid) and should be removed (ACS-1155).
-    #       skip_cleanup: true
-    #       acl: private
-    #       local_dir: "deploy_dir"
-    #       upload_dir: "alfresco-content-services/release/${TRAVIS_BRANCH}/${TRAVIS_BUILD_NUMBER}"
-    #       on:
-    #         all_branches: true
-    #   after_deploy:
-    #     - echo "Finished release and deployed to https://s3.console.aws.amazon.com/s3/buckets/alfresco-artefacts-staging/alfresco-content-services/release/${TRAVIS_BRANCH}/${TRAVIS_BUILD_NUMBER}"
+    - name: "Release and Copy to S3 Staging Bucket"
+      stage: release
+      before_script: bash scripts/travis/verify_release_tag.sh
+      script: travis_wait 60 bash scripts/travis/maven_release.sh
+      before_deploy:
+        # Move the final artifacts to a single folder (deploy_dir) to be copied to S3
+        - mkdir -p deploy_dir
+        - cp distribution/target/alfresco.war deploy_dir
+        - cp distribution/target/*-distribution*.zip deploy_dir
+        - ls -lA deploy_dir
+      deploy:
+        - provider: s3
+          access_key_id: "${AWS_STAGING_ACCESS_KEY}"
+          secret_access_key: "${AWS_STAGING_SECRET_KEY}"
+          bucket: "alfresco-artefacts-staging"
+          region: "eu-west-1"
+          # Once Travis releases their *dpl v2* api (currently in beta, check https://docs.travis-ci.com/user/deployment-v2#how-to-opt-in-to-v2)
+          # the skip_cleanup option will no longer be needed (or valid) and should be removed (ACS-1155).
+          skip_cleanup: true
+          acl: private
+          local_dir: "deploy_dir"
+          upload_dir: "alfresco-content-services/release/${TRAVIS_BRANCH}/${TRAVIS_BUILD_NUMBER}"
+          on:
+            all_branches: true
+      after_deploy:
+        - echo "Finished release and deployed to https://s3.console.aws.amazon.com/s3/buckets/alfresco-artefacts-staging/alfresco-content-services/release/${TRAVIS_BRANCH}/${TRAVIS_BUILD_NUMBER}"
 
-    # - name: "Copy to S3 Release Bucket"
-    #   stage: publish
-    #   # Nothing to build/install as we are just copying from S3 buckets
-    #   install: skip
-    #   script: skip
-    #   before_deploy: pip install awscli
-    #   deploy:
-    #     - provider: script
-    #       script: bash scripts/travis/copy_to_release_bucket.sh
-    #       on:
-    #         all_branches: true
+    - name: "Copy to S3 Release Bucket"
+      stage: publish
+      # Nothing to build/install as we are just copying from S3 buckets
+      install: skip
+      script: skip
+      before_deploy: pip install awscli
+      deploy:
+        - provider: script
+          script: bash scripts/travis/copy_to_release_bucket.sh
+          on:
+            all_branches: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -185,16 +185,22 @@ jobs:
     # Test local repo and share docker images that will be used in the single pipeline. Tag:latest
     - name: "Single Pipeline image tests"
       if: fork = false AND type != pull_request
-      # before_install:
-      #   - git clone --depth 1 --branch v1.0-M1 https://${GIT_USERNAME}:${GIT_PASSWORD}@github.com/Alfresco/alfresco-deployment-test-automation-scripts.git dtas
+      before_install:
+        - git clone --depth 1 --branch v1.0-M1 https://${GIT_USERNAME}:${GIT_PASSWORD}@github.com/Alfresco/alfresco-deployment-test-automation-scripts.git dtas
       before_script:
         - travis_retry travis_wait 20 mvn -B clean install -Ppipeline,local $(mvn -B -q help:evaluate "-Dexpression=dependency.alfresco-enterprise-repo.version" -DforceStdout | grep -q '\-SNAPSHOT$' && echo '-Drepo.image.tag=latest')
+      install:
+        - pyenv versions
+        - pyenv global 3.7.1
+        - pip install pytest
       script:
-        - cloneRepo "github.com/Alfresco/alfresco-deployment-test-automation-scripts.git" "v1.0-M1"
         - ls -hal
         - ${TAS_SCRIPTS}/start-compose.sh ${TAS_ENVIRONMENT}/docker-compose-pipeline-all-amps.yml
         - ${TAS_SCRIPTS}/wait-for-alfresco-start.sh "http://localhost:8080/alfresco"
         - docker ps
+        # Run smoke tests against the system using DTAS
+        - cd dtas
+        - pytest --verbose --configuration ${TAS_ENVIRONMENT}/dtas-config.json tests/ -s
 
     # - name: "Update latest and Single Pipeline <acs>-<build> images"
     #   stage: docker_latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -194,15 +194,13 @@ jobs:
       script:
         - ${TAS_SCRIPTS}/start-compose.sh ${TAS_ENVIRONMENT}/docker-compose-pipeline-all-amps.yml
         - ${TAS_SCRIPTS}/wait-for-alfresco-start.sh "http://localhost:8080/alfresco/api/-default-/public/alfresco/versions/1/probes/-live-"
-        - docker ps
-        - ALFCONTAINER=`docker ps -a | grep _alfresco | awk '{ print $1 }'`
-        - echo "Last 300 lines from alfresco.log on container $ALFCONTAINER:"
-        - docker logs --tail=300 $ALFCONTAINER
+        # - docker ps
+        # - ALFCONTAINER=`docker ps -a | grep _alfresco | awk '{ print $1 }'`
+        # - echo "Last 300 lines from alfresco.log on container $ALFCONTAINER:"
+        # - docker logs --tail=300 $ALFCONTAINER
         # Run smoke tests against the system using DTAS
-        - ls -hal
+        # - ls -hal
         - cd dtas
-        # - curl -v http://localhost:8080/alfresco/api/-default-/public/alfresco/versions/1/probes/-live-
-        - curl -v http://localhost:8080/alfresco/
         - pytest --verbose --configuration ../tests/environment/dtas-config.json tests/ -s
 
     # - name: "Update latest and Single Pipeline <acs>-<build> images"

--- a/.travis.yml
+++ b/.travis.yml
@@ -197,7 +197,7 @@ jobs:
         - docker ps
         # Run smoke tests against the system using DTAS
         - cd dtas
-        - pytest --verbose --configuration ${TAS_ENVIRONMENT}/dtas-config.json tests/ -s
+        - pytest --verbose --configuration ../tests/environment/dtas-config.json tests/ -s
 
     # - name: "Update latest and Single Pipeline <acs>-<build> images"
     #   stage: docker_latest

--- a/tests/environment/docker-compose-pipeline-all-amps.yml
+++ b/tests/environment/docker-compose-pipeline-all-amps.yml
@@ -174,24 +174,24 @@ services:
             - alfresco
             - share
 
-    sync-service:
-        image: quay.io/alfresco/service-sync:3.3.3
-        mem_limit: 1g
-        environment:
-            JAVA_OPTS : "
-            -Dsql.db.driver=org.postgresql.Driver
-            -Dsql.db.url=jdbc:postgresql://postgres:5432/alfresco
-            -Dsql.db.username=alfresco
-            -Dsql.db.password=alfresco
-            -Dmessaging.broker.host=activemq
-            -Drepo.hostname=alfresco
-            -Drepo.port=8080
-            -Ddw.server.applicationConnectors[0].type=http
-            -Xms1000m -Xmx1000m
-            "
+    # sync-service:
+    #     image: quay.io/alfresco/service-sync:3.3.3
+    #     mem_limit: 1g
+    #     environment:
+    #         JAVA_OPTS : "
+    #         -Dsql.db.driver=org.postgresql.Driver
+    #         -Dsql.db.url=jdbc:postgresql://postgres:5432/alfresco
+    #         -Dsql.db.username=alfresco
+    #         -Dsql.db.password=alfresco
+    #         -Dmessaging.broker.host=activemq
+    #         -Drepo.hostname=alfresco
+    #         -Drepo.port=8080
+    #         -Ddw.server.applicationConnectors[0].type=http
+    #         -Xms1000m -Xmx1000m
+    #         "
 
-        ports:
-            - 9090:9090
+    #     ports:
+    #         - 9090:9090
 
 volumes:
     shared-file-store-volume:

--- a/tests/environment/docker-compose-pipeline-all-amps.yml
+++ b/tests/environment/docker-compose-pipeline-all-amps.yml
@@ -155,7 +155,7 @@ services:
             - 61613:61613 # STOMP
 
     digital-workspace:
-        image: quay.io/alfresco/alfresco-digital-workspace:1.6.0
+        image: quay.io/alfresco/alfresco-digital-workspace:2.0.0-adw
         mem_limit: 128m
         environment:
             BASE_PATH: ./
@@ -173,24 +173,24 @@ services:
             - alfresco
             - share
 
-    # sync-service:
-    #     image: quay.io/alfresco/service-sync:3.3.3
-    #     mem_limit: 1g
-    #     environment:
-    #         JAVA_OPTS : "
-    #         -Dsql.db.driver=org.postgresql.Driver
-    #         -Dsql.db.url=jdbc:postgresql://postgres:5432/alfresco
-    #         -Dsql.db.username=alfresco
-    #         -Dsql.db.password=alfresco
-    #         -Dmessaging.broker.host=activemq
-    #         -Drepo.hostname=alfresco
-    #         -Drepo.port=8080
-    #         -Ddw.server.applicationConnectors[0].type=http
-    #         -Xms1000m -Xmx1000m
-    #         "
+    sync-service:
+        image: quay.io/alfresco/service-sync:3.3.3
+        mem_limit: 1g
+        environment:
+            JAVA_OPTS : "
+            -Dsql.db.driver=org.postgresql.Driver
+            -Dsql.db.url=jdbc:postgresql://postgres:5432/alfresco
+            -Dsql.db.username=alfresco
+            -Dsql.db.password=alfresco
+            -Dmessaging.broker.host=activemq
+            -Drepo.hostname=alfresco
+            -Drepo.port=8080
+            -Ddw.server.applicationConnectors[0].type=http
+            -Xms1000m -Xmx1000m
+            "
 
-    #     ports:
-    #         - 9090:9090
+        ports:
+            - 9090:9090
 
 volumes:
     shared-file-store-volume:

--- a/tests/environment/docker-compose-pipeline-all-amps.yml
+++ b/tests/environment/docker-compose-pipeline-all-amps.yml
@@ -30,8 +30,7 @@ services:
                 -Ddb.username=alfresco
                 -Ddb.password=alfresco
                 -Ddb.url=jdbc:postgresql://postgres:5432/alfresco
-                -Dalfresco_user_store.adminpassword=1008c2a7bffe1567fe2141c212a67653
-                -Dalfresco_user_store.adminusername=admin.adf@alfresco.com
+                -Dalfresco_user_store.adminusername=admin.pipeline@alfresco.com
                 -Dsolr.host=solr6
                 -Dsolr.port=8983
                 -Dsolr.secureComms=none

--- a/tests/environment/docker-compose-pipeline-all-amps.yml
+++ b/tests/environment/docker-compose-pipeline-all-amps.yml
@@ -50,8 +50,8 @@ services:
                 -DlocalTransform.core-aio.url=http://transform-core-aio:8090/
                 -Dcsrf.filter.enabled=false
                 -Ddsync.service.uris=http://localhost:9090/alfresco
-                -Ds3.accessKey=${AWS_ACCESS_KEY_ID}
-                -Ds3.secretKey=${AWS_SECRET_ACCESS_KEY}
+                -Ds3.accessKey=${AWS_ACCESS_KEY}
+                -Ds3.secretKey=${AWS_SECRET_KEY}
                 -Ds3.bucketName=pipeline-amps-all
                 -Ds3.autoLowerCaseBucketName=true
                 -Ds3.bucketLocation=us-east-1

--- a/tests/environment/dtas-config.json
+++ b/tests/environment/dtas-config.json
@@ -1,7 +1,7 @@
 {
     "config": {
         "host": "http://localhost:8080",
-        "username": "admin",
+        "username": "admin.pipeline@alfresco.com",
         "password": "admin"
     },
     "assertions": {
@@ -11,24 +11,69 @@
             "identity": false,
             "modules": [
                 {
+                    "name": "Alfresco Share Services AMP",
+                    "version": "7.0.0-M3",
+                    "installed": true
+                },
+                {
+                    "name": "alfresco-trashcan-cleaner project",
+                    "version": "2.3",
+                    "installed": true
+                },
+                {
                     "name": "Alfresco / Google Docs Integration",
                     "version": "3.2.0",
                     "installed": true
                 },
                 {
                     "name": "Alfresco Office Services Module",
-                    "version": "1.3.1",
+                    "version": "1.4.0-M1",
                     "installed": true
                 },
                 {
                     "name": "Alfresco Device Sync Amp",
-                    "version": "3.3.3",
+                    "version": "3.3.3.1",
+                    "installed": true
+                },
+                {
+                    "name": "AGS Repo",
+                    "version": "3.5.0",
                     "installed": true
                 },
                 {
                     "name": "AGS Enterprise Repo",
-                    "version": "3.5.0-M1",
-                    "installed": false
+                    "version": "3.5.0",
+                    "installed": true
+                },
+                {
+                    "name": "Alfresco SAML Repository AMP Module",
+                    "version": "1.2.1",
+                    "installed": true
+                },
+                {
+                    "name": "Alfresco Glacier Connector Repo",
+                    "version": "2.1.0",
+                    "installed": true
+                },
+                {
+                    "name": "S3 Connector",
+                    "version": "3.1.0",
+                    "installed": true
+                },
+                {
+                    "name": "Alfresco Intelligence Services Repository AMP",
+                    "version": "1.2.1",
+                    "installed": true
+                },
+                {
+                    "name": "Alfresco Content Connector for Azure",
+                    "version": "1.2.0",
+                    "installed": true
+                },
+                {
+                    "name": "Alfresco Content Connector for Salesforce Repository AMP",
+                    "version": "2.2.1-M1",
+                    "installed": true
                 }
             ]
         },

--- a/tests/environment/dtas-config.json
+++ b/tests/environment/dtas-config.json
@@ -22,7 +22,7 @@
                 },
                 {
                     "name": "Alfresco Device Sync Amp",
-                    "version": "3.4.0-M2",
+                    "version": "3.3.3",
                     "installed": true
                 },
                 {
@@ -33,7 +33,7 @@
             ]
         },
         "adw": {
-            "version": "2.0.0"
+            "version": "1.6.0"
         }
     }
 }

--- a/tests/environment/dtas-config.json
+++ b/tests/environment/dtas-config.json
@@ -1,0 +1,39 @@
+{
+    "config": {
+        "host": "http://localhost:8080",
+        "username": "admin",
+        "password": "admin"
+    },
+    "assertions": {
+        "acs": {
+            "edition": "Enterprise",
+            "version": "7.0.0",
+            "identity": false,
+            "modules": [
+                {
+                    "name": "Alfresco / Google Docs Integration",
+                    "version": "3.2.0",
+                    "installed": true
+                },
+                {
+                    "name": "Alfresco Office Services Module",
+                    "version": "1.3.1",
+                    "installed": true
+                },
+                {
+                    "name": "Alfresco Device Sync Amp",
+                    "version": "3.4.0-M2",
+                    "installed": true
+                },
+                {
+                    "name": "AGS Enterprise Repo",
+                    "version": "3.5.0-M1",
+                    "installed": false
+                }
+            ]
+        },
+        "adw": {
+            "version": "2.0.0"
+        }
+    }
+}

--- a/tests/pipeline-all-amps/repo/dtas/dtas-config.json
+++ b/tests/pipeline-all-amps/repo/dtas/dtas-config.json
@@ -12,27 +12,27 @@
             "modules": [
                 {
                     "name": "Alfresco Share Services AMP",
-                    "version": "7.0.0-M3",
+                    "version": "${alfresco.alfresco-share-services.version}",
                     "installed": true
                 },
                 {
                     "name": "alfresco-trashcan-cleaner project",
-                    "version": "2.3",
+                    "version": "${dependency.alfresco-trashcan-cleaner.version}",
                     "installed": true
                 },
                 {
                     "name": "Alfresco / Google Docs Integration",
-                    "version": "3.2.0",
+                    "version": "${alfresco.googledrive.version}",
                     "installed": true
                 },
                 {
                     "name": "Alfresco Office Services Module",
-                    "version": "1.4.0-M1",
+                    "version": "${alfresco.aos-module.version}",
                     "installed": true
                 },
                 {
                     "name": "Alfresco Device Sync Amp",
-                    "version": "3.3.3.1",
+                    "version": "${alfresco.desktop-sync.version}",
                     "installed": true
                 },
                 {
@@ -47,38 +47,38 @@
                 },
                 {
                     "name": "Alfresco SAML Repository AMP Module",
-                    "version": "1.2.1",
+                    "version": "${alfresco.saml.version}",
                     "installed": true
                 },
                 {
                     "name": "Alfresco Glacier Connector Repo",
-                    "version": "2.1.0",
+                    "version": "${alfresco.glacier-connector.version}",
                     "installed": true
                 },
                 {
                     "name": "S3 Connector",
-                    "version": "3.1.0",
+                    "version": "${alfresco.s3connector.version}",
                     "installed": true
                 },
                 {
                     "name": "Alfresco Intelligence Services Repository AMP",
-                    "version": "1.2.1",
+                    "version": "${alfresco.ais.version}",
                     "installed": true
                 },
                 {
                     "name": "Alfresco Content Connector for Azure",
-                    "version": "1.2.0",
+                    "version": "${alfresco.azure-connector.version}",
                     "installed": true
                 },
                 {
                     "name": "Alfresco Content Connector for Salesforce Repository AMP",
-                    "version": "2.2.1-M1",
+                    "version": "${alfresco.salesforce-connector.version}",
                     "installed": true
                 }
             ]
         },
         "adw": {
-            "version": "1.6.0"
+            "version": "2.0.0"
         }
     }
 }

--- a/tests/pipeline-all-amps/repo/pom.xml
+++ b/tests/pipeline-all-amps/repo/pom.xml
@@ -15,6 +15,29 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>3.2.0</version>
+                <executions>
+                    <execution>
+                        <id>copy-dtas-config</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${basedir}/target/dtas</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>dtas</directory>
+                                    <filtering>true</filtering>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <executions>
                     <execution>

--- a/tests/pipeline-all-amps/repo/pom.xml
+++ b/tests/pipeline-all-amps/repo/pom.xml
@@ -124,6 +124,7 @@
                                     <outputDirectory>${project.build.directory}/amps</outputDirectory>
                                 </artifactItem>
                                 <!-- Do not comment out, as this will cause problems in the Single Pipeline. -->
+                                <!--
                                 <artifactItem>
                                     <groupId>org.alfresco.services.sync</groupId>
                                     <artifactId>alfresco-device-sync-repo</artifactId>
@@ -132,6 +133,7 @@
                                     <overWrite>false</overWrite>
                                     <outputDirectory>${project.build.directory}/amps</outputDirectory>
                                 </artifactItem>
+                                -->
                             </artifactItems>
                         </configuration>
                     </execution>

--- a/tests/pipeline-all-amps/repo/pom.xml
+++ b/tests/pipeline-all-amps/repo/pom.xml
@@ -106,14 +106,14 @@
                                     <outputDirectory>${project.build.directory}/amps</outputDirectory>
                                 </artifactItem>
                                 <!-- Do not comment out, as this will cause problems in the Single Pipeline. -->
-                                <artifactItem>
+                                <!-- <artifactItem>
                                     <groupId>org.alfresco</groupId>
                                     <artifactId>alfresco-centera-connector</artifactId>
                                     <version>${alfresco.centera-connector.version}</version>
                                     <type>amp</type>
                                     <overWrite>false</overWrite>
                                     <outputDirectory>${project.build.directory}/amps</outputDirectory>
-                                </artifactItem>
+                                </artifactItem> -->
                                 <!-- Do not comment out, as this will cause problems in the Single Pipeline. -->
                                 <artifactItem>
                                     <groupId>org.alfresco.integrations</groupId>

--- a/tests/pipeline-all-amps/repo/pom.xml
+++ b/tests/pipeline-all-amps/repo/pom.xml
@@ -106,15 +106,6 @@
                                     <outputDirectory>${project.build.directory}/amps</outputDirectory>
                                 </artifactItem>
                                 <!-- Do not comment out, as this will cause problems in the Single Pipeline. -->
-                                <!-- <artifactItem>
-                                    <groupId>org.alfresco</groupId>
-                                    <artifactId>alfresco-centera-connector</artifactId>
-                                    <version>${alfresco.centera-connector.version}</version>
-                                    <type>amp</type>
-                                    <overWrite>false</overWrite>
-                                    <outputDirectory>${project.build.directory}/amps</outputDirectory>
-                                </artifactItem> -->
-                                <!-- Do not comment out, as this will cause problems in the Single Pipeline. -->
                                 <artifactItem>
                                     <groupId>org.alfresco.integrations</groupId>
                                     <artifactId>alfresco-content-connector-for-salesforce-repo</artifactId>
@@ -124,7 +115,6 @@
                                     <outputDirectory>${project.build.directory}/amps</outputDirectory>
                                 </artifactItem>
                                 <!-- Do not comment out, as this will cause problems in the Single Pipeline. -->
-                                <!--
                                 <artifactItem>
                                     <groupId>org.alfresco.services.sync</groupId>
                                     <artifactId>alfresco-device-sync-repo</artifactId>
@@ -133,7 +123,6 @@
                                     <overWrite>false</overWrite>
                                     <outputDirectory>${project.build.directory}/amps</outputDirectory>
                                 </artifactItem>
-                                -->
                             </artifactItems>
                         </configuration>
                     </execution>


### PR DESCRIPTION
- Removed Centera AMP as it's not used in the pipeline
- Fix S3 connector config & use custom admin username but default password
- Fixed startup script (was passing even though system was failing to start)
- Run DTAS after system is running

NOTE: The AGS AMP does not report the same version as the artefact version so it had to be hardcoded in DTAS config. Same for ACS version, but that shouldn't change as often.