### PR TITLE
SEARCH-2870: Re-enable Elasticsearch TAS Tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -165,12 +165,12 @@ jobs:
       script:
         - travis_wait 20 mvn -B install -f tests/tas-sync-service/pom.xml -Pall-tas-tests -Denvironment=default -DrunBugs=false
 
-    # - name: "Elasticsearch TAS tests"
-    #   before_script:
-    #     - ${TAS_SCRIPTS}/start-compose.sh ${TAS_ENVIRONMENT}/docker-compose-elasticsearch.yml
-    #     - ${TAS_SCRIPTS}/wait-for-alfresco-start.sh "http://localhost:8082/alfresco"
-    #   script:
-    #     - travis_wait 30 mvn -B install -f tests/tas-elasticsearch/pom.xml -Pall-tas-tests -Denvironment=default -DrunBugs=false
+    - name: "Elasticsearch TAS tests"
+      before_script:
+        - ${TAS_SCRIPTS}/start-compose.sh ${TAS_ENVIRONMENT}/docker-compose-elasticsearch.yml
+        - ${TAS_SCRIPTS}/wait-for-alfresco-start.sh "http://localhost:8082/alfresco"
+      script:
+        - travis_wait 30 mvn -B install -f tests/tas-elasticsearch/pom.xml -Pall-tas-tests -Denvironment=default -DrunBugs=false
 
     - name: "All AMPs tests"
       before_script:


### PR DESCRIPTION
Elasticsearch TAS Test can be re-enabled since SEARCH-2872 has been resolved.