### PR TITLE
SEARCH-2903 Use "quay.io/alfresco/alfresco-content-repository" Docker…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -165,9 +165,9 @@ jobs:
       script:
         - travis_wait 20 mvn -B install -f tests/tas-sync-service/pom.xml -Pall-tas-tests -Denvironment=default -DrunBugs=false
 
-    # - name: "Elasticsearch TAS tests"
-    #   script:
-    #     - travis_wait 30 mvn -B install -f tests/tas-elasticsearch/pom.xml -Pall-tas-tests -Denvironment=default -DrunBugs=false
+    - name: "Elasticsearch TAS tests"
+      script:
+        - travis_wait 30 mvn -B install -f tests/tas-elasticsearch/pom.xml -Pall-tas-tests -Denvironment=default -DrunBugs=false
 
     - name: "All AMPs tests"
       before_script:

--- a/tests/tas-elasticsearch/src/test/java/org/alfresco/elasticsearch/AlfrescoStackInitializer.java
+++ b/tests/tas-elasticsearch/src/test/java/org/alfresco/elasticsearch/AlfrescoStackInitializer.java
@@ -36,7 +36,7 @@ public class AlfrescoStackInitializer implements ApplicationContextInitializer<C
 
         network = Network.newNetwork();
 
-        alfresco = new GenericContainer("quay.io/alfresco/alfresco-content-repository:latest")
+        alfresco = new GenericContainer("alfresco/alfresco-content-repository:latest")
                            .withEnv("JAVA_TOOL_OPTIONS",
                                     "-Dencryption.keystore.type=JCEKS " +
                                     "-Dencryption.cipherAlgorithm=DESede/CBC/PKCS5Padding " +

--- a/tests/tas-elasticsearch/src/test/java/org/alfresco/elasticsearch/AlfrescoStackInitializer.java
+++ b/tests/tas-elasticsearch/src/test/java/org/alfresco/elasticsearch/AlfrescoStackInitializer.java
@@ -36,7 +36,7 @@ public class AlfrescoStackInitializer implements ApplicationContextInitializer<C
 
         network = Network.newNetwork();
 
-        alfresco = new GenericContainer("alfresco/alfresco-content-repository:latest")
+        alfresco = new GenericContainer("quay.io/alfresco/alfresco-content-repository:latest")
                            .withEnv("JAVA_TOOL_OPTIONS",
                                     "-Dencryption.keystore.type=JCEKS " +
                                     "-Dencryption.cipherAlgorithm=DESede/CBC/PKCS5Padding " +
@@ -71,7 +71,7 @@ public class AlfrescoStackInitializer implements ApplicationContextInitializer<C
                            .withNetworkAliases("alfresco")
                            .waitingFor(new LogMessageWaitStrategy()
                                                .withRegEx(".*Server startup in.*\\n")
-                                               .withStartupTimeout(Duration.ofSeconds(300)))
+                                               .withStartupTimeout(Duration.ofSeconds(400)))
                            .withExposedPorts(8080);
 
         GenericContainer transformRouter = new GenericContainer("quay.io/alfresco/alfresco-transform-router:" + env.getProperty("TRANSFORM_ROUTER_TAG"))


### PR DESCRIPTION
… Image for Elasticsearch TAS Test

Docker Image published to "alfresco/alfresco-content-repository" includes some wrong settings sometimes.
Increase waiting time for Alfresco Container.