### PR TITLE
APPS-1068 Enable docker updates for AGS latest images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -214,7 +214,7 @@ jobs:
     - name: "Update latest and Single Pipeline <acs>-<build> images"
       stage: docker_latest
       # Remove the pipeline profile to avoid sending an image tagged with the build number to the single pipeline
-      script: travis_retry travis_wait 30 mvn -B -V clean install -DskipTests -Dmaven.javadoc.skip=true -Dbuild-number=${TRAVIS_BUILD_NUMBER} -Ppush-docker-images,pipeline
+      script: travis_retry travis_wait 30 mvn -B -V clean install -DskipTests -Dmaven.javadoc.skip=true -Dbuild-number=${TRAVIS_BUILD_NUMBER} -Pags -Ppush-docker-images,pipeline
 
     - name: "Update release and Single Pipeline <acs>-<build> images"
       stage: docker_release


### PR DESCRIPTION
Enable the updating of AGS-specific images with the tag `latest` from the **master** branch (on Quay only):
* `quay.io/alfresco/alfresco-governance-repository-enterprise`
* `quay.io/alfresco/alfresco-governance-share-enterprise`

Access rights need to be granted to the Quay user on these two images.