### PR TITLE
ACS-2009 Alpha and Milestone releases are stored in internal nexus repository

### DIFF
--- a/.travis.settings.xml
+++ b/.travis.settings.xml
@@ -40,6 +40,11 @@
             <password>${env.MAVEN_PASSWORD}</password>
         </server>
         <server>
+            <id>alfresco-enterprise-releases</id>
+            <username>${env.MAVEN_USERNAME}</username>
+            <password>${env.MAVEN_PASSWORD}</password>
+        </server>
+        <server>
             <id>quay.io</id>
             <username>${env.QUAY_USERNAME}</username>
             <password>${env.QUAY_PASSWORD}</password>

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ env:
     - TAS_SCRIPTS=../alfresco-community-repo/packaging/tests/scripts
     - TAS_ENVIRONMENT=./tests/environment
     # Release version has to start with real version (7.2.0-....) for the docker image to build successfully.
-    - RELEASE_VERSION=7.2.0-A1
+    - RELEASE_VERSION=7.2.0-A2
     - DEVELOPMENT_VERSION=7.2.0-SNAPSHOT
     - DTAS_VERSION="${DTAS_VERSION:-v1.1}"
 
@@ -281,7 +281,7 @@ jobs:
       stage: publish
       # Nothing to build/install as we are just copying from S3 buckets
       install: skip
-      script: skip
+      script: travis_wait 60 bash scripts/travis/maven_publish.sh
       before_deploy: pip install awscli
       deploy:
         - provider: script

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,8 @@ env:
     - TAS_SCRIPTS=../alfresco-community-repo/packaging/tests/scripts
     - TAS_ENVIRONMENT=./tests/environment
     # Release version has to start with real version (7.2.0-....) for the docker image to build successfully.
-    - RELEASE_VERSION=7.2.0-A2
-    - DEVELOPMENT_VERSION=7.2.0-SNAPSHOT
+    - RELEASE_VERSION=7.2.0-A3
+    - DEVELOPMENT_VERSION=7.2.0-A4-SNAPSHOT
     - DTAS_VERSION="${DTAS_VERSION:-v1.1}"
 
 stages:

--- a/dev/dev-acs-amps-overlay/pom.xml
+++ b/dev/dev-acs-amps-overlay/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>alfresco-dev-tomcat-env</artifactId>
-        <version>7.2.0-SNAPSHOT</version>
+        <version>7.2.0-A2</version>
     </parent>
 
     <properties>

--- a/dev/dev-acs-amps-overlay/pom.xml
+++ b/dev/dev-acs-amps-overlay/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>alfresco-dev-tomcat-env</artifactId>
-        <version>7.2.0-SNAPSHOT</version>
+        <version>7.2.0-A3</version>
     </parent>
 
     <properties>

--- a/dev/dev-acs-amps-overlay/pom.xml
+++ b/dev/dev-acs-amps-overlay/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>alfresco-dev-tomcat-env</artifactId>
-        <version>7.2.0-A3</version>
+        <version>7.2.0-A4-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/dev/dev-acs-amps-overlay/pom.xml
+++ b/dev/dev-acs-amps-overlay/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>alfresco-dev-tomcat-env</artifactId>
-        <version>7.2.0-A2</version>
+        <version>7.2.0-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/dev/dev-repo-amps-overlay/pom.xml
+++ b/dev/dev-repo-amps-overlay/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>alfresco-dev-tomcat-env</artifactId>
-        <version>7.2.0-SNAPSHOT</version>
+        <version>7.2.0-A3</version>
     </parent>
 
     <build>

--- a/dev/dev-repo-amps-overlay/pom.xml
+++ b/dev/dev-repo-amps-overlay/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>alfresco-dev-tomcat-env</artifactId>
-        <version>7.2.0-A3</version>
+        <version>7.2.0-A4-SNAPSHOT</version>
     </parent>
 
     <build>

--- a/dev/dev-repo-amps-overlay/pom.xml
+++ b/dev/dev-repo-amps-overlay/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>alfresco-dev-tomcat-env</artifactId>
-        <version>7.2.0-A2</version>
+        <version>7.2.0-SNAPSHOT</version>
     </parent>
 
     <build>

--- a/dev/dev-repo-amps-overlay/pom.xml
+++ b/dev/dev-repo-amps-overlay/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>alfresco-dev-tomcat-env</artifactId>
-        <version>7.2.0-SNAPSHOT</version>
+        <version>7.2.0-A2</version>
     </parent>
 
     <build>

--- a/dev/dev-share-amps-overlay/pom.xml
+++ b/dev/dev-share-amps-overlay/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>alfresco-dev-tomcat-env</artifactId>
-        <version>7.2.0-SNAPSHOT</version>
+        <version>7.2.0-A3</version>
     </parent>
 
     <build>

--- a/dev/dev-share-amps-overlay/pom.xml
+++ b/dev/dev-share-amps-overlay/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>alfresco-dev-tomcat-env</artifactId>
-        <version>7.2.0-A3</version>
+        <version>7.2.0-A4-SNAPSHOT</version>
     </parent>
 
     <build>

--- a/dev/dev-share-amps-overlay/pom.xml
+++ b/dev/dev-share-amps-overlay/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>alfresco-dev-tomcat-env</artifactId>
-        <version>7.2.0-A2</version>
+        <version>7.2.0-SNAPSHOT</version>
     </parent>
 
     <build>

--- a/dev/dev-share-amps-overlay/pom.xml
+++ b/dev/dev-share-amps-overlay/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>alfresco-dev-tomcat-env</artifactId>
-        <version>7.2.0-SNAPSHOT</version>
+        <version>7.2.0-A2</version>
     </parent>
 
     <build>

--- a/dev/dev-tomcat/pom.xml
+++ b/dev/dev-tomcat/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>alfresco-dev-tomcat-env</artifactId>
-        <version>7.2.0-SNAPSHOT</version>
+        <version>7.2.0-A2</version>
     </parent>
 
     <properties>

--- a/dev/dev-tomcat/pom.xml
+++ b/dev/dev-tomcat/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>alfresco-dev-tomcat-env</artifactId>
-        <version>7.2.0-SNAPSHOT</version>
+        <version>7.2.0-A3</version>
     </parent>
 
     <properties>

--- a/dev/dev-tomcat/pom.xml
+++ b/dev/dev-tomcat/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>alfresco-dev-tomcat-env</artifactId>
-        <version>7.2.0-A2</version>
+        <version>7.2.0-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/dev/dev-tomcat/pom.xml
+++ b/dev/dev-tomcat/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>alfresco-dev-tomcat-env</artifactId>
-        <version>7.2.0-A3</version>
+        <version>7.2.0-A4-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/dev/pom.xml
+++ b/dev/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>acs-packaging</artifactId>
-        <version>7.2.0-A2</version>
+        <version>7.2.0-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/dev/pom.xml
+++ b/dev/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>acs-packaging</artifactId>
-        <version>7.2.0-SNAPSHOT</version>
+        <version>7.2.0-A2</version>
     </parent>
 
     <properties>

--- a/dev/pom.xml
+++ b/dev/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>acs-packaging</artifactId>
-        <version>7.2.0-SNAPSHOT</version>
+        <version>7.2.0-A3</version>
     </parent>
 
     <properties>

--- a/dev/pom.xml
+++ b/dev/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>acs-packaging</artifactId>
-        <version>7.2.0-A3</version>
+        <version>7.2.0-A4-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/distribution-ags/pom.xml
+++ b/distribution-ags/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>acs-packaging</artifactId>
-        <version>7.2.0-SNAPSHOT</version>
+        <version>7.2.0-A2</version>
     </parent>
 
     <dependencies>

--- a/distribution-ags/pom.xml
+++ b/distribution-ags/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>acs-packaging</artifactId>
-        <version>7.2.0-A2</version>
+        <version>7.2.0-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/distribution-ags/pom.xml
+++ b/distribution-ags/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>acs-packaging</artifactId>
-        <version>7.2.0-A3</version>
+        <version>7.2.0-A4-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/distribution-ags/pom.xml
+++ b/distribution-ags/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>acs-packaging</artifactId>
-        <version>7.2.0-SNAPSHOT</version>
+        <version>7.2.0-A3</version>
     </parent>
 
     <dependencies>

--- a/distribution-share/pom.xml
+++ b/distribution-share/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>acs-packaging</artifactId>
-        <version>7.2.0-A2</version>
+        <version>7.2.0-SNAPSHOT</version>
     </parent>
 
     <!-- To replace in share-config-custom.xml -->

--- a/distribution-share/pom.xml
+++ b/distribution-share/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>acs-packaging</artifactId>
-        <version>7.2.0-SNAPSHOT</version>
+        <version>7.2.0-A3</version>
     </parent>
 
     <!-- To replace in share-config-custom.xml -->

--- a/distribution-share/pom.xml
+++ b/distribution-share/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>acs-packaging</artifactId>
-        <version>7.2.0-SNAPSHOT</version>
+        <version>7.2.0-A2</version>
     </parent>
 
     <!-- To replace in share-config-custom.xml -->

--- a/distribution-share/pom.xml
+++ b/distribution-share/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>acs-packaging</artifactId>
-        <version>7.2.0-A3</version>
+        <version>7.2.0-A4-SNAPSHOT</version>
     </parent>
 
     <!-- To replace in share-config-custom.xml -->

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>acs-packaging</artifactId>
-        <version>7.2.0-SNAPSHOT</version>
+        <version>7.2.0-A2</version>
     </parent>
 
     <dependencies>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>acs-packaging</artifactId>
-        <version>7.2.0-A2</version>
+        <version>7.2.0-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>acs-packaging</artifactId>
-        <version>7.2.0-A3</version>
+        <version>7.2.0-A4-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>acs-packaging</artifactId>
-        <version>7.2.0-SNAPSHOT</version>
+        <version>7.2.0-A3</version>
     </parent>
 
     <dependencies>

--- a/docker-alfresco/ags/pom.xml
+++ b/docker-alfresco/ags/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>content-services-docker</artifactId>
-        <version>7.2.0-A3</version>
+        <version>7.2.0-A4-SNAPSHOT</version>
     </parent>
     <properties>
         <image.name>alfresco/alfresco-governance-repository-enterprise</image.name>

--- a/docker-alfresco/ags/pom.xml
+++ b/docker-alfresco/ags/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>content-services-docker</artifactId>
-        <version>7.2.0-SNAPSHOT</version>
+        <version>7.2.0-A3</version>
     </parent>
     <properties>
         <image.name>alfresco/alfresco-governance-repository-enterprise</image.name>

--- a/docker-alfresco/ags/pom.xml
+++ b/docker-alfresco/ags/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>content-services-docker</artifactId>
-        <version>7.2.0-A2</version>
+        <version>7.2.0-SNAPSHOT</version>
     </parent>
     <properties>
         <image.name>alfresco/alfresco-governance-repository-enterprise</image.name>

--- a/docker-alfresco/ags/pom.xml
+++ b/docker-alfresco/ags/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>content-services-docker</artifactId>
-        <version>7.2.0-SNAPSHOT</version>
+        <version>7.2.0-A2</version>
     </parent>
     <properties>
         <image.name>alfresco/alfresco-governance-repository-enterprise</image.name>

--- a/docker-alfresco/aws/pom.xml
+++ b/docker-alfresco/aws/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>content-services-docker</artifactId>
-        <version>7.2.0-A2</version>
+        <version>7.2.0-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/docker-alfresco/aws/pom.xml
+++ b/docker-alfresco/aws/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>content-services-docker</artifactId>
-        <version>7.2.0-SNAPSHOT</version>
+        <version>7.2.0-A3</version>
     </parent>
 
     <properties>

--- a/docker-alfresco/aws/pom.xml
+++ b/docker-alfresco/aws/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>content-services-docker</artifactId>
-        <version>7.2.0-A3</version>
+        <version>7.2.0-A4-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/docker-alfresco/aws/pom.xml
+++ b/docker-alfresco/aws/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>content-services-docker</artifactId>
-        <version>7.2.0-SNAPSHOT</version>
+        <version>7.2.0-A2</version>
     </parent>
 
     <properties>

--- a/docker-alfresco/pom.xml
+++ b/docker-alfresco/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>acs-packaging</artifactId>
-        <version>7.2.0-A2</version>
+        <version>7.2.0-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/docker-alfresco/pom.xml
+++ b/docker-alfresco/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>acs-packaging</artifactId>
-        <version>7.2.0-SNAPSHOT</version>
+        <version>7.2.0-A2</version>
     </parent>
 
     <properties>

--- a/docker-alfresco/pom.xml
+++ b/docker-alfresco/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>acs-packaging</artifactId>
-        <version>7.2.0-A3</version>
+        <version>7.2.0-A4-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/docker-alfresco/pom.xml
+++ b/docker-alfresco/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>acs-packaging</artifactId>
-        <version>7.2.0-SNAPSHOT</version>
+        <version>7.2.0-A3</version>
     </parent>
 
     <properties>

--- a/docker-share/ags/pom.xml
+++ b/docker-share/ags/pom.xml
@@ -8,7 +8,7 @@
    <parent>
       <groupId>org.alfresco</groupId>
       <artifactId>share-docker</artifactId>
-      <version>7.2.0-A3</version>
+      <version>7.2.0-A4-SNAPSHOT</version>
    </parent>
 
    <properties>

--- a/docker-share/ags/pom.xml
+++ b/docker-share/ags/pom.xml
@@ -8,7 +8,7 @@
    <parent>
       <groupId>org.alfresco</groupId>
       <artifactId>share-docker</artifactId>
-      <version>7.2.0-A2</version>
+      <version>7.2.0-SNAPSHOT</version>
    </parent>
 
    <properties>

--- a/docker-share/ags/pom.xml
+++ b/docker-share/ags/pom.xml
@@ -8,7 +8,7 @@
    <parent>
       <groupId>org.alfresco</groupId>
       <artifactId>share-docker</artifactId>
-      <version>7.2.0-SNAPSHOT</version>
+      <version>7.2.0-A3</version>
    </parent>
 
    <properties>

--- a/docker-share/ags/pom.xml
+++ b/docker-share/ags/pom.xml
@@ -8,7 +8,7 @@
    <parent>
       <groupId>org.alfresco</groupId>
       <artifactId>share-docker</artifactId>
-      <version>7.2.0-SNAPSHOT</version>
+      <version>7.2.0-A2</version>
    </parent>
 
    <properties>

--- a/docker-share/aws/pom.xml
+++ b/docker-share/aws/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>share-docker</artifactId>
-        <version>7.2.0-SNAPSHOT</version>
+        <version>7.2.0-A3</version>
     </parent>
 
     <properties>

--- a/docker-share/aws/pom.xml
+++ b/docker-share/aws/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>share-docker</artifactId>
-        <version>7.2.0-A3</version>
+        <version>7.2.0-A4-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/docker-share/aws/pom.xml
+++ b/docker-share/aws/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>share-docker</artifactId>
-        <version>7.2.0-A2</version>
+        <version>7.2.0-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/docker-share/aws/pom.xml
+++ b/docker-share/aws/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>share-docker</artifactId>
-        <version>7.2.0-SNAPSHOT</version>
+        <version>7.2.0-A2</version>
     </parent>
 
     <properties>

--- a/docker-share/pom.xml
+++ b/docker-share/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>acs-packaging</artifactId>
-        <version>7.2.0-SNAPSHOT</version>
+        <version>7.2.0-A3</version>
     </parent>
 
     <properties>

--- a/docker-share/pom.xml
+++ b/docker-share/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>acs-packaging</artifactId>
-        <version>7.2.0-A3</version>
+        <version>7.2.0-A4-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/docker-share/pom.xml
+++ b/docker-share/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>acs-packaging</artifactId>
-        <version>7.2.0-SNAPSHOT</version>
+        <version>7.2.0-A2</version>
     </parent>
 
     <properties>

--- a/docker-share/pom.xml
+++ b/docker-share/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>acs-packaging</artifactId>
-        <version>7.2.0-A2</version>
+        <version>7.2.0-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <artifactId>acs-packaging</artifactId>
     <packaging>pom</packaging>
     <name>Alfresco Content Services Packaging</name>
-    <version>7.2.0-SNAPSHOT</version>
+    <version>7.2.0-A3</version>
 
     <parent>
         <groupId>org.alfresco</groupId>
@@ -37,7 +37,7 @@
         <connection>scm:git:https://github.com/Alfresco/acs-packaging.git</connection>
         <developerConnection>scm:git:https://github.com/Alfresco/acs-packaging.git</developerConnection>
         <url>https://github.com/Alfresco/acs-packaging</url>
-      <tag>HEAD</tag>
+      <tag>7.2.0-A3</tag>
   </scm>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
     <distributionManagement>
         <repository>
             <id>alfresco-internal</id>
-            <url>https://artifacts.alfresco.com/nexus/content/repositories/internal</url>
+            <url>https://artifacts.alfresco.com/nexus/content/repositories/internal-releases</url>
         </repository>
         <snapshotRepository>
             <id>alfresco-internal-snapshots</id>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <artifactId>acs-packaging</artifactId>
     <packaging>pom</packaging>
     <name>Alfresco Content Services Packaging</name>
-    <version>7.2.0-A3</version>
+    <version>7.2.0-A4-SNAPSHOT</version>
 
     <parent>
         <groupId>org.alfresco</groupId>
@@ -37,7 +37,7 @@
         <connection>scm:git:https://github.com/Alfresco/acs-packaging.git</connection>
         <developerConnection>scm:git:https://github.com/Alfresco/acs-packaging.git</developerConnection>
         <url>https://github.com/Alfresco/acs-packaging</url>
-      <tag>7.2.0-A3</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <artifactId>acs-packaging</artifactId>
     <packaging>pom</packaging>
     <name>Alfresco Content Services Packaging</name>
-    <version>7.2.0-A2</version>
+    <version>7.2.0-SNAPSHOT</version>
 
     <parent>
         <groupId>org.alfresco</groupId>
@@ -37,7 +37,7 @@
         <connection>scm:git:https://github.com/Alfresco/acs-packaging.git</connection>
         <developerConnection>scm:git:https://github.com/Alfresco/acs-packaging.git</developerConnection>
         <url>https://github.com/Alfresco/acs-packaging</url>
-      <tag>7.2.0-A2</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <artifactId>acs-packaging</artifactId>
     <packaging>pom</packaging>
     <name>Alfresco Content Services Packaging</name>
-    <version>7.2.0-SNAPSHOT</version>
+    <version>7.2.0-A2</version>
 
     <parent>
         <groupId>org.alfresco</groupId>
@@ -37,7 +37,7 @@
         <connection>scm:git:https://github.com/Alfresco/acs-packaging.git</connection>
         <developerConnection>scm:git:https://github.com/Alfresco/acs-packaging.git</developerConnection>
         <url>https://github.com/Alfresco/acs-packaging</url>
-      <tag>HEAD</tag>
+      <tag>7.2.0-A2</tag>
   </scm>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
     <distributionManagement>
         <repository>
             <id>alfresco-internal</id>
-            <url>https://artifacts.alfresco.com/nexus/content/repositories/enterprise-releases</url>
+            <url>https://artifacts.alfresco.com/nexus/content/repositories/internal</url>
         </repository>
         <snapshotRepository>
             <id>alfresco-internal-snapshots</id>

--- a/scripts/travis/maven_publish.sh
+++ b/scripts/travis/maven_publish.sh
@@ -18,42 +18,35 @@ function publishDistributionZip() {
   local VERSION="${3}"
 
   local ARTIFACT_PATH="$(echo ${GROUP_ID}/${ARTIFACT_ID} | sed 's/\./\//g')"
-  local LOCAL_PATH="~/.m2/repository/${ARTIFACT_PATH}"
+  local LOCAL_PATH="${HOME}/.m2/repository/${ARTIFACT_PATH}"
   local TMP_PATH="/tmp/${ARTIFACT_ID}"
-  local FILE_NAME=${ARTIFACT_ID}-${VERSION}
-
-  echo
-  echo "     GROUP_ID=${GROUP_ID}"
-  echo "  ARTIFACT_ID=${ARTIFACT_ID}"
-  echo "   LOCAL_PATH=${LOCAL_PATH}"
-  echo "ARTIFACT_PATH=${ARTIFACT_PATH}"
-  echo "   LOCAL_PATH=${LOCAL_PATH}"
-  echo "     TMP_PATH=${TMP_PATH}"
-  echo "    FILE_NAME=${FILE_NAME}"
 
   rm -rf "${LOCAL_PATH}"
   mvn org.apache.maven.plugins:maven-dependency-plugin:get  \
-    -Dartifact=${GROUP_ID}:${ARTIFACT_ID}:${VERSION}:${VERSION} \
+    -Dartifact=${GROUP_ID}:${ARTIFACT_ID}:${VERSION}:zip \
     -Dtransitive=false
   ls -l "${LOCAL_PATH}/${VERSION}"
 
   rm -rf "${TMP_PATH}"
   mv "${LOCAL_PATH}/${VERSION}" "${TMP_PATH}"
 
-  echo mvn deploy:deploy-file \
-       -Dfile="${TMP_PATH}/${FILE_NAME}.${TYPE}" \
-    -DpomFile="${TMP_PATH}/${FILE_NAME}.pom" \
-    -Dsources="${TMP_PATH}/${FILE_NAME}-sources.jar"\
-      -Dfiles="${TMP_PATH}/${FILE_NAME}.zip" \
-    -Dtypes=zip
+  mvn deploy:deploy-file \
+       -Dfile="${TMP_PATH}/${ARTIFACT_ID}-${VERSION}.zip" \
     -DrepositoryId=alfresco-enterprise-releases \
     -Durl=https://nexus.alfresco.com/nexus/content/repositories/enterprise-releases/ \
-    -DgroupId="${GROUP_ID}" -DartifactId="${ARTIFACT_ID}" -Dversion="${VERSION}"
+    -DgroupId="${GROUP_ID}" -DartifactId="${ARTIFACT_ID}" -Dversion="${VERSION}" \
+    -Dpackaging=zip
+#    -DpomFile="${TMP_PATH}/${ARTIFACT_ID}-${VERSION}.pom" \ - overwrites the zip
 }
 
-publishDistributionZip org.alfresco alfresco-content-services-distribution ${RELEASE_VERSION}
+publishDistributionZip org.alfresco alfresco-content-services-distribution               ${RELEASE_VERSION}
+publishDistributionZip org.alfresco alfresco-content-services-share-distribution         ${RELEASE_VERSION}
+publishDistributionZip org.alfresco alfresco-governance-services-enterprise-distribution ${RELEASE_VERSION}
 
 popd
 set +vex
 echo "=========================== Finishing Release Script =========================="
+
+# TODO remove: Exit for now with an error as we don't want to copy to the S3 RELEASE area which happens next.
+exit 123
 

--- a/scripts/travis/maven_publish.sh
+++ b/scripts/travis/maven_publish.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+echo "=========================== Starting Publish Script ==========================="
+# downloads the distribution zips from the internal Nexus repository and then uploads them to the enterprise release repository
+
+PS4="\[\e[35m\]+ \[\e[m\]"
+set -vex
+pushd "$(dirname "${BASH_SOURCE[0]}")/../../"
+
+
+if [ -z "${RELEASE_VERSION}" ]; then
+  echo "Please provide a Release version in the format <acs-version>-<additional-info> (7.2.0-EA or 7.2.0)"
+  exit 1
+fi
+
+function publishDistributionZip() {
+  local GROUP_ID="${1}"
+  local ARTIFACT_ID="${2}"
+  local VERSION="${3}"
+
+  local ARTIFACT_PATH="$(echo ${GROUP_ID}/${ARTIFACT_ID} | sed 's/\./\//g')"
+  local LOCAL_PATH="~/.m2/repository/${ARTIFACT_PATH}"
+  local TMP_PATH="/tmp/${ARTIFACT_ID}"
+  local FILE_NAME=${ARTIFACT_ID}-${VERSION}
+
+  echo
+  echo "     GROUP_ID=${GROUP_ID}"
+  echo "  ARTIFACT_ID=${ARTIFACT_ID}"
+  echo "   LOCAL_PATH=${LOCAL_PATH}"
+  echo "ARTIFACT_PATH=${ARTIFACT_PATH}"
+  echo "   LOCAL_PATH=${LOCAL_PATH}"
+  echo "     TMP_PATH=${TMP_PATH}"
+  echo "    FILE_NAME=${FILE_NAME}"
+
+  rm -rf "${LOCAL_PATH}"
+  mvn org.apache.maven.plugins:maven-dependency-plugin:get  \
+    -Dartifact=${GROUP_ID}:${ARTIFACT_ID}:${VERSION}:${VERSION} \
+    -Dtransitive=false
+  ls -l "${LOCAL_PATH}/${VERSION}"
+
+  rm -rf "${TMP_PATH}"
+  mv "${LOCAL_PATH}/${VERSION}" "${TMP_PATH}"
+
+  echo mvn deploy:deploy-file \
+       -Dfile="${TMP_PATH}/${FILE_NAME}.${TYPE}" \
+    -DpomFile="${TMP_PATH}/${FILE_NAME}.pom" \
+    -Dsources="${TMP_PATH}/${FILE_NAME}-sources.jar"\
+      -Dfiles="${TMP_PATH}/${FILE_NAME}.zip" \
+    -Dtypes=zip
+    -DrepositoryId=alfresco-enterprise-releases \
+    -Durl=https://nexus.alfresco.com/nexus/content/repositories/enterprise-releases/ \
+    -DgroupId="${GROUP_ID}" -DartifactId="${ARTIFACT_ID}" -Dversion="${VERSION}"
+}
+
+publishDistributionZip org.alfresco alfresco-content-services-distribution ${RELEASE_VERSION}
+
+popd
+set +vex
+echo "=========================== Finishing Release Script =========================="
+

--- a/scripts/travis/maven_publish.sh
+++ b/scripts/travis/maven_publish.sh
@@ -36,7 +36,6 @@ function publishDistributionZip() {
     -Durl=https://nexus.alfresco.com/nexus/content/repositories/enterprise-releases/ \
     -DgroupId="${GROUP_ID}" -DartifactId="${ARTIFACT_ID}" -Dversion="${VERSION}" \
     -Dpackaging=zip
-#    -DpomFile="${TMP_PATH}/${ARTIFACT_ID}-${VERSION}.pom" \ - overwrites the zip
 }
 
 publishDistributionZip org.alfresco alfresco-content-services-distribution               ${RELEASE_VERSION}
@@ -47,6 +46,4 @@ popd
 set +vex
 echo "=========================== Finishing Release Script =========================="
 
-# TODO remove: Exit for now with an error as we don't want to copy to the S3 RELEASE area which happens next.
-exit 123
 

--- a/tests/pipeline-all-amps/pom.xml
+++ b/tests/pipeline-all-amps/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>content-repository-tests</artifactId>
-        <version>7.2.0-SNAPSHOT</version>
+        <version>7.2.0-A3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/tests/pipeline-all-amps/pom.xml
+++ b/tests/pipeline-all-amps/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>content-repository-tests</artifactId>
-        <version>7.2.0-A3</version>
+        <version>7.2.0-A4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/tests/pipeline-all-amps/pom.xml
+++ b/tests/pipeline-all-amps/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>content-repository-tests</artifactId>
-        <version>7.2.0-A2</version>
+        <version>7.2.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/tests/pipeline-all-amps/pom.xml
+++ b/tests/pipeline-all-amps/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>content-repository-tests</artifactId>
-        <version>7.2.0-SNAPSHOT</version>
+        <version>7.2.0-A2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/tests/pipeline-all-amps/repo/pom.xml
+++ b/tests/pipeline-all-amps/repo/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>pipeline-all-amps</artifactId>
-        <version>7.2.0-SNAPSHOT</version>
+        <version>7.2.0-A3</version>
     </parent>
 
     <artifactId>alfresco-pipeline-all-amps-repo</artifactId>

--- a/tests/pipeline-all-amps/repo/pom.xml
+++ b/tests/pipeline-all-amps/repo/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>pipeline-all-amps</artifactId>
-        <version>7.2.0-A3</version>
+        <version>7.2.0-A4-SNAPSHOT</version>
     </parent>
 
     <artifactId>alfresco-pipeline-all-amps-repo</artifactId>

--- a/tests/pipeline-all-amps/repo/pom.xml
+++ b/tests/pipeline-all-amps/repo/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>pipeline-all-amps</artifactId>
-        <version>7.2.0-SNAPSHOT</version>
+        <version>7.2.0-A2</version>
     </parent>
 
     <artifactId>alfresco-pipeline-all-amps-repo</artifactId>

--- a/tests/pipeline-all-amps/repo/pom.xml
+++ b/tests/pipeline-all-amps/repo/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>pipeline-all-amps</artifactId>
-        <version>7.2.0-A2</version>
+        <version>7.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>alfresco-pipeline-all-amps-repo</artifactId>

--- a/tests/pipeline-all-amps/share/pom.xml
+++ b/tests/pipeline-all-amps/share/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>pipeline-all-amps</artifactId>
-        <version>7.2.0-SNAPSHOT</version>
+        <version>7.2.0-A2</version>
     </parent>
 
     <artifactId>alfresco-pipeline-all-amps-share</artifactId>

--- a/tests/pipeline-all-amps/share/pom.xml
+++ b/tests/pipeline-all-amps/share/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>pipeline-all-amps</artifactId>
-        <version>7.2.0-A2</version>
+        <version>7.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>alfresco-pipeline-all-amps-share</artifactId>

--- a/tests/pipeline-all-amps/share/pom.xml
+++ b/tests/pipeline-all-amps/share/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>pipeline-all-amps</artifactId>
-        <version>7.2.0-A3</version>
+        <version>7.2.0-A4-SNAPSHOT</version>
     </parent>
 
     <artifactId>alfresco-pipeline-all-amps-share</artifactId>

--- a/tests/pipeline-all-amps/share/pom.xml
+++ b/tests/pipeline-all-amps/share/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>pipeline-all-amps</artifactId>
-        <version>7.2.0-SNAPSHOT</version>
+        <version>7.2.0-A3</version>
     </parent>
 
     <artifactId>alfresco-pipeline-all-amps-share</artifactId>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>acs-packaging</artifactId>
-        <version>7.2.0-SNAPSHOT</version>
+        <version>7.2.0-A3</version>
     </parent>
 
     <modules>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>acs-packaging</artifactId>
-        <version>7.2.0-SNAPSHOT</version>
+        <version>7.2.0-A2</version>
     </parent>
 
     <modules>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>acs-packaging</artifactId>
-        <version>7.2.0-A2</version>
+        <version>7.2.0-SNAPSHOT</version>
     </parent>
 
     <modules>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>acs-packaging</artifactId>
-        <version>7.2.0-A3</version>
+        <version>7.2.0-A4-SNAPSHOT</version>
     </parent>
 
     <modules>

--- a/tests/tas-all-amps/pom.xml
+++ b/tests/tas-all-amps/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>content-repository-tests</artifactId>
-        <version>7.2.0-SNAPSHOT</version>
+        <version>7.2.0-A2</version>
     </parent>
 
     <developers>

--- a/tests/tas-all-amps/pom.xml
+++ b/tests/tas-all-amps/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>content-repository-tests</artifactId>
-        <version>7.2.0-A2</version>
+        <version>7.2.0-SNAPSHOT</version>
     </parent>
 
     <developers>

--- a/tests/tas-all-amps/pom.xml
+++ b/tests/tas-all-amps/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>content-repository-tests</artifactId>
-        <version>7.2.0-A3</version>
+        <version>7.2.0-A4-SNAPSHOT</version>
     </parent>
 
     <developers>

--- a/tests/tas-all-amps/pom.xml
+++ b/tests/tas-all-amps/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>content-repository-tests</artifactId>
-        <version>7.2.0-SNAPSHOT</version>
+        <version>7.2.0-A3</version>
     </parent>
 
     <developers>

--- a/tests/tas-cmis/pom.xml
+++ b/tests/tas-cmis/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>content-repository-tests</artifactId>
-        <version>7.2.0-SNAPSHOT</version>
+        <version>7.2.0-A2</version>
     </parent>
 
     <developers>

--- a/tests/tas-cmis/pom.xml
+++ b/tests/tas-cmis/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>content-repository-tests</artifactId>
-        <version>7.2.0-A2</version>
+        <version>7.2.0-SNAPSHOT</version>
     </parent>
 
     <developers>

--- a/tests/tas-cmis/pom.xml
+++ b/tests/tas-cmis/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>content-repository-tests</artifactId>
-        <version>7.2.0-A3</version>
+        <version>7.2.0-A4-SNAPSHOT</version>
     </parent>
 
     <developers>

--- a/tests/tas-cmis/pom.xml
+++ b/tests/tas-cmis/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>content-repository-tests</artifactId>
-        <version>7.2.0-SNAPSHOT</version>
+        <version>7.2.0-A3</version>
     </parent>
 
     <developers>

--- a/tests/tas-elasticsearch/pom.xml
+++ b/tests/tas-elasticsearch/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.alfresco</groupId>
     <artifactId>content-repository-tests</artifactId>
-    <version>7.2.0-A2</version>
+    <version>7.2.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/tests/tas-elasticsearch/pom.xml
+++ b/tests/tas-elasticsearch/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.alfresco</groupId>
     <artifactId>content-repository-tests</artifactId>
-    <version>7.2.0-A3</version>
+    <version>7.2.0-A4-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/tests/tas-elasticsearch/pom.xml
+++ b/tests/tas-elasticsearch/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.alfresco</groupId>
     <artifactId>content-repository-tests</artifactId>
-    <version>7.2.0-SNAPSHOT</version>
+    <version>7.2.0-A3</version>
   </parent>
 
   <properties>

--- a/tests/tas-elasticsearch/pom.xml
+++ b/tests/tas-elasticsearch/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.alfresco</groupId>
     <artifactId>content-repository-tests</artifactId>
-    <version>7.2.0-SNAPSHOT</version>
+    <version>7.2.0-A2</version>
   </parent>
 
   <properties>

--- a/tests/tas-email/pom.xml
+++ b/tests/tas-email/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>content-repository-tests</artifactId>
-        <version>7.2.0-SNAPSHOT</version>
+        <version>7.2.0-A2</version>
     </parent>
 
     <developers>

--- a/tests/tas-email/pom.xml
+++ b/tests/tas-email/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>content-repository-tests</artifactId>
-        <version>7.2.0-A2</version>
+        <version>7.2.0-SNAPSHOT</version>
     </parent>
 
     <developers>

--- a/tests/tas-email/pom.xml
+++ b/tests/tas-email/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>content-repository-tests</artifactId>
-        <version>7.2.0-A3</version>
+        <version>7.2.0-A4-SNAPSHOT</version>
     </parent>
 
     <developers>

--- a/tests/tas-email/pom.xml
+++ b/tests/tas-email/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>content-repository-tests</artifactId>
-        <version>7.2.0-SNAPSHOT</version>
+        <version>7.2.0-A3</version>
     </parent>
 
     <developers>

--- a/tests/tas-integration/pom.xml
+++ b/tests/tas-integration/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>content-repository-tests</artifactId>
-        <version>7.2.0-SNAPSHOT</version>
+        <version>7.2.0-A2</version>
     </parent>
 
     <developers>

--- a/tests/tas-integration/pom.xml
+++ b/tests/tas-integration/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>content-repository-tests</artifactId>
-        <version>7.2.0-A2</version>
+        <version>7.2.0-SNAPSHOT</version>
     </parent>
 
     <developers>

--- a/tests/tas-integration/pom.xml
+++ b/tests/tas-integration/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>content-repository-tests</artifactId>
-        <version>7.2.0-A3</version>
+        <version>7.2.0-A4-SNAPSHOT</version>
     </parent>
 
     <developers>

--- a/tests/tas-integration/pom.xml
+++ b/tests/tas-integration/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>content-repository-tests</artifactId>
-        <version>7.2.0-SNAPSHOT</version>
+        <version>7.2.0-A3</version>
     </parent>
 
     <developers>

--- a/tests/tas-restapi/pom.xml
+++ b/tests/tas-restapi/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>content-repository-tests</artifactId>
-        <version>7.2.0-SNAPSHOT</version>
+        <version>7.2.0-A2</version>
     </parent>
 
     <developers>

--- a/tests/tas-restapi/pom.xml
+++ b/tests/tas-restapi/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>content-repository-tests</artifactId>
-        <version>7.2.0-A2</version>
+        <version>7.2.0-SNAPSHOT</version>
     </parent>
 
     <developers>

--- a/tests/tas-restapi/pom.xml
+++ b/tests/tas-restapi/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>content-repository-tests</artifactId>
-        <version>7.2.0-A3</version>
+        <version>7.2.0-A4-SNAPSHOT</version>
     </parent>
 
     <developers>

--- a/tests/tas-restapi/pom.xml
+++ b/tests/tas-restapi/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>content-repository-tests</artifactId>
-        <version>7.2.0-SNAPSHOT</version>
+        <version>7.2.0-A3</version>
     </parent>
 
     <developers>

--- a/tests/tas-sync-service/pom.xml
+++ b/tests/tas-sync-service/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>content-repository-tests</artifactId>
-        <version>7.2.0-SNAPSHOT</version>
+        <version>7.2.0-A2</version>
     </parent>
 
     <developers>

--- a/tests/tas-sync-service/pom.xml
+++ b/tests/tas-sync-service/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>content-repository-tests</artifactId>
-        <version>7.2.0-A2</version>
+        <version>7.2.0-SNAPSHOT</version>
     </parent>
 
     <developers>

--- a/tests/tas-sync-service/pom.xml
+++ b/tests/tas-sync-service/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>content-repository-tests</artifactId>
-        <version>7.2.0-A3</version>
+        <version>7.2.0-A4-SNAPSHOT</version>
     </parent>
 
     <developers>

--- a/tests/tas-sync-service/pom.xml
+++ b/tests/tas-sync-service/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>content-repository-tests</artifactId>
-        <version>7.2.0-SNAPSHOT</version>
+        <version>7.2.0-A3</version>
     </parent>
 
     <developers>

--- a/tests/tas-webdav/pom.xml
+++ b/tests/tas-webdav/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>content-repository-tests</artifactId>
-        <version>7.2.0-SNAPSHOT</version>
+        <version>7.2.0-A2</version>
     </parent>
 
     <developers>

--- a/tests/tas-webdav/pom.xml
+++ b/tests/tas-webdav/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>content-repository-tests</artifactId>
-        <version>7.2.0-A2</version>
+        <version>7.2.0-SNAPSHOT</version>
     </parent>
 
     <developers>

--- a/tests/tas-webdav/pom.xml
+++ b/tests/tas-webdav/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>content-repository-tests</artifactId>
-        <version>7.2.0-A3</version>
+        <version>7.2.0-A4-SNAPSHOT</version>
     </parent>
 
     <developers>

--- a/tests/tas-webdav/pom.xml
+++ b/tests/tas-webdav/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>content-repository-tests</artifactId>
-        <version>7.2.0-SNAPSHOT</version>
+        <version>7.2.0-A3</version>
     </parent>
 
     <developers>


### PR DESCRIPTION
Push acs-packaging artifacts to the Nexus Internal Releases repository and on a [publish] commit directive copy the three distribution zip files to the Nexus Alfresco Enterprise Releases repository.