### PR TITLE
ACS-2145: Bump Connectors (S3 to 5.0.0-A1 & Azure to 3.0.0-A1) (for Repo 7.2.0-A5)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
         <dependency.alfresco-enterprise-share.version>14.15</dependency.alfresco-enterprise-share.version>
 
         <alfresco.rm-enterprise-rest-api-explorer.version>3.0.2</alfresco.rm-enterprise-rest-api-explorer.version>
-        <alfresco.s3connector.version>4.2.0-A1</alfresco.s3connector.version>
+        <alfresco.s3connector.version>5.0.0-A1</alfresco.s3connector.version>
         <alfresco.glacier-connector.version>2.2.1-A1</alfresco.glacier-connector.version>
         <alfresco.azure-connector.version>2.1.0</alfresco.azure-connector.version>
         <alfresco.salesforce-connector.version>2.3.0.3</alfresco.salesforce-connector.version>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <alfresco.rm-enterprise-rest-api-explorer.version>3.0.2</alfresco.rm-enterprise-rest-api-explorer.version>
         <alfresco.s3connector.version>5.0.0-A1</alfresco.s3connector.version>
         <alfresco.glacier-connector.version>2.2.1-A1</alfresco.glacier-connector.version>
-        <alfresco.azure-connector.version>2.1.0</alfresco.azure-connector.version>
+        <alfresco.azure-connector.version>3.0.0-A1</alfresco.azure-connector.version>
         <alfresco.salesforce-connector.version>2.3.0.3</alfresco.salesforce-connector.version>
         <alfresco.saml.version>1.2.2</alfresco.saml.version>
         <alfresco.outlook.version>2.8.0</alfresco.outlook.version>


### PR DESCRIPTION
- bump S3 Connector 5.0.0-A1 and Azure Connector 3.0.0-A1 (both using Cloud Connector Base 3.1)
- both compatible with Repo 7.2.0-A5
- note: also fixes ACS-2022 (for int pipeline)