### PR TITLE
Python script to find the releases containing a fix.

### DIFF
--- a/scripts/dev/find-fix.py
+++ b/scripts/dev/find-fix.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import argparse, os, re, subprocess
+
+script_path = os.path.dirname(os.path.realpath(__file__))
+root_dir = os.path.dirname(os.path.dirname(os.path.dirname(script_path)))
+
+projects = ['alfresco-community-repo', 'alfresco-enterprise-repo', 'alfresco-enterprise-share', 'acs-packaging']
+project_dir = {project: os.path.join(root_dir, project) for project in projects}
+version_string = {project: '<dependency.{}.version>'.format(project) for project in projects}
+
+parser = argparse.ArgumentParser(description='Find the acs-packaging tags that contain commits referencing a ticket.',
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+parser.add_argument('-j', '--jira', help='The ticket number to search for.')
+parser.add_argument('-a', '--all', action='store_true', help='Display all releases containing fix.')
+parser.add_argument('-r', '--release', action='store_true', help='Only consider full releases.')
+args = parser.parse_args()
+
+# The filter to use to avoid considering test tags.
+version_filter = r'^[0-9]+(\.[0-9]+)*$' if args.release else r'^[0-9]+(\.[0-9]+)*(-(A|M|RC)[0-9]+)?$'
+
+def run_command(command_parts, project):
+    """Run the command and return the output string."""
+    output = subprocess.run(command_parts, cwd=project_dir[project], capture_output=True)
+    return output.stdout.decode('utf-8')
+
+def run_list_command(command_parts, project):
+    """Run the command and return the lines of the output as a list of strings."""
+    output = run_command(command_parts, project).strip().split('\n')
+    if '' in output:
+        output.remove('')
+    return output
+
+def compare_version_part(a_part, b_part):
+    """Compare two parts of a version number and return the difference (taking into account
+    versions like 7.0.0-M1)."""
+    try:
+        a_bits = a_part.split('-')
+        b_bits = b_part.split('-')
+        version_difference = int(a_bits[0]) - int(b_bits[0])
+        if version_difference != 0 or (len(a_bits) == 1 and len(b_bits) == 1):
+            return version_difference
+        if len(a_bits) != len(b_bits):
+            # Fewer parts indicates a later version (e.g. '7.0.0' is later than '7.0.0-M1')
+            return len(b_bits) - len(a_bits)
+        # If letter doesn't match then we can't compare the versions.
+        a_letter = a_bits[1][0]
+        b_letter = b_bits[1][0]
+        if a_letter != b_letter:
+            return 0
+        # Try to get number from after M, A or RC and compare this.
+        a_number_start = [char.isdigit() for char in a_bits[1]].index(True)
+        b_number_start = [char.isdigit() for char in b_bits[1]].index(True)
+        return int(a_bits[1][a_number_start:]) - int(b_bits[1][b_number_start:])
+    except ValueError:
+        # If the strings aren't in the format we're expecting then we can't compare them.
+        return 0
+
+def tag_before(tag_a, tag_b):
+    """Return True if the version number from tag_a is lower than tag_b."""
+    a_parts = list(tag_a.split('.'))
+    b_parts = list(tag_b.split('.'))
+    for part_index, b_part in enumerate(b_parts):
+        if len(a_parts) <= part_index:
+            return True
+        difference = compare_version_part(a_parts[part_index], b_part)
+        if difference < 0:
+            return True
+        elif difference > 0:
+            return False
+    return len(a_parts) <= len(b_parts)
+
+tags_in_project = {}
+for project in projects:
+    run_command(['git', 'fetch'], project)
+    commits = run_list_command(['git', 'rev-list', '--all', '--grep', args.jira], project)
+    for commit in commits:
+        tags = run_list_command(['git', 'tag', '--contains', commit], project)
+        # acs-packaging has a different format for older tags.
+        if project == 'acs-packaging':
+            # Remove the prefix 'acs-packaging-' if it's present.
+            tags = list(map(lambda tag: tag.replace('acs-packaging-', ''), tags))
+        # Exclude tags that aren't just chains of numbers with an optional suffix.
+        tags = list(filter(lambda tag: re.match(version_filter, tag), tags))
+        if args.all:
+            reduced_tags = tags
+        else:
+            # Filter out tags that are before other tags.
+            reduced_tags = []
+            for i, tag_a in enumerate(tags):
+                include = True
+                for tag_b in tags:
+                    if tag_a == tag_b:
+                        continue
+                    if not tag_before(tag_a, tag_b):
+                        include = False
+                        break
+                if include:
+                    reduced_tags.append(tag_a)
+        print('{} is in {}: {}'.format(commit, project, ', '.join(reduced_tags)))


### PR DESCRIPTION
I wanted to do more than this, but I think this is significantly better than nothing.  Example usage:
```
$ ./acs-packaging/scripts/dev/find-fix.py -j "SEARCH-3049"
0939e81d794ce6f337525782476a3676f4b500c3 is in alfresco-enterprise-repo: 14.8
d6e1e3ec1bbd4f0818282d342dc3eb080aaf28b9 is in acs-packaging: 7.2.0-A1
```
Hotfix example:
```
$ ./acs-packaging/scripts/dev/find-fix.py -j "REPO-5359" -r
3795fcd3efd56e6ef59ac2ef46a0b7b9a651be1a is in acs-packaging: 6.0.0.6
9bca10fa72263cbf7831e6987015814e8424c050 is in acs-packaging: 6.0.1.7
2fc2e5d249d393aa8f571a6564d008841b87c046 is in acs-packaging: 6.1.0.10
1d596f096e73112292142e67199b2ac71a9c949d is in acs-packaging: 6.1.1.8
25ac63e8ae7d2b1e8f6bbc4baee53f66ff917a0d is in acs-packaging: 6.2.0.7
94db72436942ba6e4d0d853bd55e15105e9b309d is in acs-packaging: 6.2.1.4
8c432f124261172f8e0979ce4ad08580526b842e is in acs-packaging: 6.2.2.4
e32cddfbef19c9086a3d4d0b52508d4e4da0e5ad is in acs-packaging: 
5991cedd20ae8f4811aec98d9cc62f926ee2c7e2 is in acs-packaging: 7.0.0
```
The missing version here is because e32cddf is not yet released (it would be in 6.2.3 if such a version ever got made).