### PR TITLE
ACS-2171 use package reference in test suite instead of classes

### DIFF
--- a/tests/tas-elasticsearch/src/test/java/org/alfresco/elasticsearch/basicAuth/AlfrescoStackInitializerESBasicAuth.java
+++ b/tests/tas-elasticsearch/src/test/java/org/alfresco/elasticsearch/basicAuth/AlfrescoStackInitializerESBasicAuth.java
@@ -1,5 +1,6 @@
-package org.alfresco.elasticsearch;
+package org.alfresco.elasticsearch.basicAuth;
 
+import org.alfresco.elasticsearch.AlfrescoStackInitializer;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.elasticsearch.ElasticsearchContainer;
 

--- a/tests/tas-elasticsearch/src/test/java/org/alfresco/elasticsearch/basicAuth/ElasticsearchBasicAuthTests.java
+++ b/tests/tas-elasticsearch/src/test/java/org/alfresco/elasticsearch/basicAuth/ElasticsearchBasicAuthTests.java
@@ -1,7 +1,8 @@
-package org.alfresco.elasticsearch;
+package org.alfresco.elasticsearch.basicAuth;
 
 import static org.alfresco.elasticsearch.SearchQueryService.req;
 
+import org.alfresco.elasticsearch.SearchQueryService;
 import org.alfresco.utility.data.DataContent;
 import org.alfresco.utility.data.DataSite;
 import org.alfresco.utility.data.DataUser;

--- a/tests/tas-elasticsearch/src/test/resources/test-suites/elasticsearch-basic-auth-suite.xml
+++ b/tests/tas-elasticsearch/src/test/resources/test-suites/elasticsearch-basic-auth-suite.xml
@@ -2,8 +2,8 @@
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd">
 <suite name="REST API tests Elasticsearch with Basic Auth" preserve-order="true" verbose="1">
   <test name="elasticsearch-basic-auth" verbose="3" preserve-order="true">
-    <classes>
-      <class name="org.alfresco.elasticsearch.ElasticsearchBasicAuthTests"></class>
-    </classes>
+    <packages>
+      <package name="org.alfresco.elasticsearch.basicAuth"/>
+    </packages>
   </test>
 </suite>

--- a/tests/tas-elasticsearch/src/test/resources/test-suites/elasticsearch-suite.xml
+++ b/tests/tas-elasticsearch/src/test/resources/test-suites/elasticsearch-suite.xml
@@ -2,13 +2,8 @@
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd">
 <suite name="REST API tests Elasticsearch" preserve-order="true" verbose="1">
   <test name="elasticsearch" verbose="3" preserve-order="true">
-    <classes>
-      <class name="org.alfresco.elasticsearch.ElasticsearchAdminConsoleTests"></class>
-      <class name="org.alfresco.elasticsearch.ElasticsearchLiveIndexingTests"></class>
-      <class name="org.alfresco.elasticsearch.ElasticsearchReindexingTests"></class>
-      <class name="org.alfresco.elasticsearch.ElasticsearchPathIndexingTests"></class>
-      <class name="org.alfresco.elasticsearch.ElasticsearchTagIndexingTests"></class>
-      <class name="org.alfresco.elasticsearch.ElasticsearchSiteIndexingTests"></class>
-    </classes>
+    <packages>
+      <package name="org.alfresco.elasticsearch"/>
+    </packages>
   </test>
 </suite>


### PR DESCRIPTION
use package reference in test suite instead of classes
refactor tests: move ES basicAuth test to dedicated package