### PR TITLE
ACS-2441 - adjust log levels for TAS-based ES tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -181,12 +181,12 @@ jobs:
     - name: "Elasticsearch TAS tests"
       if: commit_message !~ /\[skip search\]/
       script:
-       - travis_wait 30 mvn -B install -f tests/tas-elasticsearch/pom.xml -Pall-tas-tests,elastic -Denvironment=default -DrunBugs=false
+       - travis_wait 30 mvn -B install -ntp -f tests/tas-elasticsearch/pom.xml -Pall-tas-tests,elastic -Denvironment=default -DrunBugs=false
 
     - name: "Elasticsearch Basic Auth TAS tests"
       if: commit_message !~ /\[skip search\]/
       script:
-       - travis_wait 30 mvn -B install -f tests/tas-elasticsearch/pom.xml -Pall-tas-tests,elastic-basic-auth -Denvironment=default -DrunBugs=false
+       - travis_wait 30 mvn -B install -ntp -f tests/tas-elasticsearch/pom.xml -Pall-tas-tests,elastic-basic-auth -Denvironment=default -DrunBugs=false
 
     - name: "All AMPs tests"
       before_script:

--- a/tests/tas-elasticsearch/src/test/resources/log4j.properties
+++ b/tests/tas-elasticsearch/src/test/resources/log4j.properties
@@ -1,5 +1,5 @@
 # Root logger option
-log4j.rootLogger=INFO, stdout
+log4j.rootLogger=WARN, stdout
 
 
 # Direct log messages to stdout
@@ -8,4 +8,5 @@ log4j.appender.stdout.Target=System.out
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=[%t] %d{HH:mm:ss} %-5p %c{1}:%L - %m%n
 
-log4j.logger.org.alfresco.elasticsearch=warn
+log4j.logger.org.alfresco=WARN
+log4j.logger.org.alfresco.elasticsearch=WARN

--- a/tests/tas-elasticsearch/src/test/resources/log4j.properties
+++ b/tests/tas-elasticsearch/src/test/resources/log4j.properties
@@ -1,5 +1,5 @@
 # Root logger option
-log4j.rootLogger=WARN, stdout
+log4j.rootLogger=INFO, stdout
 
 
 # Direct log messages to stdout
@@ -8,5 +8,9 @@ log4j.appender.stdout.Target=System.out
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=[%t] %d{HH:mm:ss} %-5p %c{1}:%L - %m%n
 
-log4j.logger.org.alfresco=WARN
-log4j.logger.org.alfresco.elasticsearch=WARN
+
+log4j.logger.org.alfresco.elasticsearch=INFO
+log4j.logger.org.alfresco.rest.core=WARN
+log4j.logger.org.alfresco.utility.report.log=INFO
+
+

--- a/tests/tas-elasticsearch/src/test/resources/log4j.properties
+++ b/tests/tas-elasticsearch/src/test/resources/log4j.properties
@@ -8,4 +8,4 @@ log4j.appender.stdout.Target=System.out
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=[%t] %d{HH:mm:ss} %-5p %c{1}:%L - %m%n
 
-log4j.logger.org.alfresco.elasticsearch=info
+log4j.logger.org.alfresco.elasticsearch=debug

--- a/tests/tas-elasticsearch/src/test/resources/log4j.properties
+++ b/tests/tas-elasticsearch/src/test/resources/log4j.properties
@@ -8,4 +8,4 @@ log4j.appender.stdout.Target=System.out
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=[%t] %d{HH:mm:ss} %-5p %c{1}:%L - %m%n
 
-log4j.logger.org.alfresco.elasticsearch=debug
+log4j.logger.org.alfresco.elasticsearch=warn

--- a/tests/tas-elasticsearch/src/test/resources/test-suites/elasticsearch-suite.xml
+++ b/tests/tas-elasticsearch/src/test/resources/test-suites/elasticsearch-suite.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd">
 <suite name="REST API tests Elasticsearch" preserve-order="true" verbose="1">
-  <test name="elasticsearch" verbose="3" preserve-order="true">
+  <test name="elasticsearch" verbose="1" preserve-order="true">
     <packages>
       <package name="org.alfresco.elasticsearch"/>
     </packages>

--- a/tests/tas-elasticsearch/src/test/resources/test-suites/elasticsearch-suite.xml
+++ b/tests/tas-elasticsearch/src/test/resources/test-suites/elasticsearch-suite.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd">
 <suite name="REST API tests Elasticsearch" preserve-order="true" verbose="1">
-  <test name="elasticsearch" verbose="1" preserve-order="true">
+  <test name="elasticsearch" verbose="3" preserve-order="true">
     <packages>
       <package name="org.alfresco.elasticsearch"/>
     </packages>


### PR DESCRIPTION
log4j: log level to debug
testng: verbose to 1