### PR TITLE
ACS-2287: Bump Azure Connector to 3.0.0-A7 (from 3.0.0-A5)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <alfresco.rm-enterprise-rest-api-explorer.version>3.0.2</alfresco.rm-enterprise-rest-api-explorer.version>
 
         <alfresco.s3connector.version>5.0.0-A5</alfresco.s3connector.version>
-        <alfresco.azure-connector.version>3.0.0-A5</alfresco.azure-connector.version>
+        <alfresco.azure-connector.version>3.0.0-A7</alfresco.azure-connector.version>
 
         <alfresco.salesforce-connector.version>2.3.3-A1</alfresco.salesforce-connector.version>
         <alfresco.saml.version>1.2.2</alfresco.saml.version>


### PR DESCRIPTION
- targeting ACS Repo 7.2.0-A12 (or higher)