### PR TITLE
ACS-2104: [release] 7.2.0-A23

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,8 +31,8 @@ env:
     - TAS_SCRIPTS=../alfresco-community-repo/packaging/tests/scripts
     - TAS_ENVIRONMENT=./tests/environment
     # Release version has to start with real version (7.2.0-....) for the docker image to build successfully.
-    - RELEASE_VERSION=7.2.0-A22
-    - DEVELOPMENT_VERSION=7.2.0-A23-SNAPSHOT
+    - RELEASE_VERSION=7.2.0-A23
+    - DEVELOPMENT_VERSION=7.2.0-A24-SNAPSHOT
     - DTAS_VERSION="${DTAS_VERSION:-v1.1}"
     - PYTHON_VERSION=3.7.12
 


### PR DESCRIPTION
After changes from comm-repo [PR#908](https://github.com/Alfresco/alfresco-community-repo/pull/908) a release is needed.
As a follow-up there will be a fix and release in Azure Connector project.