### PR TITLE
OPSEXP-1194: remove usage of dev tools in main image build stage

### DIFF
--- a/docker-alfresco/ags/Dockerfile
+++ b/docker-alfresco/ags/Dockerfile
@@ -2,26 +2,29 @@
 FROM debian:11-slim AS AGSBUILDER
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get -yqq install unzip && \
-    mkdir build
+    mkdir -p /build/gs-api-explorer
 
-COPY target/gs-api-explorer-*.war
+### Copy the AGS war from the local context
+COPY target/gs-api-explorer-*.war /build
 
-RUN unzip gs-api-explorer-*.war -d build/ && \
-    chmod -R g-w,o= build
-    
+RUN unzip gs-api-explorer-*.war -d /build/gs-api-explorer && \
+    chmod -R g-w,o= /build
+
 # AcTUAL IMAGE
 FROM alfresco/alfresco-content-repository:${image.tag}
 
-# Set default docker_context.
+# Set docker variables
+ARG GROUPNAME=Alfresco
+ARG USERNAME=alfresco
 ARG resource_path=target
 
 #Use the root user
 USER root
 
-### Copy the AMP from build context to amps
-COPY target/alfresco-governance-services-enterprise-repo-*.amp /usr/local/tomcat/amps/
-### Copy gs-api-explorer war into webapps folder
-COPY --chown=root:Alfresco --from AGSBUILDER build/ /usr/local/tomcat/webapps/gs-api-explorer
+### Copy the AMP from local context to amps
+COPY --chown=root:${GROUPNAME} target/alfresco-governance-services-enterprise-repo-*.amp /usr/local/tomcat/amps/
+### Copy gs-api-explorer webapp from AGS build stage
+COPY --chown=root:${GROUPNAME} --from AGSBUILDER /build/gs-api-explorer /usr/local/tomcat/webapps
 
 # Install amps on alfresco.war & set all security permissions to jolokia and share in order to work properly.
 RUN java -jar /usr/local/tomcat/alfresco-mmt/alfresco-mmt*.jar install \
@@ -30,4 +33,4 @@ RUN java -jar /usr/local/tomcat/alfresco-mmt/alfresco-mmt*.jar install \
               sed -i -e "\$a\grant\ codeBase\ \"file:\$\{catalina.base\}\/webapps\/jolokia\/-\" \{\n\    permission\ java.security.AllPermission\;\n\};\ngrant\ codeBase\ \"file:\$\{catalina.base\}\/webapps\/share\/-\" \{\n\    permission\ java.security.AllPermission\;\n\};" /usr/local/tomcat/conf/catalina.policy
 
 #Use the alfresco user
-USER alfresco
+USER ${USERNAME}

--- a/docker-alfresco/ags/Dockerfile
+++ b/docker-alfresco/ags/Dockerfile
@@ -25,7 +25,7 @@ USER root
 ### Copy the AMP from local context to amps
 COPY --chown=root:${GROUPNAME} target/alfresco-governance-services-enterprise-repo-*.amp /usr/local/tomcat/amps/
 ### Copy gs-api-explorer webapp from AGS build stage
-COPY --chown=root:${GROUPNAME} --from=AGSBUILDER /build/gs-api-explorer /usr/local/tomcat/webapps
+COPY --chown=root:${GROUPNAME} --from=AGSBUILDER /build/gs-api-explorer /usr/local/tomcat/webapps/gs-api-explorer
 
 # Install amps on alfresco.war & set all security permissions to jolokia and share in order to work properly.
 RUN java -jar /usr/local/tomcat/alfresco-mmt/alfresco-mmt*.jar install \

--- a/docker-alfresco/ags/Dockerfile
+++ b/docker-alfresco/ags/Dockerfile
@@ -1,13 +1,14 @@
 # BUILD STAGE AGS
 FROM debian:11-slim AS AGSBUILDER
 
-RUN DEBIAN_FRONTEND=noninteractive apt-get -yqq install unzip && \
+RUN export DEBIAN_FRONTEND=noninteractive; \
+    apt-get update -qqy && apt-get -yqq install unzip && \
     mkdir -p /build/gs-api-explorer
 
 ### Copy the AGS war from the local context
 COPY target/gs-api-explorer-*.war /build
 
-RUN unzip gs-api-explorer-*.war -d /build/gs-api-explorer && \
+RUN unzip -q /build/gs-api-explorer-*.war -d /build/gs-api-explorer && \
     chmod -R g-w,o= /build
 
 # AcTUAL IMAGE
@@ -24,7 +25,7 @@ USER root
 ### Copy the AMP from local context to amps
 COPY --chown=root:${GROUPNAME} target/alfresco-governance-services-enterprise-repo-*.amp /usr/local/tomcat/amps/
 ### Copy gs-api-explorer webapp from AGS build stage
-COPY --chown=root:${GROUPNAME} --from AGSBUILDER /build/gs-api-explorer /usr/local/tomcat/webapps
+COPY --chown=root:${GROUPNAME} --from=AGSBUILDER /build/gs-api-explorer /usr/local/tomcat/webapps
 
 # Install amps on alfresco.war & set all security permissions to jolokia and share in order to work properly.
 RUN java -jar /usr/local/tomcat/alfresco-mmt/alfresco-mmt*.jar install \

--- a/docker-alfresco/ags/Dockerfile
+++ b/docker-alfresco/ags/Dockerfile
@@ -28,10 +28,17 @@ COPY --chown=root:${GROUPNAME} target/alfresco-governance-services-enterprise-re
 COPY --chown=root:${GROUPNAME} --from=AGSBUILDER /build/gs-api-explorer /usr/local/tomcat/webapps/gs-api-explorer
 
 # Install amps on alfresco.war & set all security permissions to jolokia and share in order to work properly.
+## All files in the tomcat folder must be owned by root user and Alfresco group as mentioned in the parent Dockerfile
 RUN java -jar /usr/local/tomcat/alfresco-mmt/alfresco-mmt*.jar install \
               /usr/local/tomcat/amps \
-              /usr/local/tomcat/webapps/alfresco -directory -nobackup; \
-              sed -i -e "\$a\grant\ codeBase\ \"file:\$\{catalina.base\}\/webapps\/jolokia\/-\" \{\n\    permission\ java.security.AllPermission\;\n\};\ngrant\ codeBase\ \"file:\$\{catalina.base\}\/webapps\/share\/-\" \{\n\    permission\ java.security.AllPermission\;\n\};" /usr/local/tomcat/conf/catalina.policy
+              /usr/local/tomcat/webapps/alfresco -directory -nobackup && \
+    sed -i -e "\$a\grant\ codeBase\ \"file:\$\{catalina.base\}\/webapps\/jolokia\/-\" \{\n\    permission\ java.security.AllPermission\;\n\};\ngrant\ codeBase\ \"file:\$\{catalina.base\}\/webapps\/share\/-\" \{\n\    permission\ java.security.AllPermission\;\n\};" /usr/local/tomcat/conf/catalina.policy && \
+    chgrp -R Alfresco /usr/local/tomcat && \
+    find /usr/local/tomcat/webapps -type d -exec chmod 0750 {} \; && \
+    find /usr/local/tomcat/webapps -type f -exec chmod 0640 {} \; && \
+    find /usr/local/tomcat/shared -type d -exec chmod 0750 {} \; && \
+    find /usr/local/tomcat/shared -type f -exec chmod 0640 {} \; && \
+    chmod -R g+r /usr/local/tomcat/webapps
 
 #Use the alfresco user
 USER ${USERNAME}

--- a/docker-alfresco/ags/Dockerfile
+++ b/docker-alfresco/ags/Dockerfile
@@ -1,4 +1,15 @@
-### Apply AGS enterprise repo AMP to ACS image
+# BUILD STAGE AGS
+FROM debian:11-slim AS AGSBUILDER
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get -yqq install unzip && \
+    mkdir build
+
+COPY target/gs-api-explorer-*.war
+
+RUN unzip gs-api-explorer-*.war -d build/ && \
+    chmod -R g-w,o= build
+    
+# AcTUAL IMAGE
 FROM alfresco/alfresco-content-repository:${image.tag}
 
 # Set default docker_context.
@@ -9,28 +20,14 @@ USER root
 
 ### Copy the AMP from build context to amps
 COPY target/alfresco-governance-services-enterprise-repo-*.amp /usr/local/tomcat/amps/
+### Copy gs-api-explorer war into webapps folder
+COPY --chown=root:Alfresco --from AGSBUILDER build/ /usr/local/tomcat/webapps/gs-api-explorer
 
-# Install amps on alfresco.war
+# Install amps on alfresco.war & set all security permissions to jolokia and share in order to work properly.
 RUN java -jar /usr/local/tomcat/alfresco-mmt/alfresco-mmt*.jar install \
               /usr/local/tomcat/amps \
-              /usr/local/tomcat/webapps/alfresco -directory -nobackup
-### Copy gs-api-explorer war into webapps folder
-COPY target/gs-api-explorer-*.war /usr/local/tomcat/webapps/
-
-### Unpack gs-api-explorer.war
-RUN mkdir /usr/local/tomcat/webapps/gs-api-explorer && cd /usr/local/tomcat/webapps/gs-api-explorer && \
-    jar -xvf /usr/local/tomcat/webapps/gs-api-explorer-*.war && rm -f /usr/local/tomcat/webapps/gs-api-explorer-*.war
-
-# Grant all security permissions to jolokia and share in order to work properly.
-RUN sed -i -e "\$a\grant\ codeBase\ \"file:\$\{catalina.base\}\/webapps\/jolokia\/-\" \{\n\    permission\ java.security.AllPermission\;\n\};\ngrant\ codeBase\ \"file:\$\{catalina.base\}\/webapps\/share\/-\" \{\n\    permission\ java.security.AllPermission\;\n\};" /usr/local/tomcat/conf/catalina.policy
-
-## All files in the tomcat folder must be owned by root user and Alfresco group as mentioned in the parent Dockerfile
-RUN chgrp -R Alfresco /usr/local/tomcat && \
-    find /usr/local/tomcat/webapps -type d -exec chmod 0750 {} \; && \
-    find /usr/local/tomcat/webapps -type f -exec chmod 0640 {} \; && \
-    find /usr/local/tomcat/shared -type d -exec chmod 0750 {} \; && \
-    find /usr/local/tomcat/shared -type f -exec chmod 0640 {} \; && \
-    chmod -R g+r /usr/local/tomcat/webapps
+              /usr/local/tomcat/webapps/alfresco -directory -nobackup; \
+              sed -i -e "\$a\grant\ codeBase\ \"file:\$\{catalina.base\}\/webapps\/jolokia\/-\" \{\n\    permission\ java.security.AllPermission\;\n\};\ngrant\ codeBase\ \"file:\$\{catalina.base\}\/webapps\/share\/-\" \{\n\    permission\ java.security.AllPermission\;\n\};" /usr/local/tomcat/conf/catalina.policy
 
 #Use the alfresco user
 USER alfresco

--- a/tests/environment/alfresco-with-jolokia/Dockerfile
+++ b/tests/environment/alfresco-with-jolokia/Dockerfile
@@ -3,10 +3,11 @@ FROM debian:11-slim AS JOLOKIABUILDER
 
 ARG JOLOKIA_VER=1.6.2
 
-RUN DEBIAN_FRONTEND=noninteractive apt-get -yqq install unzip && \
+RUN DEBIAN_FRONTEND=noninteractive; \
+    apt-get update -qqy && apt-get -yqq install unzip && \
     mkdir -p /build/jolokia && \
     curl -o /build/jolokia.war https://repo1.maven.org/maven2/org/jolokia/jolokia-war-unsecured/${JOLOKIA_VER}/jolokia-war-unsecured-${JOLOKIA_VER}.war && \
-    unzip /build/jolokia.war -d /build/jolokia && chmod -R g-w,o= /build
+    unzip -q /build/jolokia.war -d /build/jolokia && chmod -R g-w,o= /build
 
 # ACTUAL IMAGE
 FROM alfresco/alfresco-content-repository:latest
@@ -19,7 +20,7 @@ ARG USERID=33000
 
 USER root
 
-COPY --chown=root:${GROUPNAME} --from JOLOKIABUILDER /build/jolokia ${TOMCAT_DIR}/webapps
+COPY --chown=root:${GROUPNAME} --from=JOLOKIABUILDER /build/jolokia ${TOMCAT_DIR}/webapps
 
 # Grant all security permissions to jolokia in order to work properly.
 RUN sed -i -e "\$a\grant\ codeBase\ \"file:\$\{catalina.base\}\/webapps\/jolokia\/-\" \{\n\    permission\ java.security.AllPermission\;\n\};" ${TOMCAT_DIR}/conf/catalina.policy && \

--- a/tests/environment/alfresco-with-jolokia/Dockerfile
+++ b/tests/environment/alfresco-with-jolokia/Dockerfile
@@ -20,7 +20,7 @@ ARG USERID=33000
 
 USER root
 
-COPY --chown=root:${GROUPNAME} --from=JOLOKIABUILDER /build/jolokia ${TOMCAT_DIR}/webapps
+COPY --chown=root:${GROUPNAME} --from=JOLOKIABUILDER /build/jolokia ${TOMCAT_DIR}/webapps/jolokia
 
 # Grant all security permissions to jolokia in order to work properly.
 RUN sed -i -e "\$a\grant\ codeBase\ \"file:\$\{catalina.base\}\/webapps\/jolokia\/-\" \{\n\    permission\ java.security.AllPermission\;\n\};" ${TOMCAT_DIR}/conf/catalina.policy

--- a/tests/environment/alfresco-with-jolokia/Dockerfile
+++ b/tests/environment/alfresco-with-jolokia/Dockerfile
@@ -4,10 +4,10 @@ FROM debian:11-slim AS JOLOKIABUILDER
 ARG JOLOKIA_VER=1.6.2
 
 RUN DEBIAN_FRONTEND=noninteractive; \
-    apt-get update -qqy && apt-get -yqq install unzip && \
+    apt-get update -qqy && apt-get -yqq install curl unzip && \
     mkdir -p /build/jolokia && \
     curl -o /build/jolokia.war https://repo1.maven.org/maven2/org/jolokia/jolokia-war-unsecured/${JOLOKIA_VER}/jolokia-war-unsecured-${JOLOKIA_VER}.war && \
-    unzip -q /build/jolokia.war -d /build/jolokia && chmod -R g-w,o= /build
+    unzip -q /build/jolokia.war -d /build/jolokia && chmod -R g+r,g-w,o= /build
 
 # ACTUAL IMAGE
 FROM alfresco/alfresco-content-repository:latest
@@ -23,6 +23,6 @@ USER root
 COPY --chown=root:${GROUPNAME} --from=JOLOKIABUILDER /build/jolokia ${TOMCAT_DIR}/webapps
 
 # Grant all security permissions to jolokia in order to work properly.
-RUN sed -i -e "\$a\grant\ codeBase\ \"file:\$\{catalina.base\}\/webapps\/jolokia\/-\" \{\n\    permission\ java.security.AllPermission\;\n\};" ${TOMCAT_DIR}/conf/catalina.policy && \
+RUN sed -i -e "\$a\grant\ codeBase\ \"file:\$\{catalina.base\}\/webapps\/jolokia\/-\" \{\n\    permission\ java.security.AllPermission\;\n\};" ${TOMCAT_DIR}/conf/catalina.policy
 
 USER ${USERID}

--- a/tests/environment/alfresco-with-jolokia/Dockerfile
+++ b/tests/environment/alfresco-with-jolokia/Dockerfile
@@ -4,9 +4,9 @@ FROM debian:11-slim AS JOLOKIABUILDER
 ARG JOLOKIA_VER=1.6.2
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get -yqq install unzip && \
-    mkdir build && \
-    curl -o /tmp/jolokia.war https://repo1.maven.org/maven2/org/jolokia/jolokia-war-unsecured/${JOLOKIA_VER}/jolokia-war-unsecured-${JOLOKIA_VER}.war && \
-    unzip /tmp/jolokia.war -d build && chmod -R g-w,o= build
+    mkdir -p /build/jolokia && \
+    curl -o /build/jolokia.war https://repo1.maven.org/maven2/org/jolokia/jolokia-war-unsecured/${JOLOKIA_VER}/jolokia-war-unsecured-${JOLOKIA_VER}.war && \
+    unzip /build/jolokia.war -d /build/jolokia && chmod -R g-w,o= /build
 
 # ACTUAL IMAGE
 FROM alfresco/alfresco-content-repository:latest
@@ -19,7 +19,7 @@ ARG USERID=33000
 
 USER root
 
-COPY --chown=root:Alfresco --from JOLOKIABUILDER build ${TOMCAT_DIR}/webapps/jolokia
+COPY --chown=root:${GROUPNAME} --from JOLOKIABUILDER /build/jolokia ${TOMCAT_DIR}/webapps
 
 # Grant all security permissions to jolokia in order to work properly.
 RUN sed -i -e "\$a\grant\ codeBase\ \"file:\$\{catalina.base\}\/webapps\/jolokia\/-\" \{\n\    permission\ java.security.AllPermission\;\n\};" ${TOMCAT_DIR}/conf/catalina.policy && \

--- a/tests/environment/alfresco-with-jolokia/Dockerfile
+++ b/tests/environment/alfresco-with-jolokia/Dockerfile
@@ -1,3 +1,14 @@
+# BUILD STAGE
+FROM debian:11-slim AS JOLOKIABUILDER
+
+ARG JOLOKIA_VER=1.6.2
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get -yqq install unzip && \
+    mkdir build && \
+    curl -o /tmp/jolokia.war https://repo1.maven.org/maven2/org/jolokia/jolokia-war-unsecured/${JOLOKIA_VER}/jolokia-war-unsecured-${JOLOKIA_VER}.war && \
+    unzip /tmp/jolokia.war -d build && chmod -R g-w,o= build
+
+# ACTUAL IMAGE
 FROM alfresco/alfresco-content-repository:latest
 
 ARG TOMCAT_DIR=/usr/local/tomcat
@@ -8,19 +19,9 @@ ARG USERID=33000
 
 USER root
 
-RUN mkdir ${TOMCAT_DIR}/webapps/jolokia && \
-    curl -o /tmp/jolokia.war https://repo1.maven.org/maven2/org/jolokia/jolokia-war-unsecured/1.6.2/jolokia-war-unsecured-1.6.2.war && \
-    cd ${TOMCAT_DIR}/webapps/jolokia && \
-    jar xvf /tmp/jolokia.war && \
-    cd ${TOMCAT_DIR} && \
-    rm /tmp/jolokia.war && \
+COPY --chown=root:Alfresco --from JOLOKIABUILDER build ${TOMCAT_DIR}/webapps/jolokia
+
 # Grant all security permissions to jolokia in order to work properly.
-    sed -i -e "\$a\grant\ codeBase\ \"file:\$\{catalina.base\}\/webapps\/jolokia\/-\" \{\n\    permission\ java.security.AllPermission\;\n\};" ${TOMCAT_DIR}/conf/catalina.policy && \
-    # Restore permissions
-    chgrp -R ${GROUPNAME} ${TOMCAT_DIR}/webapps/jolokia && \
-    find ${TOMCAT_DIR}/webapps/jolokia -type d -exec chmod 0750 {} \; && \
-    find ${TOMCAT_DIR}/webapps/jolokia -type f -exec chmod 0640 {} \; && \
-    chmod -R g+r ${TOMCAT_DIR}/webapps/jolokia && \
-    chgrp -R ${GROUPNAME} ${TOMCAT_DIR}/webapps/jolokia
+RUN sed -i -e "\$a\grant\ codeBase\ \"file:\$\{catalina.base\}\/webapps\/jolokia\/-\" \{\n\    permission\ java.security.AllPermission\;\n\};" ${TOMCAT_DIR}/conf/catalina.policy && \
 
 USER ${USERID}

--- a/tests/pipeline-all-amps/repo/Dockerfile
+++ b/tests/pipeline-all-amps/repo/Dockerfile
@@ -3,16 +3,17 @@ FROM debian:11-slim AS SWAGGERBUILDER
 
 ARG JOLOKIA_VER 1.6.2
 
-RUN DEBIAN_FRONTEND=noninteractive apt-get -yqq install unzip && \
+RUN DEBIAN_FRONTEND=noninteractive; \
+    apt-get update -yqq && apt-get -yqq install unzip && \
     mkdir -p /build/{api-explorer,gs-api-explorer,jolokia} && \
     curl -o /build/jolokia.war https://repo1.maven.org/maven2/org/jolokia/jolokia-war-unsecured/${JOLOKIA_VER}/jolokia-war-unsecured-${JOLOKIA_VER}.war && \
-    unzip /build/jolokia.war -d /build/jolokia
+    unzip -q /build/jolokia.war -d /build/jolokia
 
 COPY target/wars/api-explorer.war /build
 COPY target/wars/gs-api-explorer.war /build
 
-RUN unzip /build/api-explorer.war -d /build/api-explorer && \
-    unzip /build/gs-api-explorer.war -p /build/gs-api-explorer && \
+RUN unzip -q /build/api-explorer.war -d /build/api-explorer && \
+    unzip -q /build/gs-api-explorer.war -p /build/gs-api-explorer && \
     chmod -R g-w,o= /build
 
 # ACTUAL IMAGE
@@ -30,10 +31,10 @@ COPY idp.jks /usr/src/alfresco/
 COPY target/amps/*.amp ${TOMCAT_DIR}/amps/
 
 # Copy api-explorer
-COPY --chown=root:${GROUPANME} --from SWAGGERBUILDER /build/api-explorer ${TOMCAT_DIR}/webapps
+COPY --chown=root:${GROUPANME} --from=SWAGGERBUILDER /build/api-explorer ${TOMCAT_DIR}/webapps
 
 # Copy gs-api-explorer
-COPY --chown=root:${GROUPANME} --from SWAGGERBUILDER /build/gs-api-explorer ${TOMCAT_DIR}/webapps
+COPY --chown=root:${GROUPANME} --from=SWAGGERBUILDER /build/gs-api-explorer ${TOMCAT_DIR}/webapps
 
 # Turn on log4j debug frequently needed in the single pipeline
 RUN echo -e '\n\

--- a/tests/pipeline-all-amps/repo/Dockerfile
+++ b/tests/pipeline-all-amps/repo/Dockerfile
@@ -1,3 +1,21 @@
+# BUILD STAGE SWAGGERBUILDER
+FROM debian:11-slim AS SWAGGERBUILDER
+
+ARG JOLOKIA_VER 1.6.2
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get -yqq install unzip && \
+    mkdir -p build/{api,ags,jolokia} && \
+    curl -o /tmp/jolokia.war https://repo1.maven.org/maven2/org/jolokia/jolokia-war-unsecured/${JOLOKIA_VER}/jolokia-war-unsecured-${JOLOKIA_VER}.war && \
+    unzip /tmp/jolokia.war -d build/jolokia
+
+COPY target/wars/api-explorer.war 
+COPY target/wars/gs-api-explorer.war
+
+RUN unzip api-explorer.war -d build/api && \
+    unzip gs-api-explorer.war -p build/ags && \
+    chmod -R g-w,o= build
+
+# ACTUAL IMAGE
 FROM alfresco/alfresco-enterprise-repo-base:${repo.image.tag}
 
 USER root
@@ -10,44 +28,19 @@ COPY idp.jks /usr/src/alfresco/
 # Copy the amps from build context to the appropriate location for your application server
 COPY target/amps/*.amp ${TOMCAT_DIR}/amps/
 
-# Copy api-explorer war into webapps folder
-COPY target/wars/api-explorer.war ${TOMCAT_DIR}/webapps/
+# Copy api-explorer
+COPY --chown=root:Alfresco --from SWAGGERBUILDER build/api ${TOMCAT_DIR}/webapps/api-explorer
 
-# Unpack  api-explorer
-RUN mkdir ${TOMCAT_DIR}/webapps/api-explorer && cd ${TOMCAT_DIR}/webapps/api-explorer && \
-  jar -xvf ${TOMCAT_DIR}/webapps/api-explorer.war && rm -f ${TOMCAT_DIR}/webapps/api-explorer.war
-
-# Copy gs-api-explorer war into webapps folder
-COPY target/wars/gs-api-explorer.war ${TOMCAT_DIR}/webapps/
-
-# Unpack gs-api-explorer.war
-RUN mkdir ${TOMCAT_DIR}/webapps/gs-api-explorer && cd ${TOMCAT_DIR}/webapps/gs-api-explorer && \
-  jar -xvf ${TOMCAT_DIR}/webapps/gs-api-explorer.war && rm -f ${TOMCAT_DIR}/webapps/gs-api-explorer.war
+# Copy gs-api-explorer
+COPY --chown=root:Alfresco --from SWAGGERBUILDER build/ags ${TOMCAT_DIR}/webapps/gs-api-explorer
 
 # Turn on log4j debug frequently needed in the single pipeline
 RUN echo -e '\n\
 log4j.logger.org.alfresco.repo.content.transform.TransformerDebug=debug\n\
 ' >> ${TOMCAT_DIR}/shared/classes/alfresco/extension/custom-log4j.properties
 
-
-### Download and unpack jolokia
-RUN mkdir ${TOMCAT_DIR}/webapps/jolokia && \
-    curl -o /tmp/jolokia.war https://repo1.maven.org/maven2/org/jolokia/jolokia-war-unsecured/1.6.2/jolokia-war-unsecured-1.6.2.war && \
-    cd ${TOMCAT_DIR}/webapps/jolokia && \
-    jar xvf /tmp/jolokia.war && \
-    cd ${TOMCAT_DIR} && \
-    rm /tmp/jolokia.war
-
 # Grant all security permissions to jolokia and share in order to work properly.
 RUN sed -i -e "\$a\grant\ codeBase\ \"file:\$\{catalina.base\}\/webapps\/jolokia\/-\" \{\n\    permission\ java.security.AllPermission\;\n\};\ngrant\ codeBase\ \"file:\$\{catalina.base\}\/webapps\/share\/-\" \{\n\    permission\ java.security.AllPermission\;\n\};" ${TOMCAT_DIR}/conf/catalina.policy
-
-## All files in the tomcat folder must be owned by root user and Alfresco group as mentioned in the parent Dockerfile
-RUN chgrp -R Alfresco ${TOMCAT_DIR} && \
-  find ${TOMCAT_DIR}/webapps -type d -exec chmod 0750 {} \; && \
-  find ${TOMCAT_DIR}/webapps -type f -exec chmod 0640 {} \; && \
-  find ${TOMCAT_DIR}/shared -type d -exec chmod 0750 {} \; && \
-  find ${TOMCAT_DIR}/shared -type f -exec chmod 0640 {} \; && \
-  chmod -R g+r ${TOMCAT_DIR}/webapps
 
 #Use the alfresco user
 #USER alfresco

--- a/tests/pipeline-all-amps/repo/Dockerfile
+++ b/tests/pipeline-all-amps/repo/Dockerfile
@@ -1,7 +1,7 @@
 # BUILD STAGE SWAGGERBUILDER
 FROM debian:11-slim AS SWAGGERBUILDER
 
-ARG JOLOKIA_VER 1.6.2
+ARG JOLOKIA_VER=1.6.2
 
 RUN DEBIAN_FRONTEND=noninteractive; \
     apt-get update -yqq && apt-get -yqq install curl unzip && \
@@ -13,7 +13,7 @@ COPY target/wars/api-explorer.war /build
 COPY target/wars/gs-api-explorer.war /build
 
 RUN unzip -q /build/api-explorer.war -d /build/api-explorer && \
-    unzip -q /build/gs-api-explorer.war -p /build/gs-api-explorer && \
+    unzip -q /build/gs-api-explorer.war -d /build/gs-api-explorer && \
     chmod -R g+r,g-w,o= /build
 
 # ACTUAL IMAGE

--- a/tests/pipeline-all-amps/repo/Dockerfile
+++ b/tests/pipeline-all-amps/repo/Dockerfile
@@ -31,10 +31,10 @@ COPY idp.jks /usr/src/alfresco/
 COPY target/amps/*.amp ${TOMCAT_DIR}/amps/
 
 # Copy api-explorer
-COPY --chown=root:${GROUPANME} --from=SWAGGERBUILDER /build/api-explorer ${TOMCAT_DIR}/webapps
+COPY --chown=root:${GROUPANME} --from=SWAGGERBUILDER /build/api-explorer ${TOMCAT_DIR}/webapps/api-explorer
 
 # Copy gs-api-explorer
-COPY --chown=root:${GROUPANME} --from=SWAGGERBUILDER /build/gs-api-explorer ${TOMCAT_DIR}/webapps
+COPY --chown=root:${GROUPANME} --from=SWAGGERBUILDER /build/gs-api-explorer ${TOMCAT_DIR}/webapps/gs-api-explorer
 
 # Turn on log4j debug frequently needed in the single pipeline
 RUN echo -e '\n\

--- a/tests/pipeline-all-amps/repo/Dockerfile
+++ b/tests/pipeline-all-amps/repo/Dockerfile
@@ -4,16 +4,16 @@ FROM debian:11-slim AS SWAGGERBUILDER
 ARG JOLOKIA_VER 1.6.2
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get -yqq install unzip && \
-    mkdir -p build/{api,ags,jolokia} && \
-    curl -o /tmp/jolokia.war https://repo1.maven.org/maven2/org/jolokia/jolokia-war-unsecured/${JOLOKIA_VER}/jolokia-war-unsecured-${JOLOKIA_VER}.war && \
-    unzip /tmp/jolokia.war -d build/jolokia
+    mkdir -p /build/{api-explorer,gs-api-explorer,jolokia} && \
+    curl -o /build/jolokia.war https://repo1.maven.org/maven2/org/jolokia/jolokia-war-unsecured/${JOLOKIA_VER}/jolokia-war-unsecured-${JOLOKIA_VER}.war && \
+    unzip /build/jolokia.war -d /build/jolokia
 
-COPY target/wars/api-explorer.war 
-COPY target/wars/gs-api-explorer.war
+COPY target/wars/api-explorer.war /build
+COPY target/wars/gs-api-explorer.war /build
 
-RUN unzip api-explorer.war -d build/api && \
-    unzip gs-api-explorer.war -p build/ags && \
-    chmod -R g-w,o= build
+RUN unzip /build/api-explorer.war -d /build/api-explorer && \
+    unzip /build/gs-api-explorer.war -p /build/gs-api-explorer && \
+    chmod -R g-w,o= /build
 
 # ACTUAL IMAGE
 FROM alfresco/alfresco-enterprise-repo-base:${repo.image.tag}
@@ -21,6 +21,7 @@ FROM alfresco/alfresco-enterprise-repo-base:${repo.image.tag}
 USER root
 
 ARG TOMCAT_DIR=/usr/local/tomcat
+ARG GROUPANME=Alfresco
 
 # Copy the idp.jks keystore file used to enable AOS with SAML
 COPY idp.jks /usr/src/alfresco/
@@ -29,10 +30,10 @@ COPY idp.jks /usr/src/alfresco/
 COPY target/amps/*.amp ${TOMCAT_DIR}/amps/
 
 # Copy api-explorer
-COPY --chown=root:Alfresco --from SWAGGERBUILDER build/api ${TOMCAT_DIR}/webapps/api-explorer
+COPY --chown=root:${GROUPANME} --from SWAGGERBUILDER /build/api-explorer ${TOMCAT_DIR}/webapps
 
 # Copy gs-api-explorer
-COPY --chown=root:Alfresco --from SWAGGERBUILDER build/ags ${TOMCAT_DIR}/webapps/gs-api-explorer
+COPY --chown=root:${GROUPANME} --from SWAGGERBUILDER /build/gs-api-explorer ${TOMCAT_DIR}/webapps
 
 # Turn on log4j debug frequently needed in the single pipeline
 RUN echo -e '\n\

--- a/tests/pipeline-all-amps/repo/Dockerfile
+++ b/tests/pipeline-all-amps/repo/Dockerfile
@@ -4,7 +4,7 @@ FROM debian:11-slim AS SWAGGERBUILDER
 ARG JOLOKIA_VER 1.6.2
 
 RUN DEBIAN_FRONTEND=noninteractive; \
-    apt-get update -yqq && apt-get -yqq install unzip && \
+    apt-get update -yqq && apt-get -yqq install curl unzip && \
     mkdir -p /build/{api-explorer,gs-api-explorer,jolokia} && \
     curl -o /build/jolokia.war https://repo1.maven.org/maven2/org/jolokia/jolokia-war-unsecured/${JOLOKIA_VER}/jolokia-war-unsecured-${JOLOKIA_VER}.war && \
     unzip -q /build/jolokia.war -d /build/jolokia
@@ -14,7 +14,7 @@ COPY target/wars/gs-api-explorer.war /build
 
 RUN unzip -q /build/api-explorer.war -d /build/api-explorer && \
     unzip -q /build/gs-api-explorer.war -p /build/gs-api-explorer && \
-    chmod -R g-w,o= /build
+    chmod -R g+r,g-w,o= /build
 
 # ACTUAL IMAGE
 FROM alfresco/alfresco-enterprise-repo-base:${repo.image.tag}


### PR DESCRIPTION
`jar` command being part of the JDK we'd rather use multistage builds so we can later on publish JRE only images