### PR TITLE
ACS-2476: [release] 7.2.0-A24 [skip tests] as they have just run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,8 +31,8 @@ env:
     - TAS_SCRIPTS=../alfresco-community-repo/packaging/tests/scripts
     - TAS_ENVIRONMENT=./tests/environment
     # Release version has to start with real version (7.2.0-....) for the docker image to build successfully.
-    - RELEASE_VERSION=7.2.0-M2
-    - DEVELOPMENT_VERSION=7.2.0-A24-SNAPSHOT
+    - RELEASE_VERSION=7.2.0-24
+    - DEVELOPMENT_VERSION=7.2.0-A25-SNAPSHOT
     - DTAS_VERSION="${DTAS_VERSION:-v1.1}"
     - PYTHON_VERSION=3.7.12
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ env:
     - TAS_SCRIPTS=../alfresco-community-repo/packaging/tests/scripts
     - TAS_ENVIRONMENT=./tests/environment
     # Release version has to start with real version (7.2.0-....) for the docker image to build successfully.
-    - RELEASE_VERSION=7.2.0-24
+    - RELEASE_VERSION=7.2.0-A24
     - DEVELOPMENT_VERSION=7.2.0-A25-SNAPSHOT
     - DTAS_VERSION="${DTAS_VERSION:-v1.1}"
     - PYTHON_VERSION=3.7.12


### PR DESCRIPTION
- includes:
  - https://app.travis-ci.com/github/Alfresco/acs-packaging/builds/246890724
  - https://github.com/Alfresco/acs-packaging/commit/efa66963c14a77026450c5613fbd23d03c47b73d
    - com-repo 14.114 (with Camel 3.15.0 / Netty 4.1.73.Final)
    - ent-repo 14.109
    - ent-share 14.71