### PR TITLE
ACS-2749: Replaced straight charAt usage

### DIFF
--- a/tests/tas-all-amps/src/test/java/org/alfresco/rest/discovery/DiscoveryTests.java
+++ b/tests/tas-all-amps/src/test/java/org/alfresco/rest/discovery/DiscoveryTests.java
@@ -46,45 +46,46 @@ public class DiscoveryTests extends RestTest
         restClient.assertStatusCodeIs(HttpStatus.OK);
 
         // Compare information
-        response.getRepository().getVersion().assertThat().field("major").is(version.charAt(0));
-        response.getRepository().getVersion().assertThat().field("minor").is(version.charAt(2));
-        response.getRepository().getVersion().assertThat().field("patch").is(version.charAt(4));
+        String[] semanticVersion = version.split("\\D");
+        response.getRepository().getVersion().assertThat().field("major").is(semanticVersion[0]);
+        response.getRepository().getVersion().assertThat().field("minor").is(semanticVersion[1]);
+        response.getRepository().getVersion().assertThat().field("patch").is(semanticVersion[2]);
         response.getRepository().getVersion().assertThat().field("schema").is(schema);
         response.getRepository().getId().equals(id);
         response.getRepository().getEdition().equals(edition);
         response.getRepository().getStatus().assertThat().field("isReadOnly").is(false);
     }
 
-    @Test(groups = { TestGroup.REST_API, TestGroup.DISCOVERY, TestGroup.ALL_AMPS, TestGroup.SANITY })
-    @TestRail(section = { TestGroup.REST_API, TestGroup.DISCOVERY }, executionType = ExecutionType.SANITY,
-            description = "Sanity tests for GET /discovery endpoint")
-    public void getRepositoryInstalledModules() throws Exception
-    {
-        // Get repository info using Discovery API
-        restClient.authenticateUser(userModel).withDiscoveryAPI().getRepositoryInfo();
-        restClient.assertStatusCodeIs(HttpStatus.OK);
-
-        // Check that all modules are present
-        List<String> modules = restClient.onResponse().getResponse().jsonPath().getList("entry.repository.modules.id", String.class);
-        List<String> expectedModules = Arrays.asList(
-                "alfresco-aos-module",
-                "org.alfresco.integrations.google.docs",
-                "alfresco-trashcan-cleaner",
-                "org_alfresco_integrations_S3Connector",
-                "org_alfresco_integrations_AzureConnector",
-                "alfresco-content-connector-for-salesforce-repo",
-                "alfresco-share-services",
-                "alfresco-saml-repo",
-                "org_alfresco_device_sync_repo",
-                "alfresco-ai-repo",
-                "org_alfresco_module_rm", "alfresco-rm-enterprise-repo"
-        );
-
-        expectedModules.forEach(module ->
-                assertTrue(modules.contains(module), String.format("Expected module %s is not installed", module)));
-
-        // Check that all installed modules are in INSTALLED and also UNKNOWN state as reported by some
-        List<String> modulesStates = restClient.onResponse().getResponse().jsonPath().getList("entry.repository.modules.installState", String.class);
-        assertEquals("Number of amps installed should match expected" + modulesStates, expectedModules.size(), Collections.frequency(modulesStates, "INSTALLED") + Collections.frequency(modulesStates, "UNKNOWN"));
-    }
+//    @Test(groups = { TestGroup.REST_API, TestGroup.DISCOVERY, TestGroup.ALL_AMPS, TestGroup.SANITY })
+//    @TestRail(section = { TestGroup.REST_API, TestGroup.DISCOVERY }, executionType = ExecutionType.SANITY,
+//            description = "Sanity tests for GET /discovery endpoint")
+//    public void getRepositoryInstalledModules() throws Exception
+//    {
+//        // Get repository info using Discovery API
+//        restClient.authenticateUser(userModel).withDiscoveryAPI().getRepositoryInfo();
+//        restClient.assertStatusCodeIs(HttpStatus.OK);
+//
+//        // Check that all modules are present
+//        List<String> modules = restClient.onResponse().getResponse().jsonPath().getList("entry.repository.modules.id", String.class);
+//        List<String> expectedModules = Arrays.asList(
+//                "alfresco-aos-module",
+//                "org.alfresco.integrations.google.docs",
+//                "alfresco-trashcan-cleaner",
+//                "org_alfresco_integrations_S3Connector",
+//                "org_alfresco_integrations_AzureConnector",
+//                "alfresco-content-connector-for-salesforce-repo",
+//                "alfresco-share-services",
+//                "alfresco-saml-repo",
+//                "org_alfresco_device_sync_repo",
+//                "alfresco-ai-repo",
+//                "org_alfresco_module_rm", "alfresco-rm-enterprise-repo"
+//        );
+//
+//        expectedModules.forEach(module ->
+//                assertTrue(modules.contains(module), String.format("Expected module %s is not installed", module)));
+//
+//        // Check that all installed modules are in INSTALLED and also UNKNOWN state as reported by some
+//        List<String> modulesStates = restClient.onResponse().getResponse().jsonPath().getList("entry.repository.modules.installState", String.class);
+//        assertEquals("Number of amps installed should match expected" + modulesStates, expectedModules.size(), Collections.frequency(modulesStates, "INSTALLED") + Collections.frequency(modulesStates, "UNKNOWN"));
+//    }
 }

--- a/tests/tas-all-amps/src/test/java/org/alfresco/rest/discovery/DiscoveryTests.java
+++ b/tests/tas-all-amps/src/test/java/org/alfresco/rest/discovery/DiscoveryTests.java
@@ -56,36 +56,36 @@ public class DiscoveryTests extends RestTest
         response.getRepository().getStatus().assertThat().field("isReadOnly").is(false);
     }
 
-//    @Test(groups = { TestGroup.REST_API, TestGroup.DISCOVERY, TestGroup.ALL_AMPS, TestGroup.SANITY })
-//    @TestRail(section = { TestGroup.REST_API, TestGroup.DISCOVERY }, executionType = ExecutionType.SANITY,
-//            description = "Sanity tests for GET /discovery endpoint")
-//    public void getRepositoryInstalledModules() throws Exception
-//    {
-//        // Get repository info using Discovery API
-//        restClient.authenticateUser(userModel).withDiscoveryAPI().getRepositoryInfo();
-//        restClient.assertStatusCodeIs(HttpStatus.OK);
-//
-//        // Check that all modules are present
-//        List<String> modules = restClient.onResponse().getResponse().jsonPath().getList("entry.repository.modules.id", String.class);
-//        List<String> expectedModules = Arrays.asList(
-//                "alfresco-aos-module",
-//                "org.alfresco.integrations.google.docs",
-//                "alfresco-trashcan-cleaner",
-//                "org_alfresco_integrations_S3Connector",
-//                "org_alfresco_integrations_AzureConnector",
-//                "alfresco-content-connector-for-salesforce-repo",
-//                "alfresco-share-services",
-//                "alfresco-saml-repo",
-//                "org_alfresco_device_sync_repo",
-//                "alfresco-ai-repo",
-//                "org_alfresco_module_rm", "alfresco-rm-enterprise-repo"
-//        );
-//
-//        expectedModules.forEach(module ->
-//                assertTrue(modules.contains(module), String.format("Expected module %s is not installed", module)));
-//
-//        // Check that all installed modules are in INSTALLED and also UNKNOWN state as reported by some
-//        List<String> modulesStates = restClient.onResponse().getResponse().jsonPath().getList("entry.repository.modules.installState", String.class);
-//        assertEquals("Number of amps installed should match expected" + modulesStates, expectedModules.size(), Collections.frequency(modulesStates, "INSTALLED") + Collections.frequency(modulesStates, "UNKNOWN"));
-//    }
+    @Test(groups = { TestGroup.REST_API, TestGroup.DISCOVERY, TestGroup.ALL_AMPS, TestGroup.SANITY })
+    @TestRail(section = { TestGroup.REST_API, TestGroup.DISCOVERY }, executionType = ExecutionType.SANITY,
+            description = "Sanity tests for GET /discovery endpoint")
+    public void getRepositoryInstalledModules() throws Exception
+    {
+        // Get repository info using Discovery API
+        restClient.authenticateUser(userModel).withDiscoveryAPI().getRepositoryInfo();
+        restClient.assertStatusCodeIs(HttpStatus.OK);
+
+        // Check that all modules are present
+        List<String> modules = restClient.onResponse().getResponse().jsonPath().getList("entry.repository.modules.id", String.class);
+        List<String> expectedModules = Arrays.asList(
+                "alfresco-aos-module",
+                "org.alfresco.integrations.google.docs",
+                "alfresco-trashcan-cleaner",
+                "org_alfresco_integrations_S3Connector",
+                "org_alfresco_integrations_AzureConnector",
+                "alfresco-content-connector-for-salesforce-repo",
+                "alfresco-share-services",
+                "alfresco-saml-repo",
+                "org_alfresco_device_sync_repo",
+                "alfresco-ai-repo",
+                "org_alfresco_module_rm", "alfresco-rm-enterprise-repo"
+        );
+
+        expectedModules.forEach(module ->
+                assertTrue(modules.contains(module), String.format("Expected module %s is not installed", module)));
+
+        // Check that all installed modules are in INSTALLED and also UNKNOWN state as reported by some
+        List<String> modulesStates = restClient.onResponse().getResponse().jsonPath().getList("entry.repository.modules.installState", String.class);
+        assertEquals("Number of amps installed should match expected" + modulesStates, expectedModules.size(), Collections.frequency(modulesStates, "INSTALLED") + Collections.frequency(modulesStates, "UNKNOWN"));
+    }
 }


### PR DESCRIPTION
 Now it's a regex split based on non-decimal characters to get the semantic version (major, minor, patch)