### PR TITLE
Fix broken 'envUp' alias

### DIFF
--- a/scripts/dev/start-compose.sh
+++ b/scripts/dev/start-compose.sh
@@ -1,6 +1,6 @@
 set -x
-export TRANSFORMERS_TAG=$(mvn help:evaluate -Dexpression=dependency.alfresco-transform-core.version -q -DforceStdout)
-export TRANSFORM_ROUTER_TAG=$(mvn help:evaluate -Dexpression=dependency.alfresco-transform-service.version -q -DforceStdout)
+export TRANSFORMERS_TAG=$(mvn -f acs-packaging/pom.xml help:evaluate -Dexpression=dependency.alfresco-transform-core.version -q -DforceStdout)
+export TRANSFORM_ROUTER_TAG=$(mvn -f acs-packaging/pom.xml help:evaluate -Dexpression=dependency.alfresco-transform-service.version -q -DforceStdout)
 
 # .env files are picked up from project directory correctly on docker-compose 1.23.0+
 docker-compose -f acs-packaging/dev/docker-compose.yml up


### PR DESCRIPTION
The `envUp` alias is now unusable from the parent directory, as opposed to the previous behaviour _(documented [here](https://github.com/Alfresco/acs-packaging/blob/master/dev/README.md?plain=1#L76-L79))_. This PR restores the original behaviour.