### PR TITLE
ACS-2864 Script the creation of new repo, share and packaging branches after an ACS release

### DIFF
--- a/scripts/dev/newReleaseBranch.sh
+++ b/scripts/dev/newReleaseBranch.sh
@@ -586,12 +586,21 @@ calculateBranchVersions() {
 cleanUpTestBranches() {
   local project="${1}"
 
-  echo "${prefix}Clean up ${hotFixBranch} and ${servicePackBranch} on ${project}"
-  cd "${ROOT_DIR}/${project}/"
-  git checkout .                       &>${loggingOut}
-  git checkout "${masterBranch}"       &>${loggingOut}
-  git branch -D "${hotFixBranch}"      &>${loggingOut}
-  git branch -D "${servicePackBranch}" &>${loggingOut}
+  if [[ "${hotFixRevision}" == "0" ]]
+  then
+    echo "${prefix}Clean up ${hotFixBranch} and ${servicePackBranch} on ${project}"
+    cd "${ROOT_DIR}/${project}/"
+    git checkout .                         &>${loggingOut}
+    git checkout  "${masterBranch}"      &>${loggingOut}
+    git branch -D "${hotFixBranch}"      &>${loggingOut}
+    git branch -D "${servicePackBranch}" &>${loggingOut}
+  else
+    echo "${prefix}Clean up ${hotFixBranch} on ${project}"
+    cd "${ROOT_DIR}/${project}/"
+    git checkout .                         &>${loggingOut}
+    git checkout  "${servicePackBranch}" &>${loggingOut}
+    git branch -D "${hotFixBranch}"      &>${loggingOut}
+  fi
 }
 
 cleanUpTestProjectBranches() {

--- a/scripts/dev/newReleaseBranch.sh
+++ b/scripts/dev/newReleaseBranch.sh
@@ -11,7 +11,7 @@ usage() {
 Creates HotFix and ServicePack (.N) branches for repo, share and packaging projects, and updates the master
 or ServicePack branches ready for the next release.
 
-Usage: $0 <releasedVersion> [-v <masterVersion>] [-h] [-l]
+Usage: $0 <releasedVersion> [-v <masterVersion>] [-h] [-l] [-t] [-c] [-s]
   <releasedVersion>:  The version just released. Used in the new HotFix Branch name release/<releasedVersion>.
                       Must contain 3 integers separated by dots.
   -v <masterVersion>: Overrides the next development version on master so that the major version may be changed.

--- a/scripts/dev/newReleaseBranch.sh
+++ b/scripts/dev/newReleaseBranch.sh
@@ -20,25 +20,20 @@ Usage: $0 <hotfix_version> [-v <master_version>] [-h] [-l]
   -l: Output extra logging
 
 Examples:
-
   1. After the release of 23.1.0 from the master branch:
-
      $ $0 23.1.0
      Creates the HotFix branch for 23.1.0, creates the 23.1.N ServicePack branch and modifies the master branch for
      use by the next minor version 23.2.0.
 
   2. After the release of 23.1.1 from the ServicePack branch release/23.1.N:
-
      $ $0 23.1.1
      Creates the HotFix branch for 23.1.1 and modifies the 23.1.N ServicePack branch for use by the next version 23.1.2
 
   3. After the release of 23.1.2 from the ServicePack branch release/23.1.N
-
      $ $0 23.1.2
      Creates the HotFix branch for 23.1.2 and modifies the 23.1.N ServicePack branch for use by the next version 23.1.3
 
   4. Switching to the next hotfix_major version:
-
      $ $0 23.2.0 -v 25.1.0
      Creates the HotFix branch for 23.2.0, creates the 23.2.N ServicePack branch and modifies the master branch for
      use by the next hotfix_major version 25.1.0.

--- a/scripts/dev/newReleaseBranch.sh
+++ b/scripts/dev/newReleaseBranch.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+set -o errexit
+#set -x
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="${SCRIPT_DIR}/../../.."
+RELEASE_BRANCH_PREFIX=release
+
+usage() {
+    cat << ???  1>&2;
+
+Creates HotFix or ServicePack branches for repo, share and packaging projects or just updates the master
+or ServicePack branches ready for the next release.
+
+Usage: $0 <branch> [-s <source_branch>] [-v <version>] [-p <pom_version>] [-h] [-l]
+  -s <source_branch>: Source branch when creating a new branch
+  -v <version>: An override for the ACS version - must contain 3 numbers separated by dots.
+                In 'release/M.m.r' branches, defaults to the value in the branch. An N becomes a 1 or a 2.
+  -p <pom_version>: An override for the base pom version to be used in repo and share projects.
+                Only needed in ACS versions < 23.1 where it is not the same as the <version>.
+                The initial pom versions have .1-SNAPSHOT appended.
+
+  -h: Display this help
+  -l: Output extra logging
+
+Examples:
+
+  1. After the release of 23.1.0 from the master branch:
+     Create the HotFix branch for 23.1.0
+     Create the 23.1.N ServicePack branch. The initial version will be 23.1.1
+     Modify the master branch for use by the next major or minor version 23.2.0.
+     $ $0 release/23.1.0 -s master
+     $ $0 release/23.1.N -s master -v 23.1.1
+     $ $0 master -v 23.2
+
+  2. After the release of 23.1.1 from the ServicePack branch release/23.1.N:
+     Create the HotFix branch for 23.1.1
+     Modify the ServicePack branch for use by the next version 23.1.2
+     $ $0 release/23.1.1 -s release/23.1.N
+     $ $0 release/23.1.N -v 23.1.2
+
+  3. After the release of 23.1.2 from the ServicePack branch release/23.1.N
+     $ $0 release/23.1.2 -s release/23.1.N
+     $ $0 release/23.1.N -v 23.1.3
+
+  4. After the release of 7.2.1 from the release/7.2.N ServicePack branch.
+
+     Create the HotFix branch for 7.2.1
+     Modify the ServicePack branch for use by the next version 7.2.2. Needs the -p flag as the pom and ACS version do not match before ACS 23.1
+     $ $0 release/7.2.1 -s release/7.2.N
+     $ $0 release/7.2.N -v 7.2.2 -p 16
+???
+}
+
+getVersionMajor() {
+  echo "${1}" | sed -n "s/^${RELEASE_BRANCH_PREFIX}\/\([0-9]*\)\.[0-9]*\.[^.]*$/\1/p"
+}
+
+getVersionMinor() {
+  echo "${1}" | sed -n "s/^${RELEASE_BRANCH_PREFIX}\/[0-9]*\.\([0-9]*\)\.[^.]*$/\1/p"
+}
+
+getVersionRevision() {
+  echo "${1}" | sed -n "s/^${RELEASE_BRANCH_PREFIX}\/[0-9]*\.[0-9]*\.\([^.]*\)$/\1/p"
+}
+
+branch="$1"
+source_branch=""
+version=""
+LOGGING_OUT="/dev/null"
+while getopts "s:v:p:lh" arg; do
+    case $arg in
+        s)
+            source_branch=${OPTARG}
+            ;;
+        v)
+            version=${OPTARG}
+            ;;
+        p)
+            pom_version=${OPTARG}
+            ;;
+        l)
+            LOGGING_OUT=`tty`
+            ;;
+        h | *)
+            usage
+            exit 0
+            ;;
+    esac
+done
+
+branch_major=`getVersionMajor "${branch}"`
+branch_minor=`getVersionMinor "${branch}"`
+branch_revision=`getVersionRevision "${branch}"`
+
+
+#if [ ${branch_revision} -eq "N" ]
+#then
+#  if [ ${branch_major} >= 23]
+#  then
+#     acs_revision=1
+#   else
+#     acs_revision=2
+#   fi
+#else
+#  acs_revision=${branch_revision}
+#fi
+version=${branch_major}.${branch_minor}.${acs_revision}
+
+
+schema_multiple=111
+
+echo branch=$branch
+echo source_branch=$source_branch
+echo version=$version
+
+echo branch_major=$branch_major
+echo branch_minor=$branch_minor
+echo branch_revision=$branch_revision
+
+echo END

--- a/scripts/dev/newReleaseBranch.sh
+++ b/scripts/dev/newReleaseBranch.sh
@@ -155,7 +155,7 @@ setPomVersion() {
   local pomVersion="${1}"
   local profiles="${2}"
 
-  echo "${prefix}    Set pom version ${pomVersion} using profiles: ${profiles}"
+  echo "${prefix}    set pom version ${pomVersion} using profiles: ${profiles}"
   mvn versions:set -DnewVersion="${pomVersion}" -DgenerateBackupPoms=false -P"${profiles}" &>${loggingOut}
 }
 
@@ -172,7 +172,7 @@ setScmTag() {
 
   if [[ "${newBranch}" == "NewBranch" ]]
   then
-    echo "${prefix}    Set <scm><tag> ${tag}"
+    echo "${prefix}    set <scm><tag> ${tag}"
     ed -s pom.xml &>${loggingOut} << EOF
 /<scm>
 /<tag>.*<\/tag>/s//<tag>${tag}<\/tag>/

--- a/scripts/dev/newReleaseBranch.sh
+++ b/scripts/dev/newReleaseBranch.sh
@@ -349,6 +349,12 @@ EOF
   fi
 }
 
+# Each version of the Repo has a schema number stored in it. When we need to patch something, generally the database,
+# we increment the schema by one and create a patch with that number. As a result it is possible for the repo to do the
+# patching on startup. So that we have enough space between versions each major or minor version uses the next multiple
+# of 1000 and each service pack uses the next multiple of 100. Actually patches don't have to have unique numbers, but
+# it does make it simpler to understand what is going to happen. The following code does this calculation with 1000 or
+# 100 being passed in as an argument.
 incrementSchema() {
   local schemaMultiple="${1}"
 
@@ -411,7 +417,13 @@ modifyPomVersion() {
       else
         if [[ "${branchType}" == "Master" ]]
         then
-          # Allow for two service packs before the next release off master
+          # Allow for two service packs before the next release off master.
+          # Prior to 23.1, the pom version of repo and share projects had a fixed number followed by a dot and an
+          # incrementing number. For example ACS 7.0.0 used 8.N, ACS 7.1.0 used 11.N, ACS 7.2.0 used 14.N. To allow
+          # for a couple of service packs between these it would jump two numbers. ACS 7.1.1 used 12.N. Had there been
+          # an ACS 7.1.2 it would have used 13.N. Not that we have done it for years, if there was a need for a third
+          # service pack we would have had to do something special and go down another level. For example ACS 7.1.3
+          # might have used 13.300.N
           pomMajor=`increment "${pomMajor}"`
           pomMajor=`increment "${pomMajor}"`
         fi

--- a/scripts/dev/newReleaseBranch.sh
+++ b/scripts/dev/newReleaseBranch.sh
@@ -17,7 +17,7 @@ Usage: $0 <hotFixVersion> [-v <masterVersion>] [-h] [-l]
                     Ignored if the master branch is not going to be modified. Must contain 3 integers separated by dots.
   -h: Display this help
   -l: Output extra logging
-  -t: use test branches: master-test and release/test/X.x.x
+  -t: use test branches: release/test/master and release/test/X.x.x
   -c: cleanup (delete) local test release/test/X.x.x branches that are about to be created or modified.
   -p: skip the push to the remote git repository
 
@@ -547,7 +547,7 @@ calculateBranchVersions() {
   # Branches
   if [[ -n "${doTest}" ]]
   then
-    masterBranch="master-test"
+    masterBranch="release/test/master"
     hotFixBranch="release/test/${hotFixVersion}"
     servicePackBranch="release/test/${hotFixMajor}.${hotFixMinor}.N"
   else

--- a/scripts/dev/newReleaseBranch.sh
+++ b/scripts/dev/newReleaseBranch.sh
@@ -11,10 +11,11 @@ usage() {
 Creates HotFix and ServicePack (.N) branches for repo, share and packaging projects, and updates the master
 or ServicePack branches ready for the next release.
 
-Usage: $0 <hotFixVersion> [-v <masterVersion>] [-h] [-l]
-  <hotFixVersion>:  HotFix Branch to be created or modified.
-  -v <masterVersion>: Overrides the next development version on master so that the HotFix major version may be changed.
-                    Ignored if the master branch is not going to be modified. Must contain 3 integers separated by dots.
+Usage: $0 <releasedVersion> [-v <masterVersion>] [-h] [-l]
+  <releasedVersion>:  The version just released. Used in the new HotFix Branch name release/<releasedVersion>.
+                      Must contain 3 integers separated by dots.
+  -v <masterVersion>: Overrides the next development version on master so that the major version may be changed.
+                      Ignored if the master branch is not going to be modified. Must contain 3 integers separated by dots.
   -h: Display this help
   -l: Output extra logging
   -t: use test branches: release/test/master and release/test/X.x.x
@@ -542,7 +543,7 @@ calculateBranchVersions() {
   hotFixRevision=`getVersionRevision "${hotFixVersion}"`
   if [[ "${hotFixVersion}" != "${hotFixMajor}.${hotFixMinor}.${hotFixRevision}" ]]
   then
-    echo 'The <hotFixVersion> is invalid. Must contain 3 integers separated by dots.'
+    echo 'The <releasedVersion> is invalid. Must contain 3 integers separated by dots.'
     exit 1
   fi
 

--- a/scripts/dev/newReleaseBranch.sh
+++ b/scripts/dev/newReleaseBranch.sh
@@ -9,75 +9,89 @@ RELEASE_BRANCH_PREFIX=release
 usage() {
     cat << ???  1>&2;
 
-Creates HotFix or ServicePack branches for repo, share and packaging projects or just updates the master
+Creates HotFix and ServicePack (.N) branches for repo, share and packaging projects, and updates the master
 or ServicePack branches ready for the next release.
 
-Usage: $0 <branch> [-s <source_branch>] [-v <version>] [-p <pom_version>] [-h] [-l]
-  -s <source_branch>: Source branch when creating a new branch
-  -v <version>: An override for the ACS version - must contain 3 numbers separated by dots.
-                In 'release/M.m.r' branches, defaults to the value in the branch. An N becomes a 1 or a 2.
-  -p <pom_version>: An override for the base pom version to be used in repo and share projects.
-                Only needed in ACS versions < 23.1 where it is not the same as the <version>.
-                The initial pom versions have .1-SNAPSHOT appended.
-
+Usage: $0 <hotfix_version> [-v <master_version>] [-h] [-l]
+  <hotfix_version>:  HotFix Branch to be created or modified.
+  -v <master_version>: Overrides the next development version on master so that the hotfix_major version may be changed.
+                    Ignored if the master branch is not going to be modified. Must contain 3 numbers separated by dots.
   -h: Display this help
   -l: Output extra logging
 
 Examples:
 
   1. After the release of 23.1.0 from the master branch:
-     Create the HotFix branch for 23.1.0
-     Create the 23.1.N ServicePack branch. The initial version will be 23.1.1
-     Modify the master branch for use by the next major or minor version 23.2.0.
-     $ $0 release/23.1.0 -s master
-     $ $0 release/23.1.N -s master -v 23.1.1
-     $ $0 master -v 23.2
+
+     $ $0 23.1.0
+     Creates the HotFix branch for 23.1.0, creates the 23.1.N ServicePack branch and modifies the master branch for
+     use by the next minor version 23.2.0.
 
   2. After the release of 23.1.1 from the ServicePack branch release/23.1.N:
-     Create the HotFix branch for 23.1.1
-     Modify the ServicePack branch for use by the next version 23.1.2
-     $ $0 release/23.1.1 -s release/23.1.N
-     $ $0 release/23.1.N -v 23.1.2
+
+     $ $0 23.1.1
+     Creates the HotFix branch for 23.1.1 and modifies the 23.1.N ServicePack branch for use by the next version 23.1.2
 
   3. After the release of 23.1.2 from the ServicePack branch release/23.1.N
-     $ $0 release/23.1.2 -s release/23.1.N
-     $ $0 release/23.1.N -v 23.1.3
 
-  4. After the release of 7.2.1 from the release/7.2.N ServicePack branch.
+     $ $0 23.1.2
+     Creates the HotFix branch for 23.1.2 and modifies the 23.1.N ServicePack branch for use by the next version 23.1.3
 
-     Create the HotFix branch for 7.2.1
-     Modify the ServicePack branch for use by the next version 7.2.2. Needs the -p flag as the pom and ACS version do not match before ACS 23.1
-     $ $0 release/7.2.1 -s release/7.2.N
-     $ $0 release/7.2.N -v 7.2.2 -p 16
+  4. Switching to the next hotfix_major version:
+
+     $ $0 23.2.0 -v 25.1.0
+     Creates the HotFix branch for 23.2.0, creates the 23.2.N ServicePack branch and modifies the master branch for
+     use by the next hotfix_major version 25.1.0.
 ???
 }
 
 getVersionMajor() {
-  echo "${1}" | sed -n "s/^${RELEASE_BRANCH_PREFIX}\/\([0-9]*\)\.[0-9]*\.[^.]*$/\1/p"
+  echo "${1}" | sed -n "s/^\([0-9]*\)\.[0-9]*\.[0-9N]*$/\1/p"
 }
 
 getVersionMinor() {
-  echo "${1}" | sed -n "s/^${RELEASE_BRANCH_PREFIX}\/[0-9]*\.\([0-9]*\)\.[^.]*$/\1/p"
+  echo "${1}" | sed -n "s/^[0-9]*\.\([0-9]*\)\.[0-9N]*$/\1/p"
 }
 
 getVersionRevision() {
-  echo "${1}" | sed -n "s/^${RELEASE_BRANCH_PREFIX}\/[0-9]*\.[0-9]*\.\([^.]*\)$/\1/p"
+  echo "${1}" | sed -n "s/^[0-9]*\.[0-9]*\.\([0-9N]*\)$/\1/p"
 }
 
-branch="$1"
-source_branch=""
-version=""
+increment() {
+  local number="${1}"
+  echo "${number} + 1" | bc
+}
+
+getVersionSchema() {
+  # TODO
+  echo 17002
+}
+
+setVersionSchema() {
+  echo TODO setVersionSchema
+}
+
+incrementVersionSchema() {
+  local version_multiple="${1}"
+  local version_schema=`getVersionSchema`
+  version_schema=`echo "(${version_schema} / ${schema_multiple} + 1) * ${schema_multiple}" | bc`
+  setVersionSchema "${version_schema}"
+}
+
+# Read the command line arguments
+hotfix_version="${1}"
+if [ -z "${hotfix_version}" ]
+then
+  usage
+  exit 0
+fi
+
+master_version=""
 LOGGING_OUT="/dev/null"
-while getopts "s:v:p:lh" arg; do
+while getopts "v:lh" arg; do
     case $arg in
-        s)
-            source_branch=${OPTARG}
-            ;;
         v)
-            version=${OPTARG}
-            ;;
-        p)
-            pom_version=${OPTARG}
+            master_version=${OPTARG}
             ;;
         l)
             LOGGING_OUT=`tty`
@@ -89,33 +103,82 @@ while getopts "s:v:p:lh" arg; do
     esac
 done
 
-branch_major=`getVersionMajor "${branch}"`
-branch_minor=`getVersionMinor "${branch}"`
-branch_revision=`getVersionRevision "${branch}"`
+# HotFix branch version
+hotfix_major=`getVersionMajor "${hotfix_version}"`
+hotfix_minor=`getVersionMinor "${hotfix_version}"`
+hotfix_revision=`getVersionRevision "${hotfix_version}"`
+if [[ "${hotfix_version}" != "${hotfix_major}.${hotfix_minor}.${hotfix_revision}" ]]
+then
+  echo 'The <hotfix_version> is invalid. Must contain 3 numbers separated by dots.'
+  exit 1
+fi
 
+# ServicePack branch version
+if [[ "${release_branch}" == "master"  ]]
+then
+  servicepack_revision="0"
+else
+  servicepack_revision=`increment "${hotfix_revision}"`
+fi
+servicepack_version="${hotfix_major}.${hotfix_minor}.${servicepack_revision}"
 
-#if [ ${branch_revision} -eq "N" ]
-#then
-#  if [ ${branch_major} >= 23]
-#  then
-#     acs_revision=1
-#   else
-#     acs_revision=2
-#   fi
-#else
-#  acs_revision=${branch_revision}
-#fi
-version=${branch_major}.${branch_minor}.${acs_revision}
-
-
-schema_multiple=111
+# Master branch version
+if [ -z "${master_version}" ]
+then
+  master_major=`increment "${hotfix_minor}"`
+  master_version="${hotfix_major}.${master_major}.0"
+else
+  master_major=`getVersionMajor "${master_version}"`
+  master_minor=`getVersionMinor "${master_version}"`
+  master_revision=`getVersionRevision "${master_version}"`
+  if [[ "${master_version}" != "${master_major}.${master_minor}.${master_revision}" ]]
+  then
+    echo 'The <master_version> is invalid. Must contain 3 numbers separated by dots.'
+    exit 1
+  fi
+fi
 
 echo branch=$branch
+echo hotfix_major=$hotfix_major
+echo minor=$minor
+echo hotfix_revision=$hotfix_revision
 echo source_branch=$source_branch
 echo version=$version
+echo pom_version=$pom_version
+echo schema_multiple=$schema_multiple
+echo version_schema=$version_schema
 
-echo branch_major=$branch_major
-echo branch_minor=$branch_minor
-echo branch_revision=$branch_revision
+#hotfix_version_schema=`getVersionSchema`
+#servicepack_version_schema=`incrementVersionSchema "${hotfix_version_schema}" 100`
 
-echo END
+release_branch=master
+hotfix_branch=release/23.1.0
+servicepack_branch=release/23.1.N
+servicepack_version=23.1.1
+master_version=23.2.0
+
+# Create the HotFix branch
+forkBranch "${release_branch}" "${hotfix_version}" "${hotfix_branch}"
+buildBranch
+
+# Create or update the ServicePack branch
+if [[ "${release_branch}" == "master"  ]]
+then
+  forkBranch "${hotfix_branch}" "${hotfix_version}" "${servicepack_branch}"
+else
+  checkoutBranch "${servicepack_branch}"
+fi
+setVersion "${servicepack_version}"
+incrementVersionSchema 100
+buildBranch
+
+# Update the master branch
+if [[ "${release_branch}" == "master"  ]]
+then
+  checkoutBranch master
+  setVersion "${master_version}"
+  incrementVersionSchema 1000
+  buildBranch
+fi
+
+echo DONE

--- a/tests/pipeline-all-amps/repo/dtas/dtas-config.json
+++ b/tests/pipeline-all-amps/repo/dtas/dtas-config.json
@@ -7,7 +7,7 @@
     "assertions": {
         "acs": {
             "edition": "Enterprise",
-            "version": "23.1.0",
+            "version": "${acs.version.major}.${acs.version.minor}.${acs.version.revision}",
             "identity": false,
             "modules": [
                 {


### PR DESCRIPTION
Script to creates HotFix and ServicePack (.N) branches for repo, share and packaging projects, and updates the master or ServicePack branches ready for the next release.

- This script may be used following releases >= 7.2.1.
- Master must have been used for major or mion releases and .N branches for service pack releases.

https://alfresco.atlassian.net/wiki/spaces/TECH/pages/962298737/ACS+Release+Process+-+Creating+the+branches+after+a+release

This script will be cherry picked back to release/7.2.N