### PR TITLE
ACS-2803: Prevent  CMIS tests queries from going to the database 

### DIFF
--- a/tests/tas-elasticsearch/src/test/java/org/alfresco/elasticsearch/AlfrescoStackInitializer.java
+++ b/tests/tas-elasticsearch/src/test/java/org/alfresco/elasticsearch/AlfrescoStackInitializer.java
@@ -285,6 +285,7 @@ public class AlfrescoStackInitializer implements ApplicationContextInitializer<C
                                 "-DlocalTransform.core-aio.url=http://transform-core-aio:8090/ " +
                                 "-Dcsrf.filter.enabled=false " +
                                 "-Dalfresco.restApi.basicAuthScheme=true " +
+                                "-Dsolr.query.cmis.queryConsistency=EVENTUAL " +
                                 "-Xms1500m -Xmx1500m ")
                        .withNetwork(network)
                        .withNetworkAliases("alfresco")

--- a/tests/tas-elasticsearch/src/test/java/org/alfresco/elasticsearch/ElasticsearchCMISTests.java
+++ b/tests/tas-elasticsearch/src/test/java/org/alfresco/elasticsearch/ElasticsearchCMISTests.java
@@ -96,28 +96,13 @@ public class ElasticsearchCMISTests extends AbstractTestNGSpringContextTests
         createContent(USER_2_FILE_NAME, "This is a test file that user1 does not have access to, but it still contains " + UNIQUE_WORD, siteModel2, user2);
     }
 
-    @TestRail (description = "Verify that we can perform a basic CMIS query against Elasticsearch.", section = TestGroup.SEARCH, executionType = ExecutionType.REGRESSION)
-    @Test (groups = TestGroup.SEARCH)
-    public void basicCMISQuery()
-    {
-        SearchRequest query = req("cmis", "SELECT cmis:name FROM cmis:document WHERE CONTAINS('*')");
-        searchQueryService.expectSomeResultsFromQuery(query, user1);
-    }
-
-    @TestRail(description = "Verify that we can perform a basic CMIS query against the DB.", section = TestGroup.SEARCH, executionType = ExecutionType.REGRESSION)
-    @Test(groups = TestGroup.SEARCH)
-    public void basicCMISQueryAgainstDB()
-    {
-        // This query will be handled by the DB rather than ES.
-        SearchRequest query = req("cmis", "SELECT cmis:name FROM cmis:document");
-        searchQueryService.expectSomeResultsFromQuery(query, user1);
-    }
+    //TODO Basic CMIS Query: "SELECT * FROM cmis:document"
 
     @TestRail (description = "Check we can use the CMIS LIKE syntax to match a prefix.", section = TestGroup.SEARCH, executionType = ExecutionType.REGRESSION)
     @Test (groups = TestGroup.SEARCH)
     public void matchNamesLikePrefix()
     {
-        SearchRequest query = req("cmis", "SELECT * FROM cmis:document WHERE cmis:name LIKE '" + PREFIX + "%' AND CONTAINS('*')");
+        SearchRequest query = req("cmis", "SELECT * FROM cmis:document WHERE cmis:name LIKE '" + PREFIX + "%'");
         searchQueryService.expectResultsFromQuery(query, user1, FILE_0_NAME, FILE_1_NAME, FILE_2_NAME);
     }
 
@@ -125,7 +110,7 @@ public class ElasticsearchCMISTests extends AbstractTestNGSpringContextTests
     @Test (groups = TestGroup.SEARCH)
     public void matchNamesLikeSuffix()
     {
-        SearchRequest query = req("cmis", "SELECT * FROM cmis:document WHERE cmis:name LIKE '%" + SUFFIX + "' AND CONTAINS('*')");
+        SearchRequest query = req("cmis", "SELECT * FROM cmis:document WHERE cmis:name LIKE '%" + SUFFIX + "'");
         searchQueryService.expectResultsFromQuery(query, user1, FILE_0_NAME, FILE_1_NAME, FILE_2_NAME);
     }
 
@@ -143,7 +128,7 @@ public class ElasticsearchCMISTests extends AbstractTestNGSpringContextTests
     public void checkPermissionForUser2()
     {
         // Reuse the prefix query to check which documents user2 can access.
-        SearchRequest query = req("cmis", "SELECT * FROM cmis:document WHERE cmis:name LIKE '" + PREFIX + "%' AND CONTAINS('*')");
+        SearchRequest query = req("cmis", "SELECT * FROM cmis:document WHERE cmis:name LIKE '" + PREFIX + "%'");
         searchQueryService.expectResultsFromQuery(query, user2, FILE_2_NAME, USER_2_FILE_NAME);
     }
 
@@ -151,7 +136,7 @@ public class ElasticsearchCMISTests extends AbstractTestNGSpringContextTests
     @Test (groups = TestGroup.SEARCH)
     public void matchDocumentName()
     {
-        SearchRequest query = req("cmis", "SELECT * FROM cmis:document WHERE cmis:name = '" + FILE_0_NAME + "' AND CONTAINS('*')");
+        SearchRequest query = req("cmis", "SELECT * FROM cmis:document WHERE cmis:name = '" + FILE_0_NAME + "'");
         searchQueryService.expectResultsFromQuery(query, user1, FILE_0_NAME);
     }
 
@@ -159,7 +144,7 @@ public class ElasticsearchCMISTests extends AbstractTestNGSpringContextTests
     @Test (groups = TestGroup.SEARCH)
     public void checkInSyntax()
     {
-        SearchRequest query = req("cmis", "SELECT * FROM cmis:document WHERE cmis:name IN ('" + FILE_0_NAME + "', '" + FILE_1_NAME + "') AND CONTAINS('*')");
+        SearchRequest query = req("cmis", "SELECT * FROM cmis:document WHERE cmis:name IN ('" + FILE_0_NAME + "', '" + FILE_1_NAME + "')");
         searchQueryService.expectResultsFromQuery(query, user1, FILE_0_NAME, FILE_1_NAME);
     }
 


### PR DESCRIPTION
Along with adding the `queryContistency` property and removing the `CONTAINS('*')` clauses, I have also removed 2 tests. The one testing queries to the DB is now redundant, whereas the second one should be added again once ACS-2920 is solved. 