### PR TITLE
ACS-2925: Elasticsearch - refactor DB switching to not use Solr-specific properties

### DIFF
--- a/tests/tas-elasticsearch/src/test/java/org/alfresco/elasticsearch/AlfrescoStackInitializer.java
+++ b/tests/tas-elasticsearch/src/test/java/org/alfresco/elasticsearch/AlfrescoStackInitializer.java
@@ -286,7 +286,7 @@ public class AlfrescoStackInitializer implements ApplicationContextInitializer<C
                                 "-DlocalTransform.core-aio.url=http://transform-core-aio:8090/ " +
                                 "-Dcsrf.filter.enabled=false " +
                                 "-Dalfresco.restApi.basicAuthScheme=true " +
-                                "-Dsolr.query.cmis.queryConsistency=EVENTUAL " +
+                                "-Dquery.cmis.queryConsistency=EVENTUAL " +
                                 "-Xms1500m -Xmx1500m ")
                        .withNetwork(network)
                        .withNetworkAliases("alfresco")


### PR DESCRIPTION
- update tas-elasticsearch tests (via TestContainers) to override new "query.cmis.queryConsistency" (instesd of deprecated "solr."query.cmis.queryConsistency") prop
- note: follow-on to:
-- https://github.com/Alfresco/alfresco-community-repo/pull/1089
-- https://github.com/Alfresco/alfresco-enterprise-repo/pull/800