### PR TITLE
ACS-3254 Bump Alfresco SAML to 1.2.3-A1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <alfresco.azure-connector.version>3.0.0</alfresco.azure-connector.version>
 
         <alfresco.salesforce-connector.version>2.3.5</alfresco.salesforce-connector.version>
-        <alfresco.saml.version>1.2.2</alfresco.saml.version>
+        <alfresco.saml.version>1.2.3-A1</alfresco.saml.version>
         <alfresco.outlook.version>2.9.0</alfresco.outlook.version>
         <alfresco.transformation-engine.version>2.3.1</alfresco.transformation-engine.version>
         <alfresco.desktop-sync.version>4.0.0-M1</alfresco.desktop-sync.version>


### PR DESCRIPTION
Bumping Alfresco SAML to the latest version _([1.2.3-A1](https://github.com/Alfresco/alfresco-saml-module/releases/tag/1.2.3-A1))_.