### PR TITLE
Use version of alfresco-digital-workspace from .env (2.7.0)

### DIFF
--- a/tests/environment/docker-compose-pipeline-all-amps.yml
+++ b/tests/environment/docker-compose-pipeline-all-amps.yml
@@ -160,7 +160,7 @@ services:
             - 61613:61613 # STOMP
 
     digital-workspace:
-        image: quay.io/alfresco/alfresco-digital-workspace:2.0.0-adw
+        image: quay.io/alfresco/alfresco-digital-workspace:${DIGITAL_WORKSPACE_TAG}
         mem_limit: 128m
         environment:
             BASE_PATH: ./


### PR DESCRIPTION
The original ticket asked for upgrade to 2.2.0 but this is out of date.
Code changed to use the version in .env which is currently 2.7.0.

The Single Pipeline image tests successfully pulled and started `quay.io/alfresco/alfresco-digital-workspace:2.7.0`.