### PR TITLE
APPS-1677 Remove unnecessary MAVEN_OPTS when building Share

### DIFF
--- a/scripts/travis/build.sh
+++ b/scripts/travis/build.sh
@@ -88,14 +88,6 @@ if [[ "${SHARE_DEPENDENCY_VERSION}" =~ ^.+-SNAPSHOT$ ]] && [ "${TRAVIS_BUILD_STA
 fi
 
 SHARE_UPSTREAM_REPO="github.com/Alfresco/alfresco-enterprise-share.git"
-# Temporarily opening reflective access during compilation for enterprise-share
-# This could be removed once enterprise-share will become Java 17 compliant
-# (Maven plugins included e.g.: maven-war-plugin)
-export MAVEN_OPTS="--add-opens=java.base/java.util=ALL-UNNAMED \
---add-opens=java.base/java.lang=ALL-UNNAMED \
---add-opens=java.base/java.lang.reflect=ALL-UNNAMED \
---add-opens=java.base/java.text=ALL-UNNAMED \
---add-opens=java.desktop/java.awt.font=ALL-UNNAMED"
 # Checkout the upstream alfresco-enterprise-share project (tag or branch; + build if the latter)
 if [[ "${SHARE_DEPENDENCY_VERSION}" =~ ^.+-SNAPSHOT$ ]] ; then
   pullAndBuildSameBranchOnUpstream "${SHARE_UPSTREAM_REPO}" "-Pbuild-docker-images -Pags -Dlicense.failOnNotUptodateHeader=true -Ddocker.quay-expires.value=NEVER ${REPO_IMAGE} -Ddependency.alfresco-community-repo.version=${COM_DEPENDENCY_VERSION} -Ddependency.alfresco-enterprise-repo.version=${ENT_DEPENDENCY_VERSION}"


### PR DESCRIPTION
These `MAVEN_OPTS` to open reflective access at compile time were necessary when Share was not compatible with Java 17 yet. It's safe to assume this workaround is not needed anymore since Share has been upgraded to be compatible with Java 17.