### PR TITLE
ACS-3160 Open java.lang for Integration TAS tests

### DIFF
--- a/tests/tas-integration/pom.xml
+++ b/tests/tas-integration/pom.xml
@@ -128,8 +128,10 @@
                     <suiteXmlFiles>
                         <suiteXmlFile>${suiteXmlFile}</suiteXmlFile>
                     </suiteXmlFiles>
+                    <!-- Keeping illegal-access=warn for Java 11 compatibility, even though it has no effect on JDK 17 -->
                     <argLine>
                         --illegal-access=warn
+                        --add-opens=java.base/java.lang=ALL-UNNAMED
                     </argLine>
                 </configuration>
             </plugin>


### PR DESCRIPTION
Integration TAS tests will require reflective access to `java.lang` once the migration to Log4j2 is complete, example of a failing build with Log4j2: https://app.travis-ci.com/github/Alfresco/acs-packaging/jobs/586708111#L800.