### PR TITLE
Change ACS SP page to latest

### DIFF
--- a/distribution/src/main/resources/VERSIONS.md
+++ b/distribution/src/main/resources/VERSIONS.md
@@ -1,6 +1,6 @@
 # Component Versions
 
-This file lists the recommended components for this Service Pack. Use it along with the [Supported Platforms Matrix](http://docs.alfresco.com/7.0/concepts/supported-platforms-ACS.html) and the [Alfresco Documentation](https://docs.alfresco.com/7.0/concepts/ch-upgrade.html) to apply selective component upgrades.
+This file lists the recommended components for this Service Pack. Use it along with the [Supported Platforms Matrix](https://docs.alfresco.com/content-services/latest/support/) and the [Alfresco Documentation](https://docs.alfresco.com/7.0/concepts/ch-upgrade.html) to apply selective component upgrades.
 
 #### Alfresco Content Services @project.version@
 


### PR DESCRIPTION
Changed the link to reflect a dynamic supported platforms page rather than a hard-coded version.