### PR TITLE
ACS-3871 Bump Azure Connector to 3.2.0-A1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <alfresco.rm-enterprise-rest-api-explorer.version>3.0.2</alfresco.rm-enterprise-rest-api-explorer.version>
 
         <alfresco.s3connector.version>5.1.0</alfresco.s3connector.version>
-        <alfresco.azure-connector.version>3.1.0</alfresco.azure-connector.version>
+        <alfresco.azure-connector.version>3.2.0-A1</alfresco.azure-connector.version>
         <alfresco.salesforce-connector.version>2.4.0-A1</alfresco.salesforce-connector.version>
         <alfresco.outlook.version>2.9.0</alfresco.outlook.version>
         <alfresco.transformation-engine.version>3.0.0</alfresco.transformation-engine.version>


### PR DESCRIPTION
Bump Azure Connector to the latest version relying on Log4j 2.x.