### PR TITLE
Improve logs to investigate DependaBot PRs failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -426,10 +426,12 @@ jobs:
       - name: "Run tests"
         id: tests
         timeout-minutes: 20
+        # ${{ env.TAS_SCRIPTS }}/wait-for-alfresco-start.sh "http://localhost:8082/alfresco"
+        # temporarily replaced with full logs rather than 200 lines, to analyze DependaBot PRs failures
         run: |
           ./tests/scripts/checkLibraryDuplicates.sh ./tests/tas-all-amps/target/war/alfresco/WEB-INF/lib
           ${{ env.TAS_SCRIPTS }}/start-compose.sh ${{ env.TAS_ENVIRONMENT }}/docker-compose-all-amps-test.yml
-          ${{ env.TAS_SCRIPTS }}/wait-for-alfresco-start.sh "http://localhost:8082/alfresco"
+          bash ./scripts/ci/wait-for-alfresco-start.sh "http://localhost:8082/alfresco"
           mvn -B install -ntp -f tests/tas-all-amps/pom.xml -Pall-tas-tests -Denvironment=default -DrunBugs=false
       - name: "Print output after failure"
         if: ${{ always() && steps.tests.outcome == 'failure' }}

--- a/scripts/ci/wait-for-alfresco-start.sh
+++ b/scripts/ci/wait-for-alfresco-start.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+export ALFRESCO_URL=$1
+export EXTRA_WAIT_INTERVAL=$2
+
+if [ -z "$ALFRESCO_URL" ]
+then
+  echo "Please provide the Alfresco URL to check, for example: \"${0##*/} http://localhost:8080/alfresco\""
+  exit 1
+fi
+
+WAIT_INTERVAL=1
+COUNTER=0
+TIMEOUT=300
+t0=$(date +%s)
+
+echo "Waiting for alfresco to start"
+until $(curl --output /dev/null --silent --head --fail ${ALFRESCO_URL}) || [ "$COUNTER" -eq "$TIMEOUT" ]; do
+   printf '.'
+   sleep $WAIT_INTERVAL
+   COUNTER=$(($COUNTER+$WAIT_INTERVAL))
+done
+
+if (("$COUNTER" < "$TIMEOUT")) ; then
+   t1=$(date +%s)
+   delta=$((($t1 - $t0)/60))
+   echo "Alfresco Started in $delta minutes"
+
+   if [ -n "$EXTRA_WAIT_INTERVAL" ]
+   then
+      echo "Waiting an extra $EXTRA_WAIT_INTERVAL for all the containers to initialise..."
+      sleep $EXTRA_WAIT_INTERVAL
+      echo "Waited $EXTRA_WAIT_INTERVAL seconds"
+   fi
+else
+   echo "Waited $COUNTER seconds"
+   echo "Alfresco Could not start in time."
+   echo "All started containers:"
+   docker ps -a
+   ALFCONTAINER=`docker ps -a | grep _alfresco | awk '{ print $1 }'`
+   echo "Logs from alfresco.log on container $ALFCONTAINER:"
+   docker logs $ALFCONTAINER
+   exit 1
+fi


### PR DESCRIPTION
Temporarily show full Docker logs instead of last 200 lines, in order to better investigate DependaBot PR failures such as: https://github.com/Alfresco/acs-packaging/actions/runs/3967360229/jobs/6799228445