### PR TITLE
Bump upstream repo versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,12 +10,12 @@
         <groupId>org.alfresco</groupId>
         <artifactId>alfresco-enterprise-repo</artifactId>
         <relativePath>../alfresco-enterprise-repo/pom.xml</relativePath>
-        <version>20.47</version>
+        <version>20.48</version>
     </parent>
 
     <properties>
-        <dependency.alfresco-enterprise-repo.version>20.47</dependency.alfresco-enterprise-repo.version>
-        <dependency.alfresco-enterprise-share.version>20.43</dependency.alfresco-enterprise-share.version>
+        <dependency.alfresco-enterprise-repo.version>20.48</dependency.alfresco-enterprise-repo.version>
+        <dependency.alfresco-enterprise-share.version>20.44</dependency.alfresco-enterprise-share.version>
 
         <alfresco.rm-enterprise-rest-api-explorer.version>3.0.2</alfresco.rm-enterprise-rest-api-explorer.version>
 
@@ -24,7 +24,7 @@
         <alfresco.salesforce-connector.version>2.4.0-M1</alfresco.salesforce-connector.version>
         <alfresco.outlook.version>2.9.0</alfresco.outlook.version>
         <alfresco.transformation-engine.version>3.0.0</alfresco.transformation-engine.version>
-        <alfresco.desktop-sync.version>3.9.0-A1</alfresco.desktop-sync.version>
+        <alfresco.desktop-sync.version>4.0.0-M6</alfresco.desktop-sync.version>
         <alfresco.ais.version>1.4.5</alfresco.ais.version>
 
         <acs.version>${acs.version.major}.${acs.version.minor}.${acs.version.revision}${acs.version.label}</acs.version>


### PR DESCRIPTION
Manually bump upstream repo versions until `alfresco-enterprise-share` build is fixed to work well with GHA.