### PR TITLE
ACS-3750 Improve branch detection in if conditions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
     name: "Source Clear Scan (SCA)"
     runs-on: ubuntu-latest
     if: >
-      ((github.ref_name == 'master' || contains(github.ref_name, 'release/')) && github.event_name != 'pull_request') &&
+      ((github.ref_name == 'master' || startsWith(github.ref_name, 'release/')) && github.event_name != 'pull_request') &&
       !contains(github.event.head_commit.message, '[skip tests]')
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/master_release.yml
+++ b/.github/workflows/master_release.yml
@@ -61,7 +61,7 @@ jobs:
     if: >
       !failure() &&
       !contains(github.event.head_commit.message, '[skip docker_release]') &&
-      contains(github.ref_name, 'release/') && github.event_name != 'pull_request'
+      startsWith(github.ref_name, 'release/') && github.event_name != 'pull_request'
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Replace `contains` with `startsWith` for better branch detection.