### PR TITLE
ACS-4844 Temporarily force amps installation

### DIFF
--- a/docker-alfresco/Dockerfile
+++ b/docker-alfresco/Dockerfile
@@ -24,7 +24,7 @@ COPY ${resource_path}/amps/* ${TOMCAT_DIR}/amps/
 # Install amps on alfresco.war
 RUN java -jar ${TOMCAT_DIR}/alfresco-mmt/alfresco-mmt*.jar install \
               ${TOMCAT_DIR}/amps \
-              ${TOMCAT_DIR}/webapps/alfresco -directory -nobackup
+              ${TOMCAT_DIR}/webapps/alfresco -directory -nobackup -force
 
 # The standard configuration is to have all Tomcat files owned by root with group GROUPNAME and whilst owner has read/write privileges,
 # group only has restricted permissions and world has no permissions.

--- a/docker-alfresco/ags/Dockerfile
+++ b/docker-alfresco/ags/Dockerfile
@@ -32,7 +32,7 @@ COPY --chown=root:${GROUPNAME} --from=AGSBUILDER /build/gs-api-explorer /usr/loc
 ## All files in the tomcat folder must be owned by root user and Alfresco group as mentioned in the parent Dockerfile
 RUN java -jar /usr/local/tomcat/alfresco-mmt/alfresco-mmt*.jar install \
               /usr/local/tomcat/amps \
-              /usr/local/tomcat/webapps/alfresco -directory -nobackup && \
+              /usr/local/tomcat/webapps/alfresco -directory -nobackup -force && \
     sed -i -e "\$a\grant\ codeBase\ \"file:\$\{catalina.base\}\/webapps\/jolokia\/-\" \{\n\    permission\ java.security.AllPermission\;\n\};\ngrant\ codeBase\ \"file:\$\{catalina.base\}\/webapps\/share\/-\" \{\n\    permission\ java.security.AllPermission\;\n\};" /usr/local/tomcat/conf/catalina.policy && \
     chgrp -R Alfresco /usr/local/tomcat && \
     find /usr/local/tomcat/webapps -type d -exec chmod 0750 {} \; && \

--- a/docker-alfresco/aws/Dockerfile
+++ b/docker-alfresco/aws/Dockerfile
@@ -26,7 +26,7 @@ COPY ${resource_path}/connector/* ${TOMCAT_DIR}/lib/
 # Install amps on alfresco.war
 RUN java -jar ${TOMCAT_DIR}/alfresco-mmt/alfresco-mmt*.jar install \
               ${TOMCAT_DIR}/amps \
-              ${TOMCAT_DIR}/webapps/alfresco -directory -nobackup
+              ${TOMCAT_DIR}/webapps/alfresco -directory -nobackup -force
 
 # The standard configuration is to have all Tomcat files owned by root with group GROUPNAME and whilst owner has read/write privileges,
 # group only has restricted permissions and world has no permissions.

--- a/docker-share/aws/Dockerfile
+++ b/docker-share/aws/Dockerfile
@@ -6,7 +6,7 @@ ARG TOMCAT_DIR=/usr/local/tomcat
 # Copy Dockerfile to avoid an error if no AMPs exist
 COPY target/dependency/*.amp $TOMCAT_DIR/amps_share/
 RUN java -jar $TOMCAT_DIR/alfresco-mmt/alfresco-mmt*.jar install \
-              $TOMCAT_DIR/amps_share $TOMCAT_DIR/webapps/share -directory -nobackup
+              $TOMCAT_DIR/amps_share $TOMCAT_DIR/webapps/share -directory -nobackup -force
 
 EXPOSE 8000
 

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <alfresco.rm-enterprise-rest-api-explorer.version>3.0.2</alfresco.rm-enterprise-rest-api-explorer.version>
 
         <alfresco.s3connector.version>5.1.0</alfresco.s3connector.version>
-        <alfresco.azure-connector.version>3.2.0-A4</alfresco.azure-connector.version>
+        <alfresco.azure-connector.version>3.2.0-A5</alfresco.azure-connector.version>
         <alfresco.salesforce-connector.version>2.4.0-M2</alfresco.salesforce-connector.version>
         <alfresco.outlook.version>2.9.0</alfresco.outlook.version>
         <alfresco.transformation-engine.version>3.0.0</alfresco.transformation-engine.version>

--- a/pom.xml
+++ b/pom.xml
@@ -10,12 +10,12 @@
         <groupId>org.alfresco</groupId>
         <artifactId>alfresco-enterprise-repo</artifactId>
         <relativePath>../alfresco-enterprise-repo/pom.xml</relativePath>
-        <version>20.96</version>
+        <version>20.97</version>
     </parent>
 
     <properties>
-        <dependency.alfresco-enterprise-repo.version>20.96</dependency.alfresco-enterprise-repo.version>
-        <dependency.alfresco-enterprise-share.version>20.94</dependency.alfresco-enterprise-share.version>
+        <dependency.alfresco-enterprise-repo.version>20.97</dependency.alfresco-enterprise-repo.version>
+        <dependency.alfresco-enterprise-share.version>20.95</dependency.alfresco-enterprise-share.version>
 
         <alfresco.rm-enterprise-rest-api-explorer.version>3.0.2</alfresco.rm-enterprise-rest-api-explorer.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <alfresco.rm-enterprise-rest-api-explorer.version>3.0.2</alfresco.rm-enterprise-rest-api-explorer.version>
 
         <alfresco.s3connector.version>5.1.0</alfresco.s3connector.version>
-        <alfresco.azure-connector.version>3.2.0-M1</alfresco.azure-connector.version>
+        <alfresco.azure-connector.version>3.2.0-A4</alfresco.azure-connector.version>
         <alfresco.salesforce-connector.version>2.4.0-M2</alfresco.salesforce-connector.version>
         <alfresco.outlook.version>2.9.0</alfresco.outlook.version>
         <alfresco.transformation-engine.version>3.0.0</alfresco.transformation-engine.version>

--- a/tests/scripts/checkLibraryDuplicates.sh
+++ b/tests/scripts/checkLibraryDuplicates.sh
@@ -12,7 +12,6 @@ lib_dir=$1
 multiple_version_lib_list=""
 
 echo "Scanning libraries from $lib_dir"
-find $lib_dir -name "*.jar" | sort
 if [[ -n "$WHITELIST" ]]; then
     echo "Skipping libraries which match the whitelist, check for false positives:"
 fi

--- a/tests/scripts/checkLibraryDuplicates.sh
+++ b/tests/scripts/checkLibraryDuplicates.sh
@@ -12,6 +12,7 @@ lib_dir=$1
 multiple_version_lib_list=""
 
 echo "Scanning libraries from $lib_dir"
+find $lib_dir -name "*.jar" | sort
 if [[ -n "$WHITELIST" ]]; then
     echo "Skipping libraries which match the whitelist, check for false positives:"
 fi


### PR DESCRIPTION
This is a workaround for a circular dependency between acs-packaging and amps. Should be reverted when AMPs are released and integrated into the acs-packaging.