### PR TITLE
Revert "ACS-4139 Temporarily disable multi-arch for pipeline-all-amps…

### DIFF
--- a/tests/pipeline-all-amps/pom.xml
+++ b/tests/pipeline-all-amps/pom.xml
@@ -156,8 +156,7 @@
                                             <builderName>${builder.name}</builderName>
                                             <platforms>
                                                 <platform>linux/amd64</platform>
-                                        <!-- Please restore linux/arm64 once the migration to Flux2 in terraform-alfresco-pipeline is done -->
-<!--                                                <platform>linux/arm64</platform>-->
+                                                <platform>linux/arm64</platform>
                                             </platforms>
                                         </buildx>
                                         <dockerFileDir>${project.basedir}</dockerFileDir>


### PR DESCRIPTION
… images (#2415)"

This reverts commit 776354e520b246e5459a392da69d6c62dfb9f7c9.