### PR TITLE
ACS-4970 Bump Azure Connector to 3.2.0-A7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <alfresco.rm-enterprise-rest-api-explorer.version>3.0.2</alfresco.rm-enterprise-rest-api-explorer.version>
 
         <alfresco.s3connector.version>5.1.0</alfresco.s3connector.version>
-        <alfresco.azure-connector.version>3.2.0-A6</alfresco.azure-connector.version>
+        <alfresco.azure-connector.version>3.2.0-A7</alfresco.azure-connector.version>
         <alfresco.salesforce-connector.version>2.4.0-M2</alfresco.salesforce-connector.version>
         <alfresco.outlook.version>2.9.0</alfresco.outlook.version>
         <alfresco.transformation-engine.version>3.0.0</alfresco.transformation-engine.version>


### PR DESCRIPTION
Fixes lib collisions between the ACS repo and AMPs.