### PR TITLE
GHA Workflow on master/release - Fix publish stage 

### DIFF
--- a/.github/workflows/master_release.yml
+++ b/.github/workflows/master_release.yml
@@ -180,6 +180,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           persist-credentials: false
+          fetch-depth: 0
       - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.35.2
       - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v1.35.2
       - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.35.2


### PR DESCRIPTION
Newly created tag was not being able to be checked-out