### PR TITLE
ACS-5044 Reinstate Elasticsearch tests for MS SQL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -306,10 +306,10 @@ jobs:
             search-engine-type: elasticsearch
             db-type: mariadb
           # Disabled as build takes 50 minutes and testRecreateIndexWithMetadataAndContentAndPath usually fails - see ACS-5044
-          #- testSuite: Elasticsearch MS SQL
-          #  profiles: all-tas-tests,elastic
-          #  search-engine-type: elasticsearch
-          #  db-type: mssql
+          - testSuite: Elasticsearch MS SQL
+            profiles: all-tas-tests,elastic
+            search-engine-type: elasticsearch
+            db-type: mssql
           - testSuite: Elasticsearch Oracle 19.3.0-ee
             profiles: all-tas-tests,elastic
             search-engine-type: elasticsearch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -305,7 +305,6 @@ jobs:
             profiles: all-tas-tests,elastic
             search-engine-type: elasticsearch
             db-type: mariadb
-          # Disabled as build takes 50 minutes and testRecreateIndexWithMetadataAndContentAndPath usually fails - see ACS-5044
           - testSuite: Elasticsearch MS SQL
             profiles: all-tas-tests,elastic
             search-engine-type: elasticsearch

--- a/tests/tas-elasticsearch/src/test/java/org/alfresco/elasticsearch/reindexing/ElasticsearchReindexingTests.java
+++ b/tests/tas-elasticsearch/src/test/java/org/alfresco/elasticsearch/reindexing/ElasticsearchReindexingTests.java
@@ -173,7 +173,7 @@ public class ElasticsearchReindexingTests extends AbstractTestNGSpringContextTes
     {
         // Initial timestamp for reindexing by date: this will save reindexing time for these tests
         ZonedDateTime now = ZonedDateTime.now(Clock.systemUTC());
-        String testStart = DateTimeFormatter.ofPattern("yyyyMMddHHmm").format(now.minusMinutes(10));
+        String testStart = DateTimeFormatter.ofPattern("yyyyMMddHHmm").format(now.minusMinutes(20));
 
         // GIVEN
         // Stop ElasticsearchConnector


### PR DESCRIPTION
Also, increased time to reindex from 10 minutes to 20 minutes