### PR TITLE
ACS-4955 Remove unnecessary resteasy version overrides

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,11 +10,11 @@
         <groupId>org.alfresco</groupId>
         <artifactId>alfresco-enterprise-repo</artifactId>
         <relativePath>../alfresco-enterprise-repo/pom.xml</relativePath>
-        <version>23.1.0.106</version>
+        <version>23.1.0.107-SNAPSHOT</version>
     </parent>
 
     <properties>
-        <dependency.alfresco-enterprise-repo.version>23.1.0.106</dependency.alfresco-enterprise-repo.version>
+        <dependency.alfresco-enterprise-repo.version>23.1.0.107-SNAPSHOT</dependency.alfresco-enterprise-repo.version>
         <dependency.alfresco-enterprise-share.version>23.1.0.107</dependency.alfresco-enterprise-share.version>
 
         <alfresco.rm-enterprise-rest-api-explorer.version>3.0.2</alfresco.rm-enterprise-rest-api-explorer.version>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 
     <properties>
         <dependency.alfresco-enterprise-repo.version>23.1.0.107-SNAPSHOT</dependency.alfresco-enterprise-repo.version>
-        <dependency.alfresco-enterprise-share.version>23.1.0.107</dependency.alfresco-enterprise-share.version>
+        <dependency.alfresco-enterprise-share.version>23.1.0.108-SNAPSHOT</dependency.alfresco-enterprise-share.version>
 
         <alfresco.rm-enterprise-rest-api-explorer.version>3.0.2</alfresco.rm-enterprise-rest-api-explorer.version>
 

--- a/tests/tas-cmis/pom.xml
+++ b/tests/tas-cmis/pom.xml
@@ -113,31 +113,6 @@
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>
-
-        <dependency>
-            <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-client</artifactId>
-            <version>3.13.2.Final</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-multipart-provider</artifactId>
-            <version>3.13.2.Final</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-jaxb-provider</artifactId>
-            <version>3.13.2.Final</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-jackson2-provider</artifactId>
-            <version>3.13.2.Final</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
Overrides seem to be now unnecessary even though they were introduced to address https://alfresco.atlassian.net/browse/ACS-3604.