### PR TITLE
ACS-4955 Bump Azure Connector to 3.3.0-A3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <alfresco.rm-enterprise-rest-api-explorer.version>3.0.2</alfresco.rm-enterprise-rest-api-explorer.version>
 
         <alfresco.s3connector.version>5.1.1-A2</alfresco.s3connector.version>
-        <alfresco.azure-connector.version>3.3.0-A1</alfresco.azure-connector.version>
+        <alfresco.azure-connector.version>3.3.0-A2</alfresco.azure-connector.version>
         <alfresco.salesforce-connector.version>2.4.0</alfresco.salesforce-connector.version>
         <alfresco.outlook.version>2.9.0</alfresco.outlook.version>
         <alfresco.transformation-engine.version>3.2.0-A1</alfresco.transformation-engine.version>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <alfresco.rm-enterprise-rest-api-explorer.version>3.0.2</alfresco.rm-enterprise-rest-api-explorer.version>
 
         <alfresco.s3connector.version>5.1.1-A2</alfresco.s3connector.version>
-        <alfresco.azure-connector.version>3.3.0-A2</alfresco.azure-connector.version>
+        <alfresco.azure-connector.version>3.3.0-A3</alfresco.azure-connector.version>
         <alfresco.salesforce-connector.version>2.4.0</alfresco.salesforce-connector.version>
         <alfresco.outlook.version>2.9.0</alfresco.outlook.version>
         <alfresco.transformation-engine.version>3.2.0-A1</alfresco.transformation-engine.version>


### PR DESCRIPTION
To test compatibility with the latest Camel bump.

**NOTE:** it seems there are issues with the latest Camel bump, which will be reverted and this PR will be re-used to bump Azure Connector to a 3.3.0-Ax with an appropriate version of enterprise-repo as parent.