### PR TITLE
ACS-4799: Elasticsearch query feature expansion - boosts

### DIFF
--- a/tests/tas-elasticsearch/src/test/java/org/alfresco/elasticsearch/ElasticsearchBoostedSearchTests.java
+++ b/tests/tas-elasticsearch/src/test/java/org/alfresco/elasticsearch/ElasticsearchBoostedSearchTests.java
@@ -104,19 +104,19 @@ public class ElasticsearchBoostedSearchTests extends AbstractTestNGSpringContext
     @Test(groups = { TestGroup.SEARCH })
     public void testAftsQuery_complexTermBoost()
     {
-        String boostedQuery1 = "TYPE:('cm:content'^3.5 OR 'cm:folder'^0.5)^4 AND (cm:name:" + SEARCH_TERM + "^4 OR cm:title:" + SEARCH_TERM + "^0.05)";
+        String boostedQuery1 = "TYPE:('cm:content'^4 OR 'cm:folder'^0.5)^3 AND (cm:name:" + SEARCH_TERM + "^3.5 OR cm:title:" + SEARCH_TERM + "^0.05)";
         SearchRequest searchRequest = req("afts", boostedQuery1);
         searchQueryService.expectResultsInOrder(searchRequest, testUser, fileWithTermInName.getName(), fileWithTermInTitle.getName(), folderWithTermInName.getName(), folderWithTermInTitle.getName());
 
-        String boostedQuery2 = "TYPE:('cm:content'^0.5 OR 'cm:folder'^3.5)^4 AND (cm:name:" + SEARCH_TERM + "^4 OR cm:title:" + SEARCH_TERM + "^0.05)";
+        String boostedQuery2 = "TYPE:('cm:content'^0.5 OR 'cm:folder'^4)^3 AND (cm:name:" + SEARCH_TERM + "^3.5 OR cm:title:" + SEARCH_TERM + "^0.05)";
         searchRequest = req("afts", boostedQuery2);
         searchQueryService.expectResultsInOrder(searchRequest, testUser, folderWithTermInName.getName(), folderWithTermInTitle.getName(), fileWithTermInName.getName(), fileWithTermInTitle.getName());
 
-        String boostedQuery3 = "TYPE:('cm:content'^3.5 OR 'cm:folder'^0.5)^0.25 AND (cm:name:" + SEARCH_TERM + "^0.05 OR cm:title:" + SEARCH_TERM + "^4)";
+        String boostedQuery3 = "TYPE:('cm:content'^4 OR 'cm:folder'^0.5)^0.33 AND (cm:name:" + SEARCH_TERM + "^0.05 OR cm:title:" + SEARCH_TERM + "^3.5)";
         searchRequest = req("afts", boostedQuery3);
         searchQueryService.expectResultsInOrder(searchRequest, testUser, fileWithTermInTitle.getName(), fileWithTermInName.getName(), folderWithTermInTitle.getName(), folderWithTermInName.getName());
 
-        String boostedQuery4 = "TYPE:('cm:content'^0.5 OR 'cm:folder'^3.5)^0.25 AND (cm:name:" + SEARCH_TERM + "^0.05 OR cm:title:" + SEARCH_TERM + "^4)";
+        String boostedQuery4 = "TYPE:('cm:content'^0.5 OR 'cm:folder'^4)^0.33 AND (cm:name:" + SEARCH_TERM + "^0.05 OR cm:title:" + SEARCH_TERM + "^3.5)";
         searchRequest = req("afts", boostedQuery4);
         searchQueryService.expectResultsInOrder(searchRequest, testUser, folderWithTermInTitle.getName(), folderWithTermInName.getName(), fileWithTermInTitle.getName(), fileWithTermInName.getName());
     }

--- a/tests/tas-elasticsearch/src/test/java/org/alfresco/elasticsearch/ElasticsearchBoostedSearchTests.java
+++ b/tests/tas-elasticsearch/src/test/java/org/alfresco/elasticsearch/ElasticsearchBoostedSearchTests.java
@@ -104,19 +104,19 @@ public class ElasticsearchBoostedSearchTests extends AbstractTestNGSpringContext
     @Test(groups = { TestGroup.SEARCH })
     public void testAftsQuery_complexTermBoost()
     {
-        String boostedQuery1 = "TYPE:('cm:content'^4 OR 'cm:folder'^0.5)^3 AND (cm:name:" + SEARCH_TERM + "^3.5 OR cm:title:" + SEARCH_TERM + "^0.05)";
+        String boostedQuery1 = "TYPE:('cm:content'^4 OR 'cm:folder'^0.5)^4 AND (cm:name:" + SEARCH_TERM + "^3.5 OR cm:title:" + SEARCH_TERM + "^0.05)";
         SearchRequest searchRequest = req("afts", boostedQuery1);
         searchQueryService.expectResultsInOrder(searchRequest, testUser, fileWithTermInName.getName(), fileWithTermInTitle.getName(), folderWithTermInName.getName(), folderWithTermInTitle.getName());
 
-        String boostedQuery2 = "TYPE:('cm:content'^0.5 OR 'cm:folder'^4)^3 AND (cm:name:" + SEARCH_TERM + "^3.5 OR cm:title:" + SEARCH_TERM + "^0.05)";
+        String boostedQuery2 = "TYPE:('cm:content'^0.5 OR 'cm:folder'^4)^4 AND (cm:name:" + SEARCH_TERM + "^3.5 OR cm:title:" + SEARCH_TERM + "^0.05)";
         searchRequest = req("afts", boostedQuery2);
         searchQueryService.expectResultsInOrder(searchRequest, testUser, folderWithTermInName.getName(), folderWithTermInTitle.getName(), fileWithTermInName.getName(), fileWithTermInTitle.getName());
 
-        String boostedQuery3 = "TYPE:('cm:content'^4 OR 'cm:folder'^0.5)^0.33 AND (cm:name:" + SEARCH_TERM + "^0.05 OR cm:title:" + SEARCH_TERM + "^3.5)";
+        String boostedQuery3 = "TYPE:('cm:content'^4 OR 'cm:folder'^0.5)^0.25 AND (cm:name:" + SEARCH_TERM + "^0.05 OR cm:title:" + SEARCH_TERM + "^3.5)";
         searchRequest = req("afts", boostedQuery3);
         searchQueryService.expectResultsInOrder(searchRequest, testUser, fileWithTermInTitle.getName(), fileWithTermInName.getName(), folderWithTermInTitle.getName(), folderWithTermInName.getName());
 
-        String boostedQuery4 = "TYPE:('cm:content'^0.5 OR 'cm:folder'^4)^0.33 AND (cm:name:" + SEARCH_TERM + "^0.05 OR cm:title:" + SEARCH_TERM + "^3.5)";
+        String boostedQuery4 = "TYPE:('cm:content'^0.5 OR 'cm:folder'^4)^0.25 AND (cm:name:" + SEARCH_TERM + "^0.05 OR cm:title:" + SEARCH_TERM + "^3.5)";
         searchRequest = req("afts", boostedQuery4);
         searchQueryService.expectResultsInOrder(searchRequest, testUser, folderWithTermInTitle.getName(), folderWithTermInName.getName(), fileWithTermInTitle.getName(), fileWithTermInName.getName());
     }

--- a/tests/tas-elasticsearch/src/test/java/org/alfresco/elasticsearch/ElasticsearchBoostedSearchTests.java
+++ b/tests/tas-elasticsearch/src/test/java/org/alfresco/elasticsearch/ElasticsearchBoostedSearchTests.java
@@ -1,0 +1,306 @@
+package org.alfresco.elasticsearch;
+
+import static org.alfresco.elasticsearch.SearchQueryService.req;
+import static org.alfresco.utility.data.RandomData.getRandomFile;
+import static org.alfresco.utility.data.RandomData.getRandomName;
+import static org.apache.commons.lang3.StringUtils.EMPTY;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+
+import org.alfresco.rest.model.RestTagModel;
+import org.alfresco.rest.search.SearchRequest;
+import org.alfresco.tas.AlfrescoStackInitializer;
+import org.alfresco.utility.data.DataContent;
+import org.alfresco.utility.data.DataUser;
+import org.alfresco.utility.model.ContentModel;
+import org.alfresco.utility.model.FileModel;
+import org.alfresco.utility.model.FileType;
+import org.alfresco.utility.model.FolderModel;
+import org.alfresco.utility.model.TestGroup;
+import org.alfresco.utility.model.UserModel;
+import org.alfresco.utility.network.ServerHealth;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.testng.AbstractTestNGSpringContextTests;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+@ContextConfiguration(locations = "classpath:alfresco-elasticsearch-context.xml",
+    initializers = AlfrescoStackInitializer.class)
+public class ElasticsearchBoostedSearchTests extends AbstractTestNGSpringContextTests
+{
+    private static final String SEARCH_TERM = "mountain";
+    private static final String DIFFERENT_SEARCH_TERM = SEARCH_TERM.replaceFirst("^.", "f");
+
+    @Autowired
+    private ServerHealth serverHealth;
+
+    @Autowired
+    private DataUser dataUser;
+
+    @Autowired
+    private DataContent dataContent;
+
+    @Autowired
+    private SearchQueryService searchQueryService;
+
+    private UserModel testUser;
+    private ContentModel fileWithTermInName;
+    private ContentModel fileWithDifferentTermInName;
+    private ContentModel fileWithPhraseInContent;
+    private ContentModel fileWithTermInTitle;
+    private ContentModel folderWithTermInName;
+    private ContentModel folderWithTermInTitle;
+    private LocalDateTime creationTime;
+    private LocalDateTime afterCreationTime;
+
+    @BeforeClass(alwaysRun = true)
+    public void dataPreparation() throws Exception
+    {
+        serverHealth.assertServerIsOnline();
+
+        testUser = dataUser.createRandomTestUser();
+        fileWithTermInName = createFile(SEARCH_TERM + ".txt", "dummy content");
+        fileWithDifferentTermInName = createFile(DIFFERENT_SEARCH_TERM + ".txt", "dummy other content");
+        fileWithPhraseInContent = createFile(getRandomFile(FileType.TEXT_PLAIN), "content with " + SEARCH_TERM + " searched phrase");
+        folderWithTermInName = createFolder(SEARCH_TERM);
+        creationTime = ZonedDateTime.now(Clock.system(ZoneOffset.UTC)).toLocalDateTime();
+        fileWithTermInTitle = createRandomFileWithTitle(SEARCH_TERM);
+        folderWithTermInTitle = createRandomFolderWithTitle(SEARCH_TERM);
+        afterCreationTime = ZonedDateTime.now(Clock.system(ZoneOffset.UTC)).toLocalDateTime();
+    }
+
+    @AfterClass
+    public void afterClass()
+    {
+        dataContent.usingAdmin().usingResource(fileWithTermInName).deleteContent();
+        dataContent.usingAdmin().usingResource(fileWithDifferentTermInName).deleteContent();
+        dataContent.usingAdmin().usingResource(fileWithPhraseInContent).deleteContent();
+        dataContent.usingAdmin().usingResource(folderWithTermInName).deleteContent();
+        dataContent.usingAdmin().usingResource(fileWithTermInTitle).deleteContent();
+        dataContent.usingAdmin().usingResource(folderWithTermInTitle).deleteContent();
+        dataUser.deleteUser(testUser);
+    }
+
+    @Test(groups = { TestGroup.SEARCH })
+    public void testAftsQuery_simpleTermBoost()
+    {
+        String query = "TYPE:('cm:content'^2 OR 'cm:folder'^0.5) AND cm:name:" + SEARCH_TERM;
+        SearchRequest request = req("afts", query);
+        searchQueryService.expectResultsInOrder(request, testUser, fileWithTermInName.getName(), folderWithTermInName.getName());
+
+        String queryInvertedBoost = "TYPE:('cm:content'^0.5 OR 'cm:folder'^2) AND cm:name:" + SEARCH_TERM;
+        SearchRequest requestInvertedBoost = req("afts", queryInvertedBoost);
+        searchQueryService.expectResultsInOrder(requestInvertedBoost, testUser, folderWithTermInName.getName(), fileWithTermInName.getName());
+    }
+
+    @Test(groups = { TestGroup.SEARCH })
+    public void testAftsQuery_complexTermBoost()
+    {
+        String boostedQuery1 = "TYPE:('cm:content'^4 OR 'cm:folder'^0.5) AND (cm:name:" + SEARCH_TERM + "^2 OR cm:title:" + SEARCH_TERM + "^0.1)^0.5";
+        SearchRequest boostedQueryRequest1 = req("afts", boostedQuery1);
+        searchQueryService.expectResultsInOrder(boostedQueryRequest1, testUser, fileWithTermInName.getName(), fileWithTermInTitle.getName(), folderWithTermInName.getName(), folderWithTermInTitle.getName());
+
+        String boostedQuery2 = "TYPE:('cm:content'^0.5 OR 'cm:folder'^4)^2 AND (cm:name:" + SEARCH_TERM + "^2 OR cm:title:" + SEARCH_TERM + "^0.1)";
+        SearchRequest boostedQueryRequest2 = req("afts", boostedQuery2);
+        searchQueryService.expectResultsInOrder(boostedQueryRequest2, testUser, folderWithTermInName.getName(), folderWithTermInTitle.getName(), fileWithTermInName.getName(), fileWithTermInTitle.getName());
+
+        String boostedQuery3 = "TYPE:('cm:content'^4 OR 'cm:folder'^0.5)^2 AND (cm:name:" + SEARCH_TERM + "^0.1 OR cm:title:" + SEARCH_TERM + "^2)";
+        SearchRequest boostedQueryRequest3 = req("afts", boostedQuery3);
+        searchQueryService.expectResultsInOrder(boostedQueryRequest3, testUser, fileWithTermInName.getName(), fileWithTermInTitle.getName(), folderWithTermInName.getName(), folderWithTermInTitle.getName());
+
+        String boostedQuery4 = "TYPE:('cm:content'^0.5 OR 'cm:folder'^4) AND (cm:name:" + SEARCH_TERM + "^0.1 OR cm:title:" + SEARCH_TERM + "^2)^0.5";
+        SearchRequest boostedQueryRequest4 = req("afts", boostedQuery4);
+        searchQueryService.expectResultsInOrder(boostedQueryRequest4, testUser, folderWithTermInName.getName(), folderWithTermInTitle.getName(), fileWithTermInName.getName(), fileWithTermInTitle.getName());
+    }
+
+    @Test(groups = { TestGroup.SEARCH })
+    public void testAftsQuery_phraseBoost()
+    {
+        String query = "TYPE:'cm:content' AND (cm:name:" + SEARCH_TERM + "^2 OR TEXT:'" + SEARCH_TERM + " searched'^0.1)";
+        SearchRequest request = req("afts", query);
+        searchQueryService.expectResultsInOrder(request, testUser, fileWithTermInName.getName(), fileWithPhraseInContent.getName());
+
+        String queryInvertedBoost = "TYPE:'cm:content' AND (cm:name:" + SEARCH_TERM + "^0.1 OR TEXT:'" + SEARCH_TERM + " searched'^2)";
+        SearchRequest requestInvertedBoost = req("afts", queryInvertedBoost);
+        searchQueryService.expectResultsInOrder(requestInvertedBoost, testUser, fileWithPhraseInContent.getName(), fileWithTermInName.getName());
+    }
+
+    @Test(groups = { TestGroup.SEARCH })
+    public void testAftsQuery_exactTermBoost()
+    {
+        String query = "TYPE:'cm:content' AND (=cm:name:" + SEARCH_TERM + ".txt^2 OR =cm:content:" + SEARCH_TERM + "^0.5)";
+        SearchRequest request = req("afts", query);
+        searchQueryService.expectResultsInOrder(request, testUser, fileWithTermInName.getName(), fileWithPhraseInContent.getName());
+
+        String queryInvertedBoost = "TYPE:'cm:content' AND (=cm:name:" + SEARCH_TERM + ".txt^0.1 OR =cm:content:" + SEARCH_TERM + "^3)";
+        SearchRequest requestInvertedBoost = req("afts", queryInvertedBoost);
+        searchQueryService.expectResultsInOrder(requestInvertedBoost, testUser, fileWithPhraseInContent.getName(), fileWithTermInName.getName());
+    }
+
+    @Test(groups = { TestGroup.SEARCH })
+    public void testAftsQuery_expandedTermBoost()
+    {
+        String query = "TYPE:'cm:content' AND (~cm:name:" + SEARCH_TERM + "^3 OR ~cm:name:" + DIFFERENT_SEARCH_TERM + "^0.1)";
+        SearchRequest request = req("afts", query);
+        searchQueryService.expectResultsInOrder(request, testUser, fileWithTermInName.getName(), fileWithDifferentTermInName.getName());
+
+        String queryInvertedBoost = "TYPE:'cm:content' AND (~cm:name:" + SEARCH_TERM + "^0.1 OR ~cm:name:" + DIFFERENT_SEARCH_TERM + "^3)";
+        SearchRequest requestInvertedBoost = req("afts", queryInvertedBoost);
+        searchQueryService.expectResultsInOrder(requestInvertedBoost, testUser, fileWithDifferentTermInName.getName(), fileWithTermInName.getName());
+    }
+
+    @Test(groups = { TestGroup.SEARCH })
+    public void testAftsQuery_fuzzyMatchingBoost()
+    {
+        String query = "TYPE:'cm:content' AND (cm:name:" + SEARCH_TERM + "~0.7^3 OR cm:title:" + SEARCH_TERM + "^0.01)";
+        SearchRequest request = req("afts", query);
+        searchQueryService.expectResultsInOrder(request, testUser, fileWithTermInName.getName(), fileWithDifferentTermInName.getName(), fileWithTermInTitle.getName());
+
+        String queryInvertedBoost = "TYPE:'cm:content' AND (cm:name:" + SEARCH_TERM + "~0.7^0.01 OR cm:title:" + SEARCH_TERM + "^3)";
+        SearchRequest requestInvertedBoost = req("afts", queryInvertedBoost);
+        searchQueryService.expectResultsInOrder(requestInvertedBoost, testUser, fileWithTermInTitle.getName(), fileWithTermInName.getName(), fileWithDifferentTermInName.getName());
+    }
+
+    @Test(groups = { TestGroup.SEARCH })
+    public void testAftsQuery_proximitySearchBoost()
+    {
+        String query = "TYPE:'cm:content' AND (cm:name:" + SEARCH_TERM + "^5 OR TEXT:(" + SEARCH_TERM + " * phrase)^0.1)";
+        SearchRequest request = req("afts", query);
+        searchQueryService.expectResultsInOrder(request, testUser, fileWithTermInName.getName(), fileWithPhraseInContent.getName());
+
+        String queryInvertedBoost = "TYPE:'cm:content' AND (cm:name:" + SEARCH_TERM + "^0.1 OR TEXT:(" + SEARCH_TERM + " * phrase)^5)";
+        SearchRequest requestInvertedBoost = req("afts", queryInvertedBoost);
+        searchQueryService.expectResultsInOrder(requestInvertedBoost, testUser, fileWithPhraseInContent.getName(), fileWithTermInName.getName());
+    }
+
+    @Test(groups = { TestGroup.SEARCH })
+    public void testAftsQuery_dateRangeSearchBoost()
+    {
+        String timeFrom = creationTime.format(DateTimeFormatter.ISO_DATE_TIME);
+        String timeTo = afterCreationTime.format(DateTimeFormatter.ISO_DATE_TIME);
+        String query = "TYPE:('cm:content'^2 OR 'cm:folder') AND (cm:name:" + SEARCH_TERM + "^3 OR cm:created:['" + timeFrom + "' TO '" + timeTo + "']^0.1)";
+        SearchRequest request = req("afts", query);
+        searchQueryService.expectResultsInOrder(request, testUser, fileWithTermInName.getName(), folderWithTermInName.getName(), fileWithTermInTitle.getName(), folderWithTermInTitle.getName());
+
+        String queryInvertedBoost = "TYPE:('cm:content'^2 OR 'cm:folder') AND (cm:name:" + SEARCH_TERM + "^0.1 OR cm:created:['" + timeFrom + "' TO '" + timeTo + "']^3)";
+        SearchRequest requestInvertedBoost = req("afts", queryInvertedBoost);
+        searchQueryService.expectResultsInOrder(requestInvertedBoost, testUser, fileWithTermInTitle.getName(), folderWithTermInTitle.getName(), fileWithTermInName.getName(), folderWithTermInName.getName());
+    }
+
+    @Test(groups = { TestGroup.SEARCH })
+    public void testAftsQuery_wordsRangeSearchBoost()
+    {
+        String query = "TYPE:'cm:content' AND (cm:name:" + SEARCH_TERM + "^3 OR cm:content:" + SEARCH_TERM + "..phrase^0.1)";
+        SearchRequest request = req("afts", query);
+        searchQueryService.expectResultsStartingWithOneOf(request, testUser, fileWithTermInName.getName());
+        searchQueryService.expectResultsFromQuery(request, testUser, fileWithTermInName.getName(), fileWithPhraseInContent.getName(), fileWithDifferentTermInName.getName());
+
+        String queryInvertedBoost = "TYPE:'cm:content' AND (cm:name:" + SEARCH_TERM + "^0.1 OR cm:content:" + SEARCH_TERM + "..phrase^3)";
+        SearchRequest requestInvertedBoost = req("afts", queryInvertedBoost);
+        searchQueryService.expectResultsStartingWithOneOf(request, testUser, fileWithPhraseInContent.getName(), fileWithDifferentTermInName.getName());
+        searchQueryService.expectResultsFromQuery(requestInvertedBoost, testUser, fileWithTermInName.getName(), fileWithPhraseInContent.getName(), fileWithDifferentTermInName.getName());
+    }
+
+    @Test(groups = { TestGroup.SEARCH })
+    public void testAftsQuery_wildcardSearchBoost()
+    {
+        String wildcardTerm = SEARCH_TERM.replaceFirst("^.", "?");
+        String query = "TYPE:'cm:content' AND (cm:name:" + wildcardTerm + "^3 OR cm:title:" + SEARCH_TERM + "^0.1)";
+        SearchRequest request = req("afts", query);
+        searchQueryService.expectResultsStartingWithOneOf(request, testUser, fileWithTermInName.getName(), fileWithDifferentTermInName.getName());
+        searchQueryService.expectResultsFromQuery(request, testUser, fileWithTermInName.getName(), fileWithDifferentTermInName.getName(), fileWithTermInTitle.getName());
+
+        wildcardTerm = SEARCH_TERM.replaceFirst("^.", "*");
+        String queryInvertedBoost = "TYPE:'cm:content' AND (cm:name:" + wildcardTerm + "^0.1 OR cm:title:" + SEARCH_TERM + "^3)";
+        SearchRequest requestInvertedBoost = req("afts", queryInvertedBoost);
+        searchQueryService.expectResultsStartingWithOneOf(requestInvertedBoost, testUser, fileWithTermInTitle.getName());
+        searchQueryService.expectResultsFromQuery(request, testUser, fileWithTermInName.getName(), fileWithDifferentTermInName.getName(), fileWithTermInTitle.getName());
+    }
+
+    @Test(groups = { TestGroup.SEARCH })
+    public void testAftsQuery_invalidNegativeBoost()
+    {
+        String query = "TYPE:'cm:content'^-2 AND cm:name:" + SEARCH_TERM;
+        SearchRequest request = req("afts", query);
+        searchQueryService.expectErrorFromQuery(request, testUser, HttpStatus.INTERNAL_SERVER_ERROR, EMPTY);
+    }
+
+    private ContentModel createRandomFileWithTitle(String title)
+    {
+        return createRandomFile(title, null, null);
+    }
+
+    private ContentModel createRandomFile(String title, String description, String tag)
+    {
+        return createFile(getRandomFile(FileType.TEXT_PLAIN), getRandomName("dummy content"), title, description, tag);
+    }
+
+    private ContentModel createFile(String filename, String content)
+    {
+        return createFile(filename, content, null, null, null);
+    }
+
+    private ContentModel createFile(String filename, String content, String title, String description, String tag)
+    {
+        ContentModel contentRoot = new ContentModel("-root-");
+        contentRoot.setNodeRef(contentRoot.getName());
+        FileModel fileModel = new FileModel(filename, FileType.TEXT_PLAIN, content);
+        fileModel.setTitle(title);
+        fileModel.setDescription(description);
+
+        FileModel file = dataContent
+            .usingAdmin()
+            .usingResource(contentRoot)
+            .createContent(fileModel);
+
+        if (StringUtils.isNotBlank(tag))
+        {
+            dataContent
+                .usingAdmin()
+                .usingResource(file)
+                .addTagToContent(RestTagModel.builder().tag(tag).create());
+        }
+
+        return file;
+    }
+
+    private ContentModel createRandomFolderWithTitle(String title)
+    {
+        return createFolder(getRandomName("folder"), title, null, null);
+    }
+
+    private ContentModel createFolder(String folderName)
+    {
+        return createFolder(folderName, null, null, null);
+    }
+
+    private ContentModel createFolder(String folderName, String title, String description, String tag)
+    {
+        ContentModel contentRoot = new ContentModel("-root-");
+        contentRoot.setNodeRef(contentRoot.getName());
+        FolderModel folderModel = new FolderModel(folderName, title, description);
+
+        FolderModel folder = dataContent
+            .usingAdmin()
+            .usingResource(contentRoot)
+            .createFolder(folderModel);
+
+        if (StringUtils.isNotBlank(tag))
+        {
+            dataContent
+                .usingAdmin()
+                .usingResource(folder)
+                .addTagToContent(RestTagModel.builder().tag(tag).create());
+        }
+
+        return folder;
+    }
+}

--- a/tests/tas-elasticsearch/src/test/java/org/alfresco/elasticsearch/ElasticsearchBoostedSearchTests.java
+++ b/tests/tas-elasticsearch/src/test/java/org/alfresco/elasticsearch/ElasticsearchBoostedSearchTests.java
@@ -210,14 +210,14 @@ public class ElasticsearchBoostedSearchTests extends AbstractTestNGSpringContext
         String timeTo = afterCreationTime.format(DateTimeFormatter.ISO_DATE_TIME);
 
         STEP("Search for files and folders by name or creation time range with higher priority for name filter");
-        String boostedQuery = "TYPE:('cm:content'^3 OR 'cm:folder') AND (cm:name:" + SEARCH_TERM + "^4 OR cm:created:['" + timeFrom + "' TO '" + timeTo + "']^0.1)";
+        String boostedQuery = "TYPE:('cm:content'^3 OR 'cm:folder') AND (cm:name:" + SEARCH_TERM + "^4 OR cm:created:['" + timeFrom + "' TO '" + timeTo + "']^0.1)^3";
         SearchRequest searchRequest = req("afts", boostedQuery);
         searchQueryService.expectResultsInOrder(searchRequest, testUser, fileWithTermInName.getName(), folderWithTermInName.getName(), fileWithTermInTitle.getName(), folderWithTermInTitle.getName());
 
         STEP("Search for files and folders by name or creation time range with higher priority for creation time range filter");
-        String invertedBoost = "TYPE:('cm:content'^3 OR 'cm:folder') AND (cm:name:" + SEARCH_TERM + "^0.1 OR cm:created:['" + timeFrom + "' TO '" + timeTo + "']^4)";
+        String invertedBoost = "TYPE:('cm:content' OR 'cm:folder'^3) AND (cm:name:" + SEARCH_TERM + "^0.1 OR cm:created:['" + timeFrom + "' TO '" + timeTo + "']^4)^3";
         searchRequest = req("afts", invertedBoost);
-        searchQueryService.expectResultsInOrder(searchRequest, testUser, fileWithTermInTitle.getName(), folderWithTermInTitle.getName(), fileWithTermInName.getName(), folderWithTermInName.getName());
+        searchQueryService.expectResultsInOrder(searchRequest, testUser, folderWithTermInTitle.getName(), fileWithTermInTitle.getName(), folderWithTermInName.getName(), fileWithTermInName.getName());
     }
 
     /**
@@ -226,13 +226,13 @@ public class ElasticsearchBoostedSearchTests extends AbstractTestNGSpringContext
     @Test(groups = { TestGroup.SEARCH })
     public void testAftsQuery_wordsRangeSearchBoost()
     {
-        STEP("Search for files and folders by name or words in content from given range with higher priority for name filter");
+        STEP("Search for files by name or words in content from given range with higher priority for name filter");
         String boostedQuery = "TYPE:'cm:content' AND (cm:name:" + SEARCH_TERM + "^3 OR cm:content:" + SEARCH_TERM + "..phrase^0.1)";
         SearchRequest searchRequest = req("afts", boostedQuery);
         searchQueryService.expectResultsStartingWithOneOf(searchRequest, testUser, fileWithTermInName.getName());
         searchQueryService.expectResultsFromQuery(searchRequest, testUser, fileWithTermInName.getName(), fileWithPhraseInContent.getName(), fileWithDifferentTermInName.getName());
 
-        STEP("Search for files and folders by name or words in content from given range with higher priority for words in content from given range filter");
+        STEP("Search for files by name or words in content from given range with higher priority for words in content from given range filter");
         String invertedBoost = "TYPE:'cm:content' AND (cm:name:" + SEARCH_TERM + "^0.1 OR cm:content:" + SEARCH_TERM + "..phrase^3)";
         searchRequest = req("afts", invertedBoost);
         searchQueryService.expectResultsStartingWithOneOf(searchRequest, testUser, fileWithPhraseInContent.getName(), fileWithDifferentTermInName.getName());

--- a/tests/tas-elasticsearch/src/test/java/org/alfresco/elasticsearch/ElasticsearchBoostedSearchTests.java
+++ b/tests/tas-elasticsearch/src/test/java/org/alfresco/elasticsearch/ElasticsearchBoostedSearchTests.java
@@ -3,6 +3,7 @@ package org.alfresco.elasticsearch;
 import static org.alfresco.elasticsearch.SearchQueryService.req;
 import static org.alfresco.utility.data.RandomData.getRandomFile;
 import static org.alfresco.utility.data.RandomData.getRandomName;
+import static org.alfresco.utility.report.log.Step.STEP;
 import static org.apache.commons.lang3.StringUtils.EMPTY;
 
 import java.time.Clock;
@@ -37,7 +38,7 @@ import org.testng.annotations.Test;
 public class ElasticsearchBoostedSearchTests extends AbstractTestNGSpringContextTests
 {
     private static final String SEARCH_TERM = "mountain";
-    private static final String DIFFERENT_SEARCH_TERM = SEARCH_TERM.replaceFirst("^.", "f");
+    private static final String DIFFERENT_SEARCH_TERM = "fountain";
 
     @Autowired
     private ServerHealth serverHealth;
@@ -66,6 +67,7 @@ public class ElasticsearchBoostedSearchTests extends AbstractTestNGSpringContext
     {
         serverHealth.assertServerIsOnline();
 
+        STEP("Create a test user and few files and folders containing searched term in name, title and content");
         testUser = dataUser.createRandomTestUser();
         fileWithTermInName = createFile(SEARCH_TERM + ".txt", "dummy content");
         fileWithDifferentTermInName = createFile(DIFFERENT_SEARCH_TERM + ".txt", "dummy other content");
@@ -78,8 +80,9 @@ public class ElasticsearchBoostedSearchTests extends AbstractTestNGSpringContext
     }
 
     @AfterClass
-    public void afterClass()
+    public void dataCleanup()
     {
+        STEP("Clean up created files, folders and user");
         dataContent.usingAdmin().usingResource(fileWithTermInName).deleteContent();
         dataContent.usingAdmin().usingResource(fileWithDifferentTermInName).deleteContent();
         dataContent.usingAdmin().usingResource(fileWithPhraseInContent).deleteContent();
@@ -92,10 +95,12 @@ public class ElasticsearchBoostedSearchTests extends AbstractTestNGSpringContext
     @Test(groups = { TestGroup.SEARCH })
     public void testAftsQuery_simpleTermBoost()
     {
+        STEP("Search for files and folders by name with higher priority for files");
         String boostedQuery = "TYPE:('cm:content'^2 OR 'cm:folder'^0.5) AND cm:name:" + SEARCH_TERM;
         SearchRequest searchRequest = req("afts", boostedQuery);
         searchQueryService.expectResultsInOrder(searchRequest, testUser, fileWithTermInName.getName(), folderWithTermInName.getName());
 
+        STEP("Search for files and folders by name with higher priority for folders");
         String invertedBoost = "TYPE:('cm:content'^0.5 OR 'cm:folder'^2) AND cm:name:" + SEARCH_TERM;
         searchRequest = req("afts", invertedBoost);
         searchQueryService.expectResultsInOrder(searchRequest, testUser, folderWithTermInName.getName(), fileWithTermInName.getName());
@@ -104,18 +109,22 @@ public class ElasticsearchBoostedSearchTests extends AbstractTestNGSpringContext
     @Test(groups = { TestGroup.SEARCH })
     public void testAftsQuery_complexTermBoost()
     {
+        STEP("Search for files and folders by name or title with higher priority for files by name");
         String boostedQuery1 = "TYPE:('cm:content'^4 OR 'cm:folder'^0.5)^4 AND (cm:name:" + SEARCH_TERM + "^3.5 OR cm:title:" + SEARCH_TERM + "^0.05)";
         SearchRequest searchRequest = req("afts", boostedQuery1);
         searchQueryService.expectResultsInOrder(searchRequest, testUser, fileWithTermInName.getName(), fileWithTermInTitle.getName(), folderWithTermInName.getName(), folderWithTermInTitle.getName());
 
+        STEP("Search for files and folders by name or title with higher priority for folders by name");
         String boostedQuery2 = "TYPE:('cm:content'^0.5 OR 'cm:folder'^4)^4 AND (cm:name:" + SEARCH_TERM + "^3.5 OR cm:title:" + SEARCH_TERM + "^0.05)";
         searchRequest = req("afts", boostedQuery2);
         searchQueryService.expectResultsInOrder(searchRequest, testUser, folderWithTermInName.getName(), folderWithTermInTitle.getName(), fileWithTermInName.getName(), fileWithTermInTitle.getName());
 
+        STEP("Search for files and folders by name or title with higher priority for files by title");
         String boostedQuery3 = "TYPE:('cm:content'^4 OR 'cm:folder'^0.5)^0.25 AND (cm:name:" + SEARCH_TERM + "^0.05 OR cm:title:" + SEARCH_TERM + "^3.5)";
         searchRequest = req("afts", boostedQuery3);
         searchQueryService.expectResultsInOrder(searchRequest, testUser, fileWithTermInTitle.getName(), fileWithTermInName.getName(), folderWithTermInTitle.getName(), folderWithTermInName.getName());
 
+        STEP("Search for files and folders by name or title with higher priority for folders by title");
         String boostedQuery4 = "TYPE:('cm:content'^0.5 OR 'cm:folder'^4)^0.25 AND (cm:name:" + SEARCH_TERM + "^0.05 OR cm:title:" + SEARCH_TERM + "^3.5)";
         searchRequest = req("afts", boostedQuery4);
         searchQueryService.expectResultsInOrder(searchRequest, testUser, folderWithTermInTitle.getName(), folderWithTermInName.getName(), fileWithTermInTitle.getName(), fileWithTermInName.getName());
@@ -124,10 +133,12 @@ public class ElasticsearchBoostedSearchTests extends AbstractTestNGSpringContext
     @Test(groups = { TestGroup.SEARCH })
     public void testAftsQuery_phraseBoost()
     {
+        STEP("Search for files by name or TEXT with higher priority for name filter");
         String boostedQuery = "TYPE:'cm:content' AND (cm:name:" + SEARCH_TERM + "^2 OR TEXT:'" + SEARCH_TERM + " searched'^0.1)";
         SearchRequest searchRequest = req("afts", boostedQuery);
         searchQueryService.expectResultsInOrder(searchRequest, testUser, fileWithTermInName.getName(), fileWithPhraseInContent.getName());
 
+        STEP("Search for files by name or TEXT with higher priority for TEXT filter");
         String invertedBoost = "TYPE:'cm:content' AND (cm:name:" + SEARCH_TERM + "^0.1 OR TEXT:'" + SEARCH_TERM + " searched'^2)";
         searchRequest = req("afts", invertedBoost);
         searchQueryService.expectResultsInOrder(searchRequest, testUser, fileWithPhraseInContent.getName(), fileWithTermInName.getName());
@@ -136,10 +147,12 @@ public class ElasticsearchBoostedSearchTests extends AbstractTestNGSpringContext
     @Test(groups = { TestGroup.SEARCH })
     public void testAftsQuery_exactTermBoost()
     {
+        STEP("Search for files by exact name or content with higher priority for exact name filter");
         String boostedQuery = "TYPE:'cm:content' AND (=cm:name:" + SEARCH_TERM + ".txt^2 OR =cm:content:" + SEARCH_TERM + "^0.5)";
         SearchRequest searchRequest = req("afts", boostedQuery);
         searchQueryService.expectResultsInOrder(searchRequest, testUser, fileWithTermInName.getName(), fileWithPhraseInContent.getName());
 
+        STEP("Search for files by exact name or content with higher priority for exact content filter");
         String invertedBoost = "TYPE:'cm:content' AND (=cm:name:" + SEARCH_TERM + ".txt^0.1 OR =cm:content:" + SEARCH_TERM + "^3)";
         searchRequest = req("afts", invertedBoost);
         searchQueryService.expectResultsInOrder(searchRequest, testUser, fileWithPhraseInContent.getName(), fileWithTermInName.getName());
@@ -148,10 +161,12 @@ public class ElasticsearchBoostedSearchTests extends AbstractTestNGSpringContext
     @Test(groups = { TestGroup.SEARCH })
     public void testAftsQuery_expandedTermBoost()
     {
+        STEP("Search for files by expanded name and two different terms with higher priority for first term");
         String boostedQuery = "TYPE:'cm:content' AND (~cm:name:" + SEARCH_TERM + "^3 OR ~cm:name:" + DIFFERENT_SEARCH_TERM + "^0.1)";
         SearchRequest searchRequest = req("afts", boostedQuery);
         searchQueryService.expectResultsInOrder(searchRequest, testUser, fileWithTermInName.getName(), fileWithDifferentTermInName.getName());
 
+        STEP("Search for files by expanded name and two different terms with higher priority for second term");
         String invertedBoost = "TYPE:'cm:content' AND (~cm:name:" + SEARCH_TERM + "^0.1 OR ~cm:name:" + DIFFERENT_SEARCH_TERM + "^3)";
         searchRequest = req("afts", invertedBoost);
         searchQueryService.expectResultsInOrder(searchRequest, testUser, fileWithDifferentTermInName.getName(), fileWithTermInName.getName());
@@ -160,23 +175,30 @@ public class ElasticsearchBoostedSearchTests extends AbstractTestNGSpringContext
     @Test(groups = { TestGroup.SEARCH })
     public void testAftsQuery_fuzzyMatchingBoost()
     {
+        STEP("Fuzzy matching search for files by name or title with higher priority for fuzzy name filter");
         String boostedQuery = "TYPE:'cm:content' AND (cm:name:" + SEARCH_TERM + "~0.7^3 OR cm:title:" + SEARCH_TERM + "^0.01)";
         SearchRequest searchRequest = req("afts", boostedQuery);
         searchQueryService.expectResultsInOrder(searchRequest, testUser, fileWithTermInName.getName(), fileWithDifferentTermInName.getName(), fileWithTermInTitle.getName());
 
+        STEP("Fuzzy matching search for files by name or title with higher priority for fuzzy title filter");
         String invertedBoost = "TYPE:'cm:content' AND (cm:name:" + SEARCH_TERM + "~0.7^0.01 OR cm:title:" + SEARCH_TERM + "^3)";
         searchRequest = req("afts", invertedBoost);
         searchQueryService.expectResultsInOrder(searchRequest, testUser, fileWithTermInTitle.getName(), fileWithTermInName.getName(), fileWithDifferentTermInName.getName());
     }
 
+    /**
+     * Verify if boosts works fine with words proximity search. Files containing terms within specific distance from another one should be returned.
+     */
     @Test(groups = { TestGroup.SEARCH })
     public void testAftsQuery_proximitySearchBoost()
     {
-        String boostedQuery = "TYPE:'cm:content' AND (cm:name:" + SEARCH_TERM + "^5 OR TEXT:(" + SEARCH_TERM + " * phrase)^0.1)";
+        STEP("Search for files by name or proximity TEXT with higher priority for name filter");
+        String boostedQuery = "TYPE:'cm:content' AND (cm:name:" + SEARCH_TERM + "^5 OR TEXT:(" + SEARCH_TERM + " *(1) phrase)^0.1)";
         SearchRequest searchRequest = req("afts", boostedQuery);
         searchQueryService.expectResultsInOrder(searchRequest, testUser, fileWithTermInName.getName(), fileWithPhraseInContent.getName());
 
-        String invertedBoost = "TYPE:'cm:content' AND (cm:name:" + SEARCH_TERM + "^0.1 OR TEXT:(" + SEARCH_TERM + " * phrase)^5)";
+        STEP("Search for files by name or proximity TEXT with higher priority for proximity TEXT filter");
+        String invertedBoost = "TYPE:'cm:content' AND (cm:name:" + SEARCH_TERM + "^0.1 OR TEXT:(" + SEARCH_TERM + " *(1) phrase)^5)";
         searchRequest = req("afts", invertedBoost);
         searchQueryService.expectResultsInOrder(searchRequest, testUser, fileWithPhraseInContent.getName(), fileWithTermInName.getName());
     }
@@ -186,26 +208,31 @@ public class ElasticsearchBoostedSearchTests extends AbstractTestNGSpringContext
     {
         String timeFrom = creationTime.format(DateTimeFormatter.ISO_DATE_TIME);
         String timeTo = afterCreationTime.format(DateTimeFormatter.ISO_DATE_TIME);
+
+        STEP("Search for files and folders by name or creation time range with higher priority for name filter");
         String boostedQuery = "TYPE:('cm:content'^3 OR 'cm:folder') AND (cm:name:" + SEARCH_TERM + "^4 OR cm:created:['" + timeFrom + "' TO '" + timeTo + "']^0.1)";
         SearchRequest searchRequest = req("afts", boostedQuery);
         searchQueryService.expectResultsInOrder(searchRequest, testUser, fileWithTermInName.getName(), folderWithTermInName.getName(), fileWithTermInTitle.getName(), folderWithTermInTitle.getName());
 
+        STEP("Search for files and folders by name or creation time range with higher priority for creation time range filter");
         String invertedBoost = "TYPE:('cm:content'^3 OR 'cm:folder') AND (cm:name:" + SEARCH_TERM + "^0.1 OR cm:created:['" + timeFrom + "' TO '" + timeTo + "']^4)";
         searchRequest = req("afts", invertedBoost);
         searchQueryService.expectResultsInOrder(searchRequest, testUser, fileWithTermInTitle.getName(), folderWithTermInTitle.getName(), fileWithTermInName.getName(), folderWithTermInName.getName());
     }
 
     /**
-     * Verify if boosts work with words range search. Files containing words from alphabetical range (from 'mountain' to 'phrase') should be returned.
+     * Verify if boosts works fine with words range search. Files containing words from alphabetical range (from 'mountain' to 'phrase', this includes word 'other') should be returned.
      */
     @Test(groups = { TestGroup.SEARCH })
     public void testAftsQuery_wordsRangeSearchBoost()
     {
+        STEP("Search for files and folders by name or words in content from given range with higher priority for name filter");
         String boostedQuery = "TYPE:'cm:content' AND (cm:name:" + SEARCH_TERM + "^3 OR cm:content:" + SEARCH_TERM + "..phrase^0.1)";
         SearchRequest searchRequest = req("afts", boostedQuery);
         searchQueryService.expectResultsStartingWithOneOf(searchRequest, testUser, fileWithTermInName.getName());
         searchQueryService.expectResultsFromQuery(searchRequest, testUser, fileWithTermInName.getName(), fileWithPhraseInContent.getName(), fileWithDifferentTermInName.getName());
 
+        STEP("Search for files and folders by name or words in content from given range with higher priority for words in content from given range filter");
         String invertedBoost = "TYPE:'cm:content' AND (cm:name:" + SEARCH_TERM + "^0.1 OR cm:content:" + SEARCH_TERM + "..phrase^3)";
         searchRequest = req("afts", invertedBoost);
         searchQueryService.expectResultsStartingWithOneOf(searchRequest, testUser, fileWithPhraseInContent.getName(), fileWithDifferentTermInName.getName());
@@ -215,12 +242,14 @@ public class ElasticsearchBoostedSearchTests extends AbstractTestNGSpringContext
     @Test(groups = { TestGroup.SEARCH })
     public void testAftsQuery_wildcardSearchBoost()
     {
+        STEP("Search for files by wildcard name or title with higher priority for wildcard name filter");
         String wildcardTerm = SEARCH_TERM.replaceFirst("^.", "?");
         String boostedQuery = "TYPE:'cm:content' AND (cm:name:" + wildcardTerm + "^3 OR cm:title:" + SEARCH_TERM + "^0.1)";
         SearchRequest searchRequest = req("afts", boostedQuery);
         searchQueryService.expectResultsStartingWithOneOf(searchRequest, testUser, fileWithTermInName.getName(), fileWithDifferentTermInName.getName());
         searchQueryService.expectResultsFromQuery(searchRequest, testUser, fileWithTermInName.getName(), fileWithDifferentTermInName.getName(), fileWithTermInTitle.getName());
 
+        STEP("Search for files by wildcard name or title with higher priority for wildcard title filter");
         wildcardTerm = SEARCH_TERM.replaceFirst("^.", "*");
         String invertedBoost = "TYPE:'cm:content' AND (cm:name:" + wildcardTerm + "^0.1 OR cm:title:" + SEARCH_TERM + "^3)";
         searchRequest = req("afts", invertedBoost);
@@ -231,6 +260,7 @@ public class ElasticsearchBoostedSearchTests extends AbstractTestNGSpringContext
     @Test(groups = { TestGroup.SEARCH })
     public void testAftsQuery_invalidNegativeBoost()
     {
+        STEP("Try to search for files by name using negative boost and expect 500 error response");
         String boostedQuery = "TYPE:'cm:content'^-2 AND cm:name:" + SEARCH_TERM;
         SearchRequest searchRequest = req("afts", boostedQuery);
         searchQueryService.expectErrorFromQuery(searchRequest, testUser, HttpStatus.INTERNAL_SERVER_ERROR, EMPTY);

--- a/tests/tas-elasticsearch/src/test/java/org/alfresco/elasticsearch/ElasticsearchBoostedSearchTests.java
+++ b/tests/tas-elasticsearch/src/test/java/org/alfresco/elasticsearch/ElasticsearchBoostedSearchTests.java
@@ -196,7 +196,7 @@ public class ElasticsearchBoostedSearchTests extends AbstractTestNGSpringContext
     }
 
     /**
-     * Verify if boosts work with words range search. Files containing words 'mountain', 'other' and 'phrase' should be picked up.
+     * Verify if boosts work with words range search. Files containing words from alphabetical range (from 'mountain' to 'phrase') should be returned..
      */
     @Test(groups = { TestGroup.SEARCH })
     public void testAftsQuery_wordsRangeSearchBoost()

--- a/tests/tas-elasticsearch/src/test/java/org/alfresco/elasticsearch/ElasticsearchBoostedSearchTests.java
+++ b/tests/tas-elasticsearch/src/test/java/org/alfresco/elasticsearch/ElasticsearchBoostedSearchTests.java
@@ -104,19 +104,19 @@ public class ElasticsearchBoostedSearchTests extends AbstractTestNGSpringContext
     @Test(groups = { TestGroup.SEARCH })
     public void testAftsQuery_complexTermBoost()
     {
-        String boostedQuery1 = "TYPE:('cm:content'^4 OR 'cm:folder'^0.5)^3 AND (cm:name:" + SEARCH_TERM + "^3 OR cm:title:" + SEARCH_TERM + "^0.1)";
+        String boostedQuery1 = "TYPE:('cm:content'^3.5 OR 'cm:folder'^0.5)^4 AND (cm:name:" + SEARCH_TERM + "^4 OR cm:title:" + SEARCH_TERM + "^0.05)";
         SearchRequest searchRequest = req("afts", boostedQuery1);
         searchQueryService.expectResultsInOrder(searchRequest, testUser, fileWithTermInName.getName(), fileWithTermInTitle.getName(), folderWithTermInName.getName(), folderWithTermInTitle.getName());
 
-        String boostedQuery2 = "TYPE:('cm:content'^0.5 OR 'cm:folder'^4)^3 AND (cm:name:" + SEARCH_TERM + "^3 OR cm:title:" + SEARCH_TERM + "^0.1)";
+        String boostedQuery2 = "TYPE:('cm:content'^0.5 OR 'cm:folder'^3.5)^4 AND (cm:name:" + SEARCH_TERM + "^4 OR cm:title:" + SEARCH_TERM + "^0.05)";
         searchRequest = req("afts", boostedQuery2);
         searchQueryService.expectResultsInOrder(searchRequest, testUser, folderWithTermInName.getName(), folderWithTermInTitle.getName(), fileWithTermInName.getName(), fileWithTermInTitle.getName());
 
-        String boostedQuery3 = "TYPE:('cm:content'^4 OR 'cm:folder'^0.5)^3 AND (cm:name:" + SEARCH_TERM + "^0.1 OR cm:title:" + SEARCH_TERM + "^3)";
+        String boostedQuery3 = "TYPE:('cm:content'^3.5 OR 'cm:folder'^0.5)^0.25 AND (cm:name:" + SEARCH_TERM + "^0.05 OR cm:title:" + SEARCH_TERM + "^4)";
         searchRequest = req("afts", boostedQuery3);
         searchQueryService.expectResultsInOrder(searchRequest, testUser, fileWithTermInTitle.getName(), fileWithTermInName.getName(), folderWithTermInTitle.getName(), folderWithTermInName.getName());
 
-        String boostedQuery4 = "TYPE:('cm:content'^0.5 OR 'cm:folder'^4)^3 AND (cm:name:" + SEARCH_TERM + "^0.1 OR cm:title:" + SEARCH_TERM + "^3)";
+        String boostedQuery4 = "TYPE:('cm:content'^0.5 OR 'cm:folder'^3.5)^0.25 AND (cm:name:" + SEARCH_TERM + "^0.05 OR cm:title:" + SEARCH_TERM + "^4)";
         searchRequest = req("afts", boostedQuery4);
         searchQueryService.expectResultsInOrder(searchRequest, testUser, folderWithTermInTitle.getName(), folderWithTermInName.getName(), fileWithTermInTitle.getName(), fileWithTermInName.getName());
     }

--- a/tests/tas-elasticsearch/src/test/java/org/alfresco/elasticsearch/ElasticsearchBoostedSearchTests.java
+++ b/tests/tas-elasticsearch/src/test/java/org/alfresco/elasticsearch/ElasticsearchBoostedSearchTests.java
@@ -196,7 +196,7 @@ public class ElasticsearchBoostedSearchTests extends AbstractTestNGSpringContext
     }
 
     /**
-     * Verify if boosts work with words range search. Files containing words from alphabetical range (from 'mountain' to 'phrase') should be returned..
+     * Verify if boosts work with words range search. Files containing words from alphabetical range (from 'mountain' to 'phrase') should be returned.
      */
     @Test(groups = { TestGroup.SEARCH })
     public void testAftsQuery_wordsRangeSearchBoost()

--- a/tests/tas-elasticsearch/src/test/java/org/alfresco/elasticsearch/ElasticsearchBoostedSearchTests.java
+++ b/tests/tas-elasticsearch/src/test/java/org/alfresco/elasticsearch/ElasticsearchBoostedSearchTests.java
@@ -92,93 +92,93 @@ public class ElasticsearchBoostedSearchTests extends AbstractTestNGSpringContext
     @Test(groups = { TestGroup.SEARCH })
     public void testAftsQuery_simpleTermBoost()
     {
-        String query = "TYPE:('cm:content'^2 OR 'cm:folder'^0.5) AND cm:name:" + SEARCH_TERM;
-        SearchRequest request = req("afts", query);
-        searchQueryService.expectResultsInOrder(request, testUser, fileWithTermInName.getName(), folderWithTermInName.getName());
+        String boostedQuery = "TYPE:('cm:content'^2 OR 'cm:folder'^0.5) AND cm:name:" + SEARCH_TERM;
+        SearchRequest searchRequest = req("afts", boostedQuery);
+        searchQueryService.expectResultsInOrder(searchRequest, testUser, fileWithTermInName.getName(), folderWithTermInName.getName());
 
-        String queryInvertedBoost = "TYPE:('cm:content'^0.5 OR 'cm:folder'^2) AND cm:name:" + SEARCH_TERM;
-        SearchRequest requestInvertedBoost = req("afts", queryInvertedBoost);
-        searchQueryService.expectResultsInOrder(requestInvertedBoost, testUser, folderWithTermInName.getName(), fileWithTermInName.getName());
+        String invertedBoost = "TYPE:('cm:content'^0.5 OR 'cm:folder'^2) AND cm:name:" + SEARCH_TERM;
+        searchRequest = req("afts", invertedBoost);
+        searchQueryService.expectResultsInOrder(searchRequest, testUser, folderWithTermInName.getName(), fileWithTermInName.getName());
     }
 
     @Test(groups = { TestGroup.SEARCH })
     public void testAftsQuery_complexTermBoost()
     {
-        String boostedQuery1 = "TYPE:('cm:content'^5 OR 'cm:folder'^0.5) AND (cm:name:" + SEARCH_TERM + "^3 OR cm:title:" + SEARCH_TERM + "^0.1)^0.5";
-        SearchRequest boostedQueryRequest1 = req("afts", boostedQuery1);
-        searchQueryService.expectResultsInOrder(boostedQueryRequest1, testUser, fileWithTermInName.getName(), fileWithTermInTitle.getName(), folderWithTermInName.getName(), folderWithTermInTitle.getName());
+        String boostedQuery1 = "TYPE:('cm:content'^4 OR 'cm:folder'^0.5)^3 AND (cm:name:" + SEARCH_TERM + "^3 OR cm:title:" + SEARCH_TERM + "^0.1)^0.5";
+        SearchRequest searchRequest = req("afts", boostedQuery1);
+        searchQueryService.expectResultsInOrder(searchRequest, testUser, fileWithTermInName.getName(), fileWithTermInTitle.getName(), folderWithTermInName.getName(), folderWithTermInTitle.getName());
 
-        String boostedQuery2 = "TYPE:('cm:content'^0.5 OR 'cm:folder'^5)^2 AND (cm:name:" + SEARCH_TERM + "^3 OR cm:title:" + SEARCH_TERM + "^0.1)";
-        SearchRequest boostedQueryRequest2 = req("afts", boostedQuery2);
-        searchQueryService.expectResultsInOrder(boostedQueryRequest2, testUser, folderWithTermInName.getName(), folderWithTermInTitle.getName(), fileWithTermInName.getName(), fileWithTermInTitle.getName());
+        String boostedQuery2 = "TYPE:('cm:content'^0.5 OR 'cm:folder'^4)^3 AND (cm:name:" + SEARCH_TERM + "^3 OR cm:title:" + SEARCH_TERM + "^0.1)";
+        searchRequest = req("afts", boostedQuery2);
+        searchQueryService.expectResultsInOrder(searchRequest, testUser, folderWithTermInName.getName(), folderWithTermInTitle.getName(), fileWithTermInName.getName(), fileWithTermInTitle.getName());
 
-        String boostedQuery3 = "TYPE:('cm:content'^5 OR 'cm:folder'^0.5)^2 AND (cm:name:" + SEARCH_TERM + "^0.1 OR cm:title:" + SEARCH_TERM + "^3)";
-        SearchRequest boostedQueryRequest3 = req("afts", boostedQuery3);
-        searchQueryService.expectResultsInOrder(boostedQueryRequest3, testUser, fileWithTermInName.getName(), fileWithTermInTitle.getName(), folderWithTermInName.getName(), folderWithTermInTitle.getName());
+        String boostedQuery3 = "TYPE:('cm:content'^4 OR 'cm:folder'^0.5)^3 AND (cm:name:" + SEARCH_TERM + "^0.1 OR cm:title:" + SEARCH_TERM + "^3)";
+        searchRequest = req("afts", boostedQuery3);
+        searchQueryService.expectResultsInOrder(searchRequest, testUser, fileWithTermInName.getName(), fileWithTermInTitle.getName(), folderWithTermInName.getName(), folderWithTermInTitle.getName());
 
-        String boostedQuery4 = "TYPE:('cm:content'^0.5 OR 'cm:folder'^5) AND (cm:name:" + SEARCH_TERM + "^0.1 OR cm:title:" + SEARCH_TERM + "^3)^0.5";
-        SearchRequest boostedQueryRequest4 = req("afts", boostedQuery4);
-        searchQueryService.expectResultsInOrder(boostedQueryRequest4, testUser, folderWithTermInName.getName(), folderWithTermInTitle.getName(), fileWithTermInName.getName(), fileWithTermInTitle.getName());
+        String boostedQuery4 = "TYPE:('cm:content'^0.5 OR 'cm:folder'^4)^3 AND (cm:name:" + SEARCH_TERM + "^0.1 OR cm:title:" + SEARCH_TERM + "^3)^0.5";
+        searchRequest = req("afts", boostedQuery4);
+        searchQueryService.expectResultsInOrder(searchRequest, testUser, folderWithTermInName.getName(), folderWithTermInTitle.getName(), fileWithTermInName.getName(), fileWithTermInTitle.getName());
     }
 
     @Test(groups = { TestGroup.SEARCH })
     public void testAftsQuery_phraseBoost()
     {
-        String query = "TYPE:'cm:content' AND (cm:name:" + SEARCH_TERM + "^2 OR TEXT:'" + SEARCH_TERM + " searched'^0.1)";
-        SearchRequest request = req("afts", query);
-        searchQueryService.expectResultsInOrder(request, testUser, fileWithTermInName.getName(), fileWithPhraseInContent.getName());
+        String boostedQuery = "TYPE:'cm:content' AND (cm:name:" + SEARCH_TERM + "^2 OR TEXT:'" + SEARCH_TERM + " searched'^0.1)";
+        SearchRequest searchRequest = req("afts", boostedQuery);
+        searchQueryService.expectResultsInOrder(searchRequest, testUser, fileWithTermInName.getName(), fileWithPhraseInContent.getName());
 
-        String queryInvertedBoost = "TYPE:'cm:content' AND (cm:name:" + SEARCH_TERM + "^0.1 OR TEXT:'" + SEARCH_TERM + " searched'^2)";
-        SearchRequest requestInvertedBoost = req("afts", queryInvertedBoost);
-        searchQueryService.expectResultsInOrder(requestInvertedBoost, testUser, fileWithPhraseInContent.getName(), fileWithTermInName.getName());
+        String invertedBoost = "TYPE:'cm:content' AND (cm:name:" + SEARCH_TERM + "^0.1 OR TEXT:'" + SEARCH_TERM + " searched'^2)";
+        searchRequest = req("afts", invertedBoost);
+        searchQueryService.expectResultsInOrder(searchRequest, testUser, fileWithPhraseInContent.getName(), fileWithTermInName.getName());
     }
 
     @Test(groups = { TestGroup.SEARCH })
     public void testAftsQuery_exactTermBoost()
     {
-        String query = "TYPE:'cm:content' AND (=cm:name:" + SEARCH_TERM + ".txt^2 OR =cm:content:" + SEARCH_TERM + "^0.5)";
-        SearchRequest request = req("afts", query);
-        searchQueryService.expectResultsInOrder(request, testUser, fileWithTermInName.getName(), fileWithPhraseInContent.getName());
+        String boostedQuery = "TYPE:'cm:content' AND (=cm:name:" + SEARCH_TERM + ".txt^2 OR =cm:content:" + SEARCH_TERM + "^0.5)";
+        SearchRequest searchRequest = req("afts", boostedQuery);
+        searchQueryService.expectResultsInOrder(searchRequest, testUser, fileWithTermInName.getName(), fileWithPhraseInContent.getName());
 
-        String queryInvertedBoost = "TYPE:'cm:content' AND (=cm:name:" + SEARCH_TERM + ".txt^0.1 OR =cm:content:" + SEARCH_TERM + "^3)";
-        SearchRequest requestInvertedBoost = req("afts", queryInvertedBoost);
-        searchQueryService.expectResultsInOrder(requestInvertedBoost, testUser, fileWithPhraseInContent.getName(), fileWithTermInName.getName());
+        String invertedBoost = "TYPE:'cm:content' AND (=cm:name:" + SEARCH_TERM + ".txt^0.1 OR =cm:content:" + SEARCH_TERM + "^3)";
+        searchRequest = req("afts", invertedBoost);
+        searchQueryService.expectResultsInOrder(searchRequest, testUser, fileWithPhraseInContent.getName(), fileWithTermInName.getName());
     }
 
     @Test(groups = { TestGroup.SEARCH })
     public void testAftsQuery_expandedTermBoost()
     {
-        String query = "TYPE:'cm:content' AND (~cm:name:" + SEARCH_TERM + "^3 OR ~cm:name:" + DIFFERENT_SEARCH_TERM + "^0.1)";
-        SearchRequest request = req("afts", query);
-        searchQueryService.expectResultsInOrder(request, testUser, fileWithTermInName.getName(), fileWithDifferentTermInName.getName());
+        String boostedQuery = "TYPE:'cm:content' AND (~cm:name:" + SEARCH_TERM + "^3 OR ~cm:name:" + DIFFERENT_SEARCH_TERM + "^0.1)";
+        SearchRequest searchRequest = req("afts", boostedQuery);
+        searchQueryService.expectResultsInOrder(searchRequest, testUser, fileWithTermInName.getName(), fileWithDifferentTermInName.getName());
 
-        String queryInvertedBoost = "TYPE:'cm:content' AND (~cm:name:" + SEARCH_TERM + "^0.1 OR ~cm:name:" + DIFFERENT_SEARCH_TERM + "^3)";
-        SearchRequest requestInvertedBoost = req("afts", queryInvertedBoost);
-        searchQueryService.expectResultsInOrder(requestInvertedBoost, testUser, fileWithDifferentTermInName.getName(), fileWithTermInName.getName());
+        String invertedBoost = "TYPE:'cm:content' AND (~cm:name:" + SEARCH_TERM + "^0.1 OR ~cm:name:" + DIFFERENT_SEARCH_TERM + "^3)";
+        searchRequest = req("afts", invertedBoost);
+        searchQueryService.expectResultsInOrder(searchRequest, testUser, fileWithDifferentTermInName.getName(), fileWithTermInName.getName());
     }
 
     @Test(groups = { TestGroup.SEARCH })
     public void testAftsQuery_fuzzyMatchingBoost()
     {
-        String query = "TYPE:'cm:content' AND (cm:name:" + SEARCH_TERM + "~0.7^3 OR cm:title:" + SEARCH_TERM + "^0.01)";
-        SearchRequest request = req("afts", query);
-        searchQueryService.expectResultsInOrder(request, testUser, fileWithTermInName.getName(), fileWithDifferentTermInName.getName(), fileWithTermInTitle.getName());
+        String boostedQuery = "TYPE:'cm:content' AND (cm:name:" + SEARCH_TERM + "~0.7^3 OR cm:title:" + SEARCH_TERM + "^0.01)";
+        SearchRequest searchRequest = req("afts", boostedQuery);
+        searchQueryService.expectResultsInOrder(searchRequest, testUser, fileWithTermInName.getName(), fileWithDifferentTermInName.getName(), fileWithTermInTitle.getName());
 
-        String queryInvertedBoost = "TYPE:'cm:content' AND (cm:name:" + SEARCH_TERM + "~0.7^0.01 OR cm:title:" + SEARCH_TERM + "^3)";
-        SearchRequest requestInvertedBoost = req("afts", queryInvertedBoost);
-        searchQueryService.expectResultsInOrder(requestInvertedBoost, testUser, fileWithTermInTitle.getName(), fileWithTermInName.getName(), fileWithDifferentTermInName.getName());
+        String invertedBoost = "TYPE:'cm:content' AND (cm:name:" + SEARCH_TERM + "~0.7^0.01 OR cm:title:" + SEARCH_TERM + "^3)";
+        searchRequest = req("afts", invertedBoost);
+        searchQueryService.expectResultsInOrder(searchRequest, testUser, fileWithTermInTitle.getName(), fileWithTermInName.getName(), fileWithDifferentTermInName.getName());
     }
 
     @Test(groups = { TestGroup.SEARCH })
     public void testAftsQuery_proximitySearchBoost()
     {
-        String query = "TYPE:'cm:content' AND (cm:name:" + SEARCH_TERM + "^5 OR TEXT:(" + SEARCH_TERM + " * phrase)^0.1)";
-        SearchRequest request = req("afts", query);
-        searchQueryService.expectResultsInOrder(request, testUser, fileWithTermInName.getName(), fileWithPhraseInContent.getName());
+        String boostedQuery = "TYPE:'cm:content' AND (cm:name:" + SEARCH_TERM + "^5 OR TEXT:(" + SEARCH_TERM + " * phrase)^0.1)";
+        SearchRequest searchRequest = req("afts", boostedQuery);
+        searchQueryService.expectResultsInOrder(searchRequest, testUser, fileWithTermInName.getName(), fileWithPhraseInContent.getName());
 
-        String queryInvertedBoost = "TYPE:'cm:content' AND (cm:name:" + SEARCH_TERM + "^0.1 OR TEXT:(" + SEARCH_TERM + " * phrase)^5)";
-        SearchRequest requestInvertedBoost = req("afts", queryInvertedBoost);
-        searchQueryService.expectResultsInOrder(requestInvertedBoost, testUser, fileWithPhraseInContent.getName(), fileWithTermInName.getName());
+        String invertedBoost = "TYPE:'cm:content' AND (cm:name:" + SEARCH_TERM + "^0.1 OR TEXT:(" + SEARCH_TERM + " * phrase)^5)";
+        searchRequest = req("afts", invertedBoost);
+        searchQueryService.expectResultsInOrder(searchRequest, testUser, fileWithPhraseInContent.getName(), fileWithTermInName.getName());
     }
 
     @Test(groups = { TestGroup.SEARCH })
@@ -186,51 +186,54 @@ public class ElasticsearchBoostedSearchTests extends AbstractTestNGSpringContext
     {
         String timeFrom = creationTime.format(DateTimeFormatter.ISO_DATE_TIME);
         String timeTo = afterCreationTime.format(DateTimeFormatter.ISO_DATE_TIME);
-        String query = "TYPE:('cm:content'^3 OR 'cm:folder') AND (cm:name:" + SEARCH_TERM + "^4 OR cm:created:['" + timeFrom + "' TO '" + timeTo + "']^0.1)";
-        SearchRequest request = req("afts", query);
-        searchQueryService.expectResultsInOrder(request, testUser, fileWithTermInName.getName(), folderWithTermInName.getName(), fileWithTermInTitle.getName(), folderWithTermInTitle.getName());
+        String boostedQuery = "TYPE:('cm:content'^3 OR 'cm:folder') AND (cm:name:" + SEARCH_TERM + "^4 OR cm:created:['" + timeFrom + "' TO '" + timeTo + "']^0.1)";
+        SearchRequest searchRequest = req("afts", boostedQuery);
+        searchQueryService.expectResultsInOrder(searchRequest, testUser, fileWithTermInName.getName(), folderWithTermInName.getName(), fileWithTermInTitle.getName(), folderWithTermInTitle.getName());
 
-        String queryInvertedBoost = "TYPE:('cm:content'^3 OR 'cm:folder') AND (cm:name:" + SEARCH_TERM + "^0.1 OR cm:created:['" + timeFrom + "' TO '" + timeTo + "']^4)";
-        SearchRequest requestInvertedBoost = req("afts", queryInvertedBoost);
-        searchQueryService.expectResultsInOrder(requestInvertedBoost, testUser, fileWithTermInTitle.getName(), folderWithTermInTitle.getName(), fileWithTermInName.getName(), folderWithTermInName.getName());
+        String invertedBoost = "TYPE:('cm:content'^3 OR 'cm:folder') AND (cm:name:" + SEARCH_TERM + "^0.1 OR cm:created:['" + timeFrom + "' TO '" + timeTo + "']^4)";
+        searchRequest = req("afts", invertedBoost);
+        searchQueryService.expectResultsInOrder(searchRequest, testUser, fileWithTermInTitle.getName(), folderWithTermInTitle.getName(), fileWithTermInName.getName(), folderWithTermInName.getName());
     }
 
+    /**
+     * Verify if boosts work with words range search. Files containing words 'mountain', 'other' and 'phrase' should be picked up.
+     */
     @Test(groups = { TestGroup.SEARCH })
     public void testAftsQuery_wordsRangeSearchBoost()
     {
-        String query = "TYPE:'cm:content' AND (cm:name:" + SEARCH_TERM + "^3 OR cm:content:" + SEARCH_TERM + "..phrase^0.1)";
-        SearchRequest request = req("afts", query);
-        searchQueryService.expectResultsStartingWithOneOf(request, testUser, fileWithTermInName.getName());
-        searchQueryService.expectResultsFromQuery(request, testUser, fileWithTermInName.getName(), fileWithPhraseInContent.getName(), fileWithDifferentTermInName.getName());
+        String boostedQuery = "TYPE:'cm:content' AND (cm:name:" + SEARCH_TERM + "^3 OR cm:content:" + SEARCH_TERM + "..phrase^0.1)";
+        SearchRequest searchRequest = req("afts", boostedQuery);
+        searchQueryService.expectResultsStartingWithOneOf(searchRequest, testUser, fileWithTermInName.getName());
+        searchQueryService.expectResultsFromQuery(searchRequest, testUser, fileWithTermInName.getName(), fileWithPhraseInContent.getName(), fileWithDifferentTermInName.getName());
 
-        String queryInvertedBoost = "TYPE:'cm:content' AND (cm:name:" + SEARCH_TERM + "^0.1 OR cm:content:" + SEARCH_TERM + "..phrase^3)";
-        SearchRequest requestInvertedBoost = req("afts", queryInvertedBoost);
-        searchQueryService.expectResultsStartingWithOneOf(request, testUser, fileWithPhraseInContent.getName(), fileWithDifferentTermInName.getName());
-        searchQueryService.expectResultsFromQuery(requestInvertedBoost, testUser, fileWithTermInName.getName(), fileWithPhraseInContent.getName(), fileWithDifferentTermInName.getName());
+        String invertedBoost = "TYPE:'cm:content' AND (cm:name:" + SEARCH_TERM + "^0.1 OR cm:content:" + SEARCH_TERM + "..phrase^3)";
+        searchRequest = req("afts", invertedBoost);
+        searchQueryService.expectResultsStartingWithOneOf(searchRequest, testUser, fileWithPhraseInContent.getName(), fileWithDifferentTermInName.getName());
+        searchQueryService.expectResultsFromQuery(searchRequest, testUser, fileWithTermInName.getName(), fileWithPhraseInContent.getName(), fileWithDifferentTermInName.getName());
     }
 
     @Test(groups = { TestGroup.SEARCH })
     public void testAftsQuery_wildcardSearchBoost()
     {
         String wildcardTerm = SEARCH_TERM.replaceFirst("^.", "?");
-        String query = "TYPE:'cm:content' AND (cm:name:" + wildcardTerm + "^3 OR cm:title:" + SEARCH_TERM + "^0.1)";
-        SearchRequest request = req("afts", query);
-        searchQueryService.expectResultsStartingWithOneOf(request, testUser, fileWithTermInName.getName(), fileWithDifferentTermInName.getName());
-        searchQueryService.expectResultsFromQuery(request, testUser, fileWithTermInName.getName(), fileWithDifferentTermInName.getName(), fileWithTermInTitle.getName());
+        String boostedQuery = "TYPE:'cm:content' AND (cm:name:" + wildcardTerm + "^3 OR cm:title:" + SEARCH_TERM + "^0.1)";
+        SearchRequest searchRequest = req("afts", boostedQuery);
+        searchQueryService.expectResultsStartingWithOneOf(searchRequest, testUser, fileWithTermInName.getName(), fileWithDifferentTermInName.getName());
+        searchQueryService.expectResultsFromQuery(searchRequest, testUser, fileWithTermInName.getName(), fileWithDifferentTermInName.getName(), fileWithTermInTitle.getName());
 
         wildcardTerm = SEARCH_TERM.replaceFirst("^.", "*");
-        String queryInvertedBoost = "TYPE:'cm:content' AND (cm:name:" + wildcardTerm + "^0.1 OR cm:title:" + SEARCH_TERM + "^3)";
-        SearchRequest requestInvertedBoost = req("afts", queryInvertedBoost);
-        searchQueryService.expectResultsStartingWithOneOf(requestInvertedBoost, testUser, fileWithTermInTitle.getName());
-        searchQueryService.expectResultsFromQuery(request, testUser, fileWithTermInName.getName(), fileWithDifferentTermInName.getName(), fileWithTermInTitle.getName());
+        String invertedBoost = "TYPE:'cm:content' AND (cm:name:" + wildcardTerm + "^0.1 OR cm:title:" + SEARCH_TERM + "^3)";
+        searchRequest = req("afts", invertedBoost);
+        searchQueryService.expectResultsStartingWithOneOf(searchRequest, testUser, fileWithTermInTitle.getName());
+        searchQueryService.expectResultsFromQuery(searchRequest, testUser, fileWithTermInName.getName(), fileWithDifferentTermInName.getName(), fileWithTermInTitle.getName());
     }
 
     @Test(groups = { TestGroup.SEARCH })
     public void testAftsQuery_invalidNegativeBoost()
     {
-        String query = "TYPE:'cm:content'^-2 AND cm:name:" + SEARCH_TERM;
-        SearchRequest request = req("afts", query);
-        searchQueryService.expectErrorFromQuery(request, testUser, HttpStatus.INTERNAL_SERVER_ERROR, EMPTY);
+        String boostedQuery = "TYPE:'cm:content'^-2 AND cm:name:" + SEARCH_TERM;
+        SearchRequest searchRequest = req("afts", boostedQuery);
+        searchQueryService.expectErrorFromQuery(searchRequest, testUser, HttpStatus.INTERNAL_SERVER_ERROR, EMPTY);
     }
 
     private ContentModel createRandomFileWithTitle(String title)
@@ -240,7 +243,7 @@ public class ElasticsearchBoostedSearchTests extends AbstractTestNGSpringContext
 
     private ContentModel createRandomFile(String title, String description, String tag)
     {
-        return createFile(getRandomFile(FileType.TEXT_PLAIN), getRandomName("dummy content"), title, description, tag);
+        return createFile(getRandomFile(FileType.TEXT_PLAIN), "dummy content", title, description, tag);
     }
 
     private ContentModel createFile(String filename, String content)

--- a/tests/tas-elasticsearch/src/test/java/org/alfresco/elasticsearch/ElasticsearchBoostedSearchTests.java
+++ b/tests/tas-elasticsearch/src/test/java/org/alfresco/elasticsearch/ElasticsearchBoostedSearchTests.java
@@ -104,19 +104,19 @@ public class ElasticsearchBoostedSearchTests extends AbstractTestNGSpringContext
     @Test(groups = { TestGroup.SEARCH })
     public void testAftsQuery_complexTermBoost()
     {
-        String boostedQuery1 = "TYPE:('cm:content'^4 OR 'cm:folder'^0.5) AND (cm:name:" + SEARCH_TERM + "^2 OR cm:title:" + SEARCH_TERM + "^0.1)^0.5";
+        String boostedQuery1 = "TYPE:('cm:content'^4 OR 'cm:folder'^0.5) AND (cm:name:" + SEARCH_TERM + "^3 OR cm:title:" + SEARCH_TERM + "^0.1)^0.5";
         SearchRequest boostedQueryRequest1 = req("afts", boostedQuery1);
         searchQueryService.expectResultsInOrder(boostedQueryRequest1, testUser, fileWithTermInName.getName(), fileWithTermInTitle.getName(), folderWithTermInName.getName(), folderWithTermInTitle.getName());
 
-        String boostedQuery2 = "TYPE:('cm:content'^0.5 OR 'cm:folder'^4)^2 AND (cm:name:" + SEARCH_TERM + "^2 OR cm:title:" + SEARCH_TERM + "^0.1)";
+        String boostedQuery2 = "TYPE:('cm:content'^0.5 OR 'cm:folder'^4)^2 AND (cm:name:" + SEARCH_TERM + "^3 OR cm:title:" + SEARCH_TERM + "^0.1)";
         SearchRequest boostedQueryRequest2 = req("afts", boostedQuery2);
         searchQueryService.expectResultsInOrder(boostedQueryRequest2, testUser, folderWithTermInName.getName(), folderWithTermInTitle.getName(), fileWithTermInName.getName(), fileWithTermInTitle.getName());
 
-        String boostedQuery3 = "TYPE:('cm:content'^4 OR 'cm:folder'^0.5)^2 AND (cm:name:" + SEARCH_TERM + "^0.1 OR cm:title:" + SEARCH_TERM + "^2)";
+        String boostedQuery3 = "TYPE:('cm:content'^4 OR 'cm:folder'^0.5)^2 AND (cm:name:" + SEARCH_TERM + "^0.1 OR cm:title:" + SEARCH_TERM + "^3)";
         SearchRequest boostedQueryRequest3 = req("afts", boostedQuery3);
         searchQueryService.expectResultsInOrder(boostedQueryRequest3, testUser, fileWithTermInName.getName(), fileWithTermInTitle.getName(), folderWithTermInName.getName(), folderWithTermInTitle.getName());
 
-        String boostedQuery4 = "TYPE:('cm:content'^0.5 OR 'cm:folder'^4) AND (cm:name:" + SEARCH_TERM + "^0.1 OR cm:title:" + SEARCH_TERM + "^2)^0.5";
+        String boostedQuery4 = "TYPE:('cm:content'^0.5 OR 'cm:folder'^4) AND (cm:name:" + SEARCH_TERM + "^0.1 OR cm:title:" + SEARCH_TERM + "^3)^0.5";
         SearchRequest boostedQueryRequest4 = req("afts", boostedQuery4);
         searchQueryService.expectResultsInOrder(boostedQueryRequest4, testUser, folderWithTermInName.getName(), folderWithTermInTitle.getName(), fileWithTermInName.getName(), fileWithTermInTitle.getName());
     }
@@ -186,11 +186,11 @@ public class ElasticsearchBoostedSearchTests extends AbstractTestNGSpringContext
     {
         String timeFrom = creationTime.format(DateTimeFormatter.ISO_DATE_TIME);
         String timeTo = afterCreationTime.format(DateTimeFormatter.ISO_DATE_TIME);
-        String query = "TYPE:('cm:content'^2 OR 'cm:folder') AND (cm:name:" + SEARCH_TERM + "^3 OR cm:created:['" + timeFrom + "' TO '" + timeTo + "']^0.1)";
+        String query = "TYPE:('cm:content'^3 OR 'cm:folder') AND (cm:name:" + SEARCH_TERM + "^4 OR cm:created:['" + timeFrom + "' TO '" + timeTo + "']^0.1)";
         SearchRequest request = req("afts", query);
         searchQueryService.expectResultsInOrder(request, testUser, fileWithTermInName.getName(), folderWithTermInName.getName(), fileWithTermInTitle.getName(), folderWithTermInTitle.getName());
 
-        String queryInvertedBoost = "TYPE:('cm:content'^2 OR 'cm:folder') AND (cm:name:" + SEARCH_TERM + "^0.1 OR cm:created:['" + timeFrom + "' TO '" + timeTo + "']^3)";
+        String queryInvertedBoost = "TYPE:('cm:content'^3 OR 'cm:folder') AND (cm:name:" + SEARCH_TERM + "^0.1 OR cm:created:['" + timeFrom + "' TO '" + timeTo + "']^4)";
         SearchRequest requestInvertedBoost = req("afts", queryInvertedBoost);
         searchQueryService.expectResultsInOrder(requestInvertedBoost, testUser, fileWithTermInTitle.getName(), folderWithTermInTitle.getName(), fileWithTermInName.getName(), folderWithTermInName.getName());
     }

--- a/tests/tas-elasticsearch/src/test/java/org/alfresco/elasticsearch/ElasticsearchBoostedSearchTests.java
+++ b/tests/tas-elasticsearch/src/test/java/org/alfresco/elasticsearch/ElasticsearchBoostedSearchTests.java
@@ -104,7 +104,7 @@ public class ElasticsearchBoostedSearchTests extends AbstractTestNGSpringContext
     @Test(groups = { TestGroup.SEARCH })
     public void testAftsQuery_complexTermBoost()
     {
-        String boostedQuery1 = "TYPE:('cm:content'^4 OR 'cm:folder'^0.5)^3 AND (cm:name:" + SEARCH_TERM + "^3 OR cm:title:" + SEARCH_TERM + "^0.1)^0.5";
+        String boostedQuery1 = "TYPE:('cm:content'^4 OR 'cm:folder'^0.5)^3 AND (cm:name:" + SEARCH_TERM + "^3 OR cm:title:" + SEARCH_TERM + "^0.1)";
         SearchRequest searchRequest = req("afts", boostedQuery1);
         searchQueryService.expectResultsInOrder(searchRequest, testUser, fileWithTermInName.getName(), fileWithTermInTitle.getName(), folderWithTermInName.getName(), folderWithTermInTitle.getName());
 
@@ -114,11 +114,11 @@ public class ElasticsearchBoostedSearchTests extends AbstractTestNGSpringContext
 
         String boostedQuery3 = "TYPE:('cm:content'^4 OR 'cm:folder'^0.5)^3 AND (cm:name:" + SEARCH_TERM + "^0.1 OR cm:title:" + SEARCH_TERM + "^3)";
         searchRequest = req("afts", boostedQuery3);
-        searchQueryService.expectResultsInOrder(searchRequest, testUser, fileWithTermInName.getName(), fileWithTermInTitle.getName(), folderWithTermInName.getName(), folderWithTermInTitle.getName());
+        searchQueryService.expectResultsInOrder(searchRequest, testUser, fileWithTermInTitle.getName(), fileWithTermInName.getName(), folderWithTermInTitle.getName(), folderWithTermInName.getName());
 
-        String boostedQuery4 = "TYPE:('cm:content'^0.5 OR 'cm:folder'^4)^3 AND (cm:name:" + SEARCH_TERM + "^0.1 OR cm:title:" + SEARCH_TERM + "^3)^0.5";
+        String boostedQuery4 = "TYPE:('cm:content'^0.5 OR 'cm:folder'^4)^3 AND (cm:name:" + SEARCH_TERM + "^0.1 OR cm:title:" + SEARCH_TERM + "^3)";
         searchRequest = req("afts", boostedQuery4);
-        searchQueryService.expectResultsInOrder(searchRequest, testUser, folderWithTermInName.getName(), folderWithTermInTitle.getName(), fileWithTermInName.getName(), fileWithTermInTitle.getName());
+        searchQueryService.expectResultsInOrder(searchRequest, testUser, folderWithTermInTitle.getName(), folderWithTermInName.getName(), fileWithTermInTitle.getName(), fileWithTermInName.getName());
     }
 
     @Test(groups = { TestGroup.SEARCH })

--- a/tests/tas-elasticsearch/src/test/java/org/alfresco/elasticsearch/ElasticsearchBoostedSearchTests.java
+++ b/tests/tas-elasticsearch/src/test/java/org/alfresco/elasticsearch/ElasticsearchBoostedSearchTests.java
@@ -104,19 +104,19 @@ public class ElasticsearchBoostedSearchTests extends AbstractTestNGSpringContext
     @Test(groups = { TestGroup.SEARCH })
     public void testAftsQuery_complexTermBoost()
     {
-        String boostedQuery1 = "TYPE:('cm:content'^4 OR 'cm:folder'^0.5) AND (cm:name:" + SEARCH_TERM + "^3 OR cm:title:" + SEARCH_TERM + "^0.1)^0.5";
+        String boostedQuery1 = "TYPE:('cm:content'^5 OR 'cm:folder'^0.5) AND (cm:name:" + SEARCH_TERM + "^3 OR cm:title:" + SEARCH_TERM + "^0.1)^0.5";
         SearchRequest boostedQueryRequest1 = req("afts", boostedQuery1);
         searchQueryService.expectResultsInOrder(boostedQueryRequest1, testUser, fileWithTermInName.getName(), fileWithTermInTitle.getName(), folderWithTermInName.getName(), folderWithTermInTitle.getName());
 
-        String boostedQuery2 = "TYPE:('cm:content'^0.5 OR 'cm:folder'^4)^2 AND (cm:name:" + SEARCH_TERM + "^3 OR cm:title:" + SEARCH_TERM + "^0.1)";
+        String boostedQuery2 = "TYPE:('cm:content'^0.5 OR 'cm:folder'^5)^2 AND (cm:name:" + SEARCH_TERM + "^3 OR cm:title:" + SEARCH_TERM + "^0.1)";
         SearchRequest boostedQueryRequest2 = req("afts", boostedQuery2);
         searchQueryService.expectResultsInOrder(boostedQueryRequest2, testUser, folderWithTermInName.getName(), folderWithTermInTitle.getName(), fileWithTermInName.getName(), fileWithTermInTitle.getName());
 
-        String boostedQuery3 = "TYPE:('cm:content'^4 OR 'cm:folder'^0.5)^2 AND (cm:name:" + SEARCH_TERM + "^0.1 OR cm:title:" + SEARCH_TERM + "^3)";
+        String boostedQuery3 = "TYPE:('cm:content'^5 OR 'cm:folder'^0.5)^2 AND (cm:name:" + SEARCH_TERM + "^0.1 OR cm:title:" + SEARCH_TERM + "^3)";
         SearchRequest boostedQueryRequest3 = req("afts", boostedQuery3);
         searchQueryService.expectResultsInOrder(boostedQueryRequest3, testUser, fileWithTermInName.getName(), fileWithTermInTitle.getName(), folderWithTermInName.getName(), folderWithTermInTitle.getName());
 
-        String boostedQuery4 = "TYPE:('cm:content'^0.5 OR 'cm:folder'^4) AND (cm:name:" + SEARCH_TERM + "^0.1 OR cm:title:" + SEARCH_TERM + "^3)^0.5";
+        String boostedQuery4 = "TYPE:('cm:content'^0.5 OR 'cm:folder'^5) AND (cm:name:" + SEARCH_TERM + "^0.1 OR cm:title:" + SEARCH_TERM + "^3)^0.5";
         SearchRequest boostedQueryRequest4 = req("afts", boostedQuery4);
         searchQueryService.expectResultsInOrder(boostedQueryRequest4, testUser, folderWithTermInName.getName(), folderWithTermInTitle.getName(), fileWithTermInName.getName(), fileWithTermInTitle.getName());
     }

--- a/tests/tas-elasticsearch/src/test/java/org/alfresco/elasticsearch/ElasticsearchTemplateSearchTests.java
+++ b/tests/tas-elasticsearch/src/test/java/org/alfresco/elasticsearch/ElasticsearchTemplateSearchTests.java
@@ -3,6 +3,7 @@ package org.alfresco.elasticsearch;
 import static org.alfresco.elasticsearch.SearchQueryService.req;
 import static org.alfresco.utility.data.RandomData.getRandomFile;
 import static org.alfresco.utility.data.RandomData.getRandomName;
+import static org.alfresco.utility.report.log.Step.STEP;
 
 import java.util.Map;
 
@@ -59,6 +60,7 @@ public class ElasticsearchTemplateSearchTests extends AbstractTestNGSpringContex
     {
         serverHealth.assertServerIsOnline();
 
+        STEP("Create a test user and few files and folders containing searched term in name, title, description, content and tag");
         fileWithTermInName = createFile(SEARCH_TERM + ".txt", "some text");
         fileWithPhraseInContent = createFile(getRandomFile(FileType.TEXT_PLAIN), "Dummy " + SEARCH_TERM + " irrelevant text");
         fileWithTermInTitle = createRandomFileWithTitle(SEARCH_TERM);
@@ -71,8 +73,9 @@ public class ElasticsearchTemplateSearchTests extends AbstractTestNGSpringContex
     }
 
     @AfterClass
-    public void afterClass()
+    public void dataCleanup()
     {
+        STEP("Clean up created files, folders and user");
         dataContent.usingAdmin().usingResource(fileWithTermInName).deleteContent();
         dataContent.usingAdmin().usingResource(fileWithPhraseInContent).deleteContent();
         dataContent.usingAdmin().usingResource(fileWithTermInTitle).deleteContent();
@@ -86,6 +89,7 @@ public class ElasticsearchTemplateSearchTests extends AbstractTestNGSpringContex
     @Test(groups = { TestGroup.SEARCH })
     public void testAftsQuery_simpleTemplate()
     {
+        STEP("Search for files by name using simple template with one property");
         Map<String, String> templates = Map.of("_NODE", "%cm:name");
         String query = "TYPE:'cm:content' AND _NODE:" + SEARCH_TERM;
         SearchRequest request = req("afts", query, templates);
@@ -96,6 +100,7 @@ public class ElasticsearchTemplateSearchTests extends AbstractTestNGSpringContex
     @Test(groups = { TestGroup.SEARCH })
     public void testAftsQuery_simpleTemplateWithPhrase()
     {
+        STEP("Search for files containing specific phrase using simple template with one property");
         Map<String, String> templates = Map.of("_NODE", "%TEXT");
         String query = "TYPE:'cm:content' AND _NODE:\"" + SEARCH_TERM + " irrelevant\"";
         SearchRequest request = req("afts", query, templates);
@@ -106,6 +111,7 @@ public class ElasticsearchTemplateSearchTests extends AbstractTestNGSpringContex
     @Test(groups = { TestGroup.SEARCH })
     public void testAftsQuery_templateWithTwoParameters()
     {
+        STEP("Search for files using template containing multiple properties");
         Map<String, String> templates = Map.of("_NODE", "%(cm:name cm:title)");
         String query = "TYPE:'cm:content' AND _NODE:" + SEARCH_TERM;
         SearchRequest request = req("afts", query, templates);
@@ -122,11 +128,13 @@ public class ElasticsearchTemplateSearchTests extends AbstractTestNGSpringContex
             "_NODEX", "%(_NODE cm:description)"
 
         );
+        STEP("Search for files using more complex two-level nested template containing multiple properties");
         String query = "TYPE:'cm:content' AND _NODEX:" + SEARCH_TERM;
         SearchRequest request = req("afts", query, templates);
         searchQueryService.expectNodeRefsFromQuery(request, testUser,
             fileWithTermInName.getNodeRef(), fileWithTermInDescription.getNodeRef(), fileWithTermInTitle.getNodeRef());
 
+        STEP("Search for files using three-level nested template containing multiple properties");
         String queryIncludingTag = "TYPE:'cm:content' AND _NODET:" + SEARCH_TERM;
         SearchRequest requestIncludingTag = req("afts", queryIncludingTag, templates);
         searchQueryService.expectNodeRefsFromQuery(requestIncludingTag, testUser,
@@ -136,6 +144,7 @@ public class ElasticsearchTemplateSearchTests extends AbstractTestNGSpringContex
     @Test(groups = { TestGroup.SEARCH })
     public void testAftsQuery_templateNameAsQueryDefaultFieldName()
     {
+        STEP("Search for files using template containing multiple properties, as a default search field");
         Map<String, String> templates = Map.of("_NODE", "%(cm:name cm:title)");
         String query = "TYPE:'cm:content' AND " + SEARCH_TERM;
         SearchRequest request = req("afts", query, templates);
@@ -147,6 +156,7 @@ public class ElasticsearchTemplateSearchTests extends AbstractTestNGSpringContex
     @Test(groups = { TestGroup.SEARCH })
     public void testAftsQuery_templateWithFixedValue()
     {
+        STEP("Search for files and folders using template containing multiple properties, including a fixed one");
         Map<String, String> templates = Map.of("_NODE", "%cm:name AND TYPE:'cm:folder'");
         String query = "_NODE:" + SEARCH_TERM;
         SearchRequest request = req("afts", query, templates);
@@ -157,11 +167,13 @@ public class ElasticsearchTemplateSearchTests extends AbstractTestNGSpringContex
     @Test(groups = { TestGroup.SEARCH })
     public void testAftsQuery_boostedTemplate()
     {
+        STEP("Search for files using templates and boosts, where second term has higher priority ");
         Map<String, String> templates = Map.of("_NODE", "%cm:name");
         String query = "TYPE:'cm:content' AND _NODE:" + SEARCH_TERM + "^0.5 OR _NODE:dummy^2";
         SearchRequest request = req("afts", query, templates);
         searchQueryService.expectResultsInOrder(request, testUser, fileWithDifferentTermInName.getName(), fileWithTermInName.getName());
 
+        STEP("Search for files using templates and boosts, where first term has higher priority ");
         String queryInvertedBoost = "TYPE:'cm:content' AND _NODE:" + SEARCH_TERM + "^2 OR _NODE:dummy^0.5";
         SearchRequest requestInvertedBoost = req("afts", queryInvertedBoost, templates);
         searchQueryService.expectResultsInOrder(requestInvertedBoost, testUser, fileWithTermInName.getName(), fileWithDifferentTermInName.getName());

--- a/tests/tas-elasticsearch/src/test/java/org/alfresco/elasticsearch/ElasticsearchTemplateSearchTests.java
+++ b/tests/tas-elasticsearch/src/test/java/org/alfresco/elasticsearch/ElasticsearchTemplateSearchTests.java
@@ -160,11 +160,11 @@ public class ElasticsearchTemplateSearchTests extends AbstractTestNGSpringContex
         Map<String, String> templates = Map.of("_NODE", "%cm:name");
         String query = "TYPE:'cm:content' AND _NODE:" + SEARCH_TERM + "^0.5 OR _NODE:dummy^2";
         SearchRequest request = req("afts", query, templates);
-        searchQueryService.expectResultsInOrder(request, testUser, true, fileWithDifferentTermInName.getName(), fileWithTermInName.getName());
+        searchQueryService.expectResultsInOrder(request, testUser, fileWithDifferentTermInName.getName(), fileWithTermInName.getName());
 
         String queryInvertedBoost = "TYPE:'cm:content' AND _NODE:" + SEARCH_TERM + "^2 OR _NODE:dummy^0.5";
         SearchRequest requestInvertedBoost = req("afts", queryInvertedBoost, templates);
-        searchQueryService.expectResultsInOrder(requestInvertedBoost, testUser, false, fileWithTermInName.getName(), fileWithDifferentTermInName.getName());
+        searchQueryService.expectResultsInOrder(requestInvertedBoost, testUser, fileWithTermInName.getName(), fileWithDifferentTermInName.getName());
     }
 
     @Test(groups = { TestGroup.SEARCH })

--- a/tests/tas-elasticsearch/src/test/java/org/alfresco/elasticsearch/SearchQueryService.java
+++ b/tests/tas-elasticsearch/src/test/java/org/alfresco/elasticsearch/SearchQueryService.java
@@ -56,6 +56,26 @@ public class SearchQueryService
         expectResultsFromQuery(searchRequest,user,response);
     }
 
+    public void expectResultsInOrder(SearchRequest searchRequest, UserModel user, String... expectedOrder)
+    {
+        Consumer<SearchResponse> response = searchResponse -> assertNamesInOrder(searchResponse, expectedOrder);
+        expectResultsFromQuery(searchRequest,user,response);
+    }
+
+    public void expectResultsStartingWithOneOf(SearchRequest searchRequest, UserModel user, String... expected)
+    {
+        Consumer<SearchResponse> response = searchResponse -> {
+            List<String> expectedFirstElements = List.of(expected);
+            String actualFirstElement = searchResponse.getEntries().stream()
+                .map(SearchNodeModel::getModel)
+                .map(SearchNodeModel::getName)
+                .findFirst()
+                .orElse(null);
+            assertTrue(expectedFirstElements.contains(actualFirstElement), "Unexpected search results - actual first element: " + actualFirstElement + ", expected one of: " + expectedFirstElements + " |");
+        };
+        expectResultsFromQuery(searchRequest,user,response);
+    }
+
     public void expectResultsFromQuery(SearchRequest searchRequest, UserModel user, String... expected)
     {
         Consumer<SearchResponse> assertNames = searchResponse -> assertNames(searchResponse, expected);
@@ -167,6 +187,16 @@ public class SearchQueryService
                 .map(SearchNodeModel::getModel)
                 .map(SearchNodeModel::getName)
                 .collect(Collectors.toList());
+        assertEquals(result, expectedInOrder, "Unexpected search results - got " + result + " expected " + expectedInOrder);
+    }
+
+    private void assertNamesInOrder(SearchResponse actual, String... expectedOrder)
+    {
+        List<String> expectedInOrder = List.of(expectedOrder);
+        List<String> result = actual.getEntries().stream()
+            .map(SearchNodeModel::getModel)
+            .map(SearchNodeModel::getName)
+            .toList();
         assertEquals(result, expectedInOrder, "Unexpected search results - got " + result + " expected " + expectedInOrder);
     }
 


### PR DESCRIPTION
E2E tests verifying search boosts functionality for ElasticSearch.
https://alfresco.atlassian.net/browse/ACS-4799