### PR TITLE
ACS-5426: ElasticsearchGetTagsTests fails on acs-packaging

### DIFF
--- a/tests/tas-elasticsearch/src/test/java/org/alfresco/elasticsearch/reindexing/ElasticsearchGetTagsTests.java
+++ b/tests/tas-elasticsearch/src/test/java/org/alfresco/elasticsearch/reindexing/ElasticsearchGetTagsTests.java
@@ -50,7 +50,11 @@ public class ElasticsearchGetTagsTests extends AbstractTestNGSpringContextTests
     @BeforeClass(alwaysRun = true)
     public void dataPreparation() throws InterruptedException
     {
+        serverHealth.isServerReachable();
         serverHealth.assertServerIsOnline();
+
+        STEP("Index system nodes");
+        AlfrescoStackInitializer.reindexEverything();
 
         STEP("Create user and site");
         user = dataUser.createRandomTestUser();

--- a/tests/tas-elasticsearch/src/test/resources/test-suites/elasticsearch-suite.xml
+++ b/tests/tas-elasticsearch/src/test/resources/test-suites/elasticsearch-suite.xml
@@ -18,13 +18,5 @@
     <packages>
       <package name="org.alfresco.elasticsearch.reindexing" />
     </packages>
-    <classes>
-        <class
-            name="org.alfresco.elasticsearch.reindexing.ElasticsearchGetTagsTests">
-            <methods>
-                <exclude name=".*" />
-            </methods>
-        </class>
-    </classes>
   </test>
 </suite>


### PR DESCRIPTION
https://alfresco.atlassian.net/browse/ACS-5426