### PR TITLE
ACS-5273: Removing docker_release job

### DIFF
--- a/.github/workflows/master_release.yml
+++ b/.github/workflows/master_release.yml
@@ -68,48 +68,10 @@ jobs:
       - name: "Clean Maven cache"
         run: bash ./scripts/ci/cleanup_cache.sh
 
-  docker_release:
-    name: "Update release and Single Pipeline <acs>-<build> images"
-    runs-on: ubuntu-latest
-    needs: [run_ci]
-    if: >
-      !(failure() || cancelled()) &&
-      !contains(github.event.head_commit.message, '[skip docker_release]') &&
-      startsWith(github.ref_name, 'release/') && github.event_name != 'pull_request'
-    services:
-      registry:
-        image: registry:2
-        ports:
-          - 5000:5000
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          persist-credentials: false
-      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.35.2
-      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v1.35.2
-      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.35.2
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: linux/amd64,linux/arm64
-      - name: "Build"
-        timeout-minutes: ${{ fromJSON(env.GITHUB_ACTIONS_DEPLOY_TIMEOUT) }}
-        run: |
-          bash ./scripts/ci/init.sh
-          bash ./scripts/ci/build.sh -m
-      - name: Compute final build number
-        run: |
-          echo "COMPUTED_BUILD_NUMBER=$(( $BASE_BUILD_NUMBER + $BUILD_NUMBER ))" >> $GITHUB_ENV
-      - name: "Update images"
-        timeout-minutes: ${{ fromJSON(env.GITHUB_ACTIONS_DEPLOY_TIMEOUT) }}
-        run: mvn -B -V clean install -ntp -DskipTests -Dmaven.javadoc.skip=true -Dbuild-number=${COMPUTED_BUILD_NUMBER} -Ppush-docker-images,pipeline,release-branch
-      - name: "Clean Maven cache"
-        run: bash ./scripts/ci/cleanup_cache.sh
-
   release:
     name: "Release and Copy to S3 Staging Bucket"
     runs-on: ubuntu-latest
-    needs: [docker_latest, docker_release]
+    needs: [docker_latest]
     if: >
       !(failure() || cancelled()) &&
       contains(github.event.head_commit.message, '[release]') &&


### PR DESCRIPTION
As discussed - `docker_release` CI job is removed (already done in applicable `release/7.x.y` branches)