### PR TITLE
ACS-5778 ARM64 Jira integration should close tickets in Review/Verify status

### DIFF
--- a/scripts/ci/jira/jira_integration.py
+++ b/scripts/ci/jira/jira_integration.py
@@ -78,7 +78,7 @@ def get_issue_key():
     result = jira.jql(sql_query)
     for issue in result['issues']:
         if issue['fields']['summary'] == get_summary_name():
-            if issue['fields']['status']['name'].upper() in ['TO DO', 'IN PROGRESS', 'BACKLOG', 'OPEN']:
+            if issue['fields']['status']['name'].upper() in ['TO DO', 'IN PROGRESS', 'BACKLOG', 'OPEN', 'REVIEW', 'VERIFY']:
                 logging.info("Issue already created")
                 return issue['key']
     return False

--- a/scripts/ci/jira/jira_integration.py
+++ b/scripts/ci/jira/jira_integration.py
@@ -188,7 +188,7 @@ if __name__ == "__main__":
 
     if not TEST_FAILURE:
         logging.info("Test passed, close issue if there is one")
-        # If tests passed and jira issue in 'TO DO', 'IN PROGRESS', 'BACKLOG', 'OPEN' state, close it
+        # If tests passed and jira issue in 'TO DO', 'IN PROGRESS', 'BACKLOG', 'OPEN', 'REVIEW', 'VERIFY' state, close it
         key = get_issue_key()
         if key:
             logging.info(f"Closing issue {key}")


### PR DESCRIPTION
As per title, the ARM64 Jira integration should be able to close previously created tickets even if they're in Review/Verify status.

Tested here: https://github.com/Alfresco/acs-packaging/actions/runs/5749195631/job/15583558417
It successfully closed this issue that was in **Verify** status: https://alfresco.atlassian.net/browse/ACS-5762