### PR TITLE
ACS-5039 [release] ACS 23.1.0-A27 [force][skip tests]

### DIFF
--- a/.github/workflows/master_release.yml
+++ b/.github/workflows/master_release.yml
@@ -22,8 +22,8 @@ env:
   GITHUB_ACTIONS_DEPLOY_TIMEOUT: 60
   BASE_BUILD_NUMBER: 10000
   # Release version has to start with real version (7.4.0-....) for the docker image to build successfully.
-  RELEASE_VERSION: 23.1.0-M3
-  DEVELOPMENT_VERSION: 23.1.0-SNAPSHOT
+  RELEASE_VERSION: 23.1.0-A27
+  DEVELOPMENT_VERSION: 23.1.0-A28-SNAPSHOT
 
 jobs:
   run_ci:


### PR DESCRIPTION
Releasing a new -Ax of acs-packaging to include the multi-arch ATS images for test purposes.