### PR TITLE
ACS-5951 Add Java 11 compatibility tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -499,7 +499,7 @@ jobs:
         run: bash ./scripts/ci/cleanup_cache.sh
 
   distribution_zip_content_tests:
-    name: "Distribution Zip content tests"
+    name: "Distribution Zip content tests (Java ${{ matrix.version }})"
     runs-on: ubuntu-latest
     if: >
       !contains(github.event.head_commit.message, '[skip tests]')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -499,7 +499,7 @@ jobs:
         run: bash ./scripts/ci/cleanup_cache.sh
 
   distribution_zip_content_tests:
-    name: Distribution Zip content tests (Java ${{ matrix.version }})
+    name: Distribution Zip content tests (Java ${{ matrix.java-version }})
     runs-on: ubuntu-latest
     if: >
       !contains(github.event.head_commit.message, '[skip tests]')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -548,6 +548,8 @@ jobs:
       - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.35.2
       - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v1.35.2
       - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.35.2
+        with:
+          java-version: ${{ matrix.java-version }}
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ env.PYTHON_VERSION }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -534,11 +534,15 @@ jobs:
         run: bash ./scripts/ci/cleanup_cache.sh
 
   single_pipeline_image_tests:
-    name: "Single Pipeline image tests"
+    name: "Single Pipeline image tests (Java ${{ matrix.java-version}})"
     runs-on: ubuntu-latest
     if: >
       github.event_name != 'pull_request' &&
       !contains(github.event.head_commit.message, '[skip tests]')
+    strategy:
+      fail-fast: false
+      matrix:
+        java-version: [11, 17]
     steps:
       - uses: actions/checkout@v3
         with:
@@ -560,7 +564,9 @@ jobs:
           AWS_ACCESS_KEY: ${{ secrets.AWS_S3_PIPELINE_AMPS_ACCESS_KEY_ID }}
           AWS_SECRET_KEY: ${{ secrets.AWS_S3_PIPELINE_AMPS_SECRET_ACCESS_KEY }}
         run: |
-          mvn -B clean install -ntp -Ppipeline,build-docker-images $(mvn -B -q help:evaluate "-Dexpression=dependency.alfresco-enterprise-repo.version" -DforceStdout | grep -q '\-SNAPSHOT$' && echo '-Drepo.image.tag=latest') $(mvn -B -q help:evaluate "-Dexpression=dependency.alfresco-enterprise-share.version" -DforceStdout | grep -q '\-SNAPSHOT$' && echo '-Dshare.image.tag=latest')
+          mvn -B clean install -ntp -Ppipeline,build-docker-images \
+            $(mvn -B -q help:evaluate "-Dexpression=dependency.alfresco-enterprise-repo.version" -DforceStdout | grep -q '\-SNAPSHOT$' && echo '-Drepo.image.tag=latest') $(mvn -B -q help:evaluate "-Dexpression=dependency.alfresco-enterprise-share.version" -DforceStdout | grep -q '\-SNAPSHOT$' && echo '-Dshare.image.tag=latest') \
+            -Ddocker.buildArg.JAVA_VERSION=${{ matrix.java-version }}
           cat tests/pipeline-all-amps/repo/target/dtas/dtas-config.json
           pip install requests pytest==6.2.4 pytest-testinfra==6.3.0 jmespath==0.10.0
           git clone --depth 1 --branch $DTAS_VERSION https://${GIT_USERNAME}:${GIT_PASSWORD}@github.com/Alfresco/alfresco-deployment-test-automation-scripts.git dtas
@@ -573,5 +579,7 @@ jobs:
         run: |
           cd dtas
           pytest --configuration ../tests/pipeline-all-amps/repo/target/dtas/dtas-config.json tests/ -s
+          # Temporarily add Docker logs
+          docker exec $(docker ps | grep pipeline-all-amps-repo | cut -d " " -f 1) ps -aux
       - name: "Clean Maven cache"
         run: bash ./scripts/ci/cleanup_cache.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,8 @@ jobs:
       - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.35.2
       - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v1.35.2
       - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.35.2
+        with:
+          java-version: 11
       - name: "Init"
         run: bash ./scripts/ci/init.sh
       - uses: Alfresco/alfresco-build-tools/.github/actions/veracode@v1.35.2
@@ -127,6 +129,8 @@ jobs:
       - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.35.2
       - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v1.35.2
       - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.35.2
+        with:
+          java-version: 11
       - name: "Build"
         timeout-minutes: ${{ fromJSON(env.GITHUB_ACTIONS_DEPLOY_TIMEOUT) }}
         run: |
@@ -175,6 +179,8 @@ jobs:
       - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.35.2
       - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v1.35.2
       - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.35.2
+        with:
+          java-version: 11
       - name: "Build"
         timeout-minutes: ${{ fromJSON(env.GITHUB_ACTIONS_DEPLOY_TIMEOUT) }}
         run: |
@@ -228,6 +234,8 @@ jobs:
       - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.35.2
       - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v1.35.2
       - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.35.2
+        with:
+          java-version: 11
       - name: "Build"
         timeout-minutes: ${{ fromJSON(env.GITHUB_ACTIONS_DEPLOY_TIMEOUT) }}
         run: |
@@ -264,6 +272,8 @@ jobs:
       - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.35.2
       - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v1.35.2
       - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.35.2
+        with:
+          java-version: 11
       - name: "Build"
         timeout-minutes: ${{ fromJSON(env.GITHUB_ACTIONS_DEPLOY_TIMEOUT) }}
         run: |
@@ -348,6 +358,8 @@ jobs:
       - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.35.2
       - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v1.35.2
       - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.35.2
+        with:
+          java-version: 11
       - name: "Build"
         timeout-minutes: ${{ fromJSON(env.GITHUB_ACTIONS_DEPLOY_TIMEOUT) }}
         run: |
@@ -380,6 +392,8 @@ jobs:
       - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.35.2
       - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v1.35.2
       - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.35.2
+        with:
+          java-version: 11
       - name: "Build"
         timeout-minutes: ${{ fromJSON(env.GITHUB_ACTIONS_DEPLOY_TIMEOUT) }}
         run: |
@@ -411,6 +425,8 @@ jobs:
       - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.35.2
       - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v1.35.2
       - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.35.2
+        with:
+          java-version: 11
       - name: "Build"
         timeout-minutes: ${{ fromJSON(env.GITHUB_ACTIONS_DEPLOY_TIMEOUT) }}
         run: |
@@ -466,6 +482,8 @@ jobs:
       - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.35.2
       - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v1.35.2
       - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.35.2
+        with:
+          java-version: 11
       - name: "Generate Keystores and Truststores for Mutual TLS configuration"
         if: ${{ matrix.mtls }}
         run: |
@@ -508,6 +526,8 @@ jobs:
       - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.35.2
       - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v1.35.2
       - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.35.2
+        with:
+          java-version: 11
       - name: "Build"
         timeout-minutes: ${{ fromJSON(env.GITHUB_ACTIONS_DEPLOY_TIMEOUT) }}
         run: |
@@ -538,6 +558,8 @@ jobs:
       - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.35.2
       - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v1.35.2
       - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.35.2
+        with:
+          java-version: 11
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ env.PYTHON_VERSION }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -411,8 +411,6 @@ jobs:
       - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.35.2
       - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v1.35.2
       - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.35.2
-        with:
-          java-version: 11
       - name: "Build"
         timeout-minutes: ${{ fromJSON(env.GITHUB_ACTIONS_DEPLOY_TIMEOUT) }}
         run: |
@@ -499,7 +497,7 @@ jobs:
         run: bash ./scripts/ci/cleanup_cache.sh
 
   distribution_zip_content_tests:
-    name: Distribution Zip content tests (Java ${{ matrix.java-version }})
+    name: "Distribution Zip content tests (Java ${{ matrix.java-version }})"
     runs-on: ubuntu-latest
     if: >
       !contains(github.event.head_commit.message, '[skip tests]')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -534,7 +534,7 @@ jobs:
         run: bash ./scripts/ci/cleanup_cache.sh
 
   single_pipeline_image_tests:
-    name: "Single Pipeline image tests (Java ${{ matrix.java-version}})"
+    name: "Single Pipeline image tests (Java ${{ matrix.java-version }})"
     runs-on: ubuntu-latest
     if: >
       github.event_name != 'pull_request' &&

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -499,7 +499,7 @@ jobs:
         run: bash ./scripts/ci/cleanup_cache.sh
 
   distribution_zip_content_tests:
-    name: "Distribution Zip content tests (Java ${{ matrix.version }})"
+    name: Distribution Zip content tests (Java ${{ matrix.version }})
     runs-on: ubuntu-latest
     if: >
       !contains(github.event.head_commit.message, '[skip tests]')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,8 +51,6 @@ jobs:
       - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.35.2
       - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v1.35.2
       - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.35.2
-        with:
-          java-version: 11
       - name: "Init"
         run: bash ./scripts/ci/init.sh
       - uses: Alfresco/alfresco-build-tools/.github/actions/veracode@v1.35.2
@@ -129,8 +127,6 @@ jobs:
       - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.35.2
       - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v1.35.2
       - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.35.2
-        with:
-          java-version: 11
       - name: "Build"
         timeout-minutes: ${{ fromJSON(env.GITHUB_ACTIONS_DEPLOY_TIMEOUT) }}
         run: |
@@ -179,8 +175,6 @@ jobs:
       - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.35.2
       - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v1.35.2
       - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.35.2
-        with:
-          java-version: 11
       - name: "Build"
         timeout-minutes: ${{ fromJSON(env.GITHUB_ACTIONS_DEPLOY_TIMEOUT) }}
         run: |
@@ -234,8 +228,6 @@ jobs:
       - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.35.2
       - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v1.35.2
       - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.35.2
-        with:
-          java-version: 11
       - name: "Build"
         timeout-minutes: ${{ fromJSON(env.GITHUB_ACTIONS_DEPLOY_TIMEOUT) }}
         run: |
@@ -272,8 +264,6 @@ jobs:
       - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.35.2
       - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v1.35.2
       - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.35.2
-        with:
-          java-version: 11
       - name: "Build"
         timeout-minutes: ${{ fromJSON(env.GITHUB_ACTIONS_DEPLOY_TIMEOUT) }}
         run: |
@@ -358,8 +348,6 @@ jobs:
       - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.35.2
       - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v1.35.2
       - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.35.2
-        with:
-          java-version: 11
       - name: "Build"
         timeout-minutes: ${{ fromJSON(env.GITHUB_ACTIONS_DEPLOY_TIMEOUT) }}
         run: |
@@ -392,8 +380,6 @@ jobs:
       - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.35.2
       - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v1.35.2
       - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.35.2
-        with:
-          java-version: 11
       - name: "Build"
         timeout-minutes: ${{ fromJSON(env.GITHUB_ACTIONS_DEPLOY_TIMEOUT) }}
         run: |
@@ -482,8 +468,6 @@ jobs:
       - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.35.2
       - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v1.35.2
       - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.35.2
-        with:
-          java-version: 11
       - name: "Generate Keystores and Truststores for Mutual TLS configuration"
         if: ${{ matrix.mtls }}
         run: |
@@ -519,6 +503,10 @@ jobs:
     runs-on: ubuntu-latest
     if: >
       !contains(github.event.head_commit.message, '[skip tests]')
+    strategy:
+      fail-fast: false
+      matrix:
+        java-version: [11, 17]
     steps:
       - uses: actions/checkout@v3
         with:
@@ -527,7 +515,7 @@ jobs:
       - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v1.35.2
       - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.35.2
         with:
-          java-version: 11
+          java-version: ${{ matrix.java-version }}
       - name: "Build"
         timeout-minutes: ${{ fromJSON(env.GITHUB_ACTIONS_DEPLOY_TIMEOUT) }}
         run: |
@@ -558,8 +546,6 @@ jobs:
       - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.35.2
       - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v1.35.2
       - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.35.2
-        with:
-          java-version: 11
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ env.PYTHON_VERSION }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -579,7 +579,5 @@ jobs:
         run: |
           cd dtas
           pytest --configuration ../tests/pipeline-all-amps/repo/target/dtas/dtas-config.json tests/ -s
-          # Temporarily add Docker logs
-          docker exec $(docker ps | grep pipeline-all-amps-repo | cut -d " " -f 1) ps -aux
       - name: "Clean Maven cache"
         run: bash ./scripts/ci/cleanup_cache.sh

--- a/pom.xml
+++ b/pom.xml
@@ -10,11 +10,11 @@
         <groupId>org.alfresco</groupId>
         <artifactId>alfresco-enterprise-repo</artifactId>
         <relativePath>../alfresco-enterprise-repo/pom.xml</relativePath>
-        <version>21.14</version>
+        <version>21.15-SNAPSHOT</version>
     </parent>
 
     <properties>
-        <dependency.alfresco-enterprise-repo.version>21.14</dependency.alfresco-enterprise-repo.version>
+        <dependency.alfresco-enterprise-repo.version>21.15-SNAPSHOT</dependency.alfresco-enterprise-repo.version>
         <dependency.alfresco-enterprise-share.version>21.16</dependency.alfresco-enterprise-share.version>
 
         <alfresco.rm-enterprise-rest-api-explorer.version>3.0.2</alfresco.rm-enterprise-rest-api-explorer.version>

--- a/pom.xml
+++ b/pom.xml
@@ -10,12 +10,12 @@
         <groupId>org.alfresco</groupId>
         <artifactId>alfresco-enterprise-repo</artifactId>
         <relativePath>../alfresco-enterprise-repo/pom.xml</relativePath>
-        <version>21.15-SNAPSHOT</version>
+        <version>21.14</version>
     </parent>
 
     <properties>
-        <dependency.alfresco-enterprise-repo.version>21.15-SNAPSHOT</dependency.alfresco-enterprise-repo.version>
-        <dependency.alfresco-enterprise-share.version>21.17-SNAPSHOT</dependency.alfresco-enterprise-share.version>
+        <dependency.alfresco-enterprise-repo.version>21.14</dependency.alfresco-enterprise-repo.version>
+        <dependency.alfresco-enterprise-share.version>21.16</dependency.alfresco-enterprise-share.version>
 
         <alfresco.rm-enterprise-rest-api-explorer.version>3.0.2</alfresco.rm-enterprise-rest-api-explorer.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 
     <properties>
         <dependency.alfresco-enterprise-repo.version>21.15-SNAPSHOT</dependency.alfresco-enterprise-repo.version>
-        <dependency.alfresco-enterprise-share.version>21.16</dependency.alfresco-enterprise-share.version>
+        <dependency.alfresco-enterprise-share.version>21.17-SNAPSHOT</dependency.alfresco-enterprise-share.version>
 
         <alfresco.rm-enterprise-rest-api-explorer.version>3.0.2</alfresco.rm-enterprise-rest-api-explorer.version>
 

--- a/tests/pipeline-all-amps/repo/Dockerfile
+++ b/tests/pipeline-all-amps/repo/Dockerfile
@@ -45,11 +45,15 @@ RUN sed -i -e "\$a\grant\ codeBase\ \"file:\$\{catalina.base\}\/webapps\/jolokia
 
 # Switch between currently installed JRE version and 11
 ARG JAVA_VERSION
-RUN if [[ "$JAVA_VERSION" == "11" ]]; then curl -fsLo java.tar.gz https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.15+10/OpenJDK11U-jre_x64_linux_hotspot_11.0.15_10.tar.gz && \
+RUN if [[ "$JAVA_VERSION" == "11" ]]; then \
+      ARCH=$(uname -m | sed s/86_//); \
+      JAVA_RELEASE=11.0.15_10; \
+      curl -fsLo java.tar.gz https://github.com/adoptium/temurin${JAVA_VERSION}-binaries/releases/download/jdk-${JAVA_RELEASE/_/+}/OpenJDK${JAVA_VERSION}U-jre_${ARCH}_linux_hotspot_${JAVA_RELEASE}.tar.gz && \
       tar xvfz java.tar.gz && \
       mv jdk-* /usr/lib/jvm/temurin-11-jdk && \
       update-alternatives --install /usr/bin/java java /usr/lib/jvm/temurin-11-jdk/bin/java 1 && \
-      update-alternatives --remove java $(update-alternatives --display java | head -2 | tail -1 | cut -d " " -f6); fi
+      update-alternatives --remove java $(update-alternatives --display java | head -2 | tail -1 | cut -d " " -f6); \
+    fi
 
 #Use the alfresco user
 #USER alfresco

--- a/tests/pipeline-all-amps/repo/Dockerfile
+++ b/tests/pipeline-all-amps/repo/Dockerfile
@@ -43,6 +43,14 @@ logger.alfresco-repo-content-transform-TransformerDebug.level=debug\n\
 # Grant all security permissions to jolokia and share in order to work properly.
 RUN sed -i -e "\$a\grant\ codeBase\ \"file:\$\{catalina.base\}\/webapps\/jolokia\/-\" \{\n\    permission\ java.security.AllPermission\;\n\};\ngrant\ codeBase\ \"file:\$\{catalina.base\}\/webapps\/share\/-\" \{\n\    permission\ java.security.AllPermission\;\n\};" ${TOMCAT_DIR}/conf/catalina.policy
 
+# Switch between currently installed JRE version and 11
+ARG JAVA_VERSION
+RUN if [[ "$JAVA_VERSION" == "11" ]]; then curl -fsLo java.tar.gz https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.15+10/OpenJDK11U-jre_x64_linux_hotspot_11.0.15_10.tar.gz && \
+      tar xvfz java.tar.gz && \
+      mv jdk-* /usr/lib/jvm/temurin-11-jdk && \
+      update-alternatives --install /usr/bin/java java /usr/lib/jvm/temurin-11-jdk/bin/java 1 && \
+      update-alternatives --remove java $(update-alternatives --display java | head -2 | tail -1 | cut -d " " -f6); fi
+
 #Use the alfresco user
 #USER alfresco
 

--- a/tests/pipeline-all-amps/repo/docker-entrypoint.sh
+++ b/tests/pipeline-all-amps/repo/docker-entrypoint.sh
@@ -2,6 +2,9 @@
 
 set -e
 
+# Switch to Java 11 if it has been installed
+[ -d "/usr/lib/jvm/temurin-11-jdk" ] && export JAVA_HOME=/usr/lib/jvm/temurin-11-jdk
+
 ALFRESCO_WEBAPP_DIR=$TOMCAT_DIR/webapps/$ALFRESCO_WEBAPP
 ALFRESCO_MMT_JAR=$TOMCAT_DIR/alfresco-mmt/alfresco-mmt*.jar
 


### PR DESCRIPTION
Repeating both the Zip distribution tests and the Single Pipeline image (with all AMPs) tests with both Java 11 and 17 as opposed to Java 17.
This should help identifying issues with lack of backwards compatibility with Java 11 at CI/CD time.

>**NOTE:** the build currently fails due to GitHub issues + Java 11 incompatible version of surf webscripts present in community-repo and enterprise-share, I believe it's safe to merge even now as it's been proved to work against special versions of comm-repo / ent-share.

## Examples of passing tests

**Tests**:
- [Zip distribution (Java 11)](https://github.com/Alfresco/acs-packaging/actions/runs/6076160720/job/16494840865)
- [Zip distribution (Java 17)](https://github.com/Alfresco/acs-packaging/actions/runs/6076160720/job/16494840935)
- [Single pipeline all AMPs (Java 11)](https://github.com/Alfresco/acs-packaging/actions/runs/6082863565/job/16501527587#step:9:62)
- [Single pipeline all AMPs (Java 17)](https://github.com/Alfresco/acs-packaging/actions/runs/6082987363/job/16502515069#step:9:61)