### PR TITLE
ACS-6054 JIRA integration now works with >1 word release trains

### DIFF
--- a/scripts/ci/jira/jira_integration.py
+++ b/scripts/ci/jira/jira_integration.py
@@ -74,7 +74,7 @@ def get_issue_key():
     epic_id = get_epic_id_to_assign(project_id)
     if not epic_id:
         return
-    sql_query = f'project = {project_id} AND "Release Train" = {CURRENT_RELEASE} AND issuetype = "bug"  AND  "parentEpic" = {epic_id}'
+    sql_query = f'project = {project_id} AND "Release Train" = "{CURRENT_RELEASE}" AND issuetype = "bug"  AND  "parentEpic" = {epic_id}'
     result = jira.jql(sql_query)
     for issue in result['issues']:
         if issue['fields']['summary'] == get_summary_name():
@@ -123,7 +123,7 @@ def get_epic_id_to_assign(project_id):
 
     try:
         sql_query = f"""project = {project_id} AND
-        'Release Train' = {CURRENT_RELEASE} AND
+        'Release Train' = '{CURRENT_RELEASE}' AND
         issuetype = 'Epic' AND
         Summary ~ '{CURRENT_RELEASE} % Content Services Maintenance'
         ORDER BY issuekey"""


### PR DESCRIPTION
The JIRA integration used within the arm64 workflow fails with `Error in the JQL Query: Expecting either 'OR' or 'AND' but got 'Borealis'. (line 2, character 34)` due to the release train containing a whitespace and not being properly quoted.

This should address the issue.

**Example failure**: https://github.com/Alfresco/acs-packaging/actions/runs/6256641849/job/16988051747#step:4:63
**Example run after the fix**: https://github.com/Alfresco/acs-packaging/actions/runs/6258693313