### PR TITLE
Fix Elasticsearch Boosted Search Test

### DIFF
--- a/tests/tas-elasticsearch/src/test/java/org/alfresco/elasticsearch/ElasticsearchBoostedSearchTests.java
+++ b/tests/tas-elasticsearch/src/test/java/org/alfresco/elasticsearch/ElasticsearchBoostedSearchTests.java
@@ -1,5 +1,17 @@
 package org.alfresco.elasticsearch;
 
+import static org.alfresco.elasticsearch.SearchQueryService.req;
+import static org.alfresco.utility.data.RandomData.getRandomFile;
+import static org.alfresco.utility.data.RandomData.getRandomName;
+import static org.alfresco.utility.report.log.Step.STEP;
+import static org.apache.commons.lang3.StringUtils.EMPTY;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+
 import org.alfresco.rest.model.RestTagModel;
 import org.alfresco.rest.search.SearchRequest;
 import org.alfresco.tas.AlfrescoStackInitializer;
@@ -20,18 +32,6 @@ import org.springframework.test.context.testng.AbstractTestNGSpringContextTests;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
-
-import java.time.Clock;
-import java.time.LocalDateTime;
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
-
-import static org.alfresco.elasticsearch.SearchQueryService.req;
-import static org.alfresco.utility.data.RandomData.getRandomFile;
-import static org.alfresco.utility.data.RandomData.getRandomName;
-import static org.alfresco.utility.report.log.Step.STEP;
-import static org.apache.commons.lang3.StringUtils.EMPTY;
 
 @ContextConfiguration(locations = "classpath:alfresco-elasticsearch-context.xml",
     initializers = AlfrescoStackInitializer.class)

--- a/tests/tas-elasticsearch/src/test/java/org/alfresco/elasticsearch/ElasticsearchBoostedSearchTests.java
+++ b/tests/tas-elasticsearch/src/test/java/org/alfresco/elasticsearch/ElasticsearchBoostedSearchTests.java
@@ -1,17 +1,5 @@
 package org.alfresco.elasticsearch;
 
-import static org.alfresco.elasticsearch.SearchQueryService.req;
-import static org.alfresco.utility.data.RandomData.getRandomFile;
-import static org.alfresco.utility.data.RandomData.getRandomName;
-import static org.alfresco.utility.report.log.Step.STEP;
-import static org.apache.commons.lang3.StringUtils.EMPTY;
-
-import java.time.Clock;
-import java.time.LocalDateTime;
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
-
 import org.alfresco.rest.model.RestTagModel;
 import org.alfresco.rest.search.SearchRequest;
 import org.alfresco.tas.AlfrescoStackInitializer;
@@ -32,6 +20,18 @@ import org.springframework.test.context.testng.AbstractTestNGSpringContextTests;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+
+import static org.alfresco.elasticsearch.SearchQueryService.req;
+import static org.alfresco.utility.data.RandomData.getRandomFile;
+import static org.alfresco.utility.data.RandomData.getRandomName;
+import static org.alfresco.utility.report.log.Step.STEP;
+import static org.apache.commons.lang3.StringUtils.EMPTY;
 
 @ContextConfiguration(locations = "classpath:alfresco-elasticsearch-context.xml",
     initializers = AlfrescoStackInitializer.class)
@@ -120,12 +120,12 @@ public class ElasticsearchBoostedSearchTests extends AbstractTestNGSpringContext
         searchQueryService.expectResultsInOrder(searchRequest, testUser, folderWithTermInName.getName(), folderWithTermInTitle.getName(), fileWithTermInName.getName(), fileWithTermInTitle.getName());
 
         STEP("Search for files and folders by name or title with higher priority for files by title");
-        String boostedQuery3 = "TYPE:('cm:content'^4 OR 'cm:folder'^0.5)^0.25 AND (cm:name:" + SEARCH_TERM + "^0.05 OR cm:title:" + SEARCH_TERM + "^3.5)";
+        String boostedQuery3 = "TYPE:('cm:content'^4 OR 'cm:folder'^0.5)^6 AND (cm:name:" + SEARCH_TERM + "^0.05 OR cm:title:" + SEARCH_TERM + "^3.5)";
         searchRequest = req("afts", boostedQuery3);
         searchQueryService.expectResultsInOrder(searchRequest, testUser, fileWithTermInTitle.getName(), fileWithTermInName.getName(), folderWithTermInTitle.getName(), folderWithTermInName.getName());
 
         STEP("Search for files and folders by name or title with higher priority for folders by title");
-        String boostedQuery4 = "TYPE:('cm:content'^0.5 OR 'cm:folder'^4)^0.25 AND (cm:name:" + SEARCH_TERM + "^0.05 OR cm:title:" + SEARCH_TERM + "^3.5)";
+        String boostedQuery4 = "TYPE:('cm:content'^0.5 OR 'cm:folder'^4)^6 AND (cm:name:" + SEARCH_TERM + "^0.05 OR cm:title:" + SEARCH_TERM + "^3.5)";
         searchRequest = req("afts", boostedQuery4);
         searchQueryService.expectResultsInOrder(searchRequest, testUser, folderWithTermInTitle.getName(), folderWithTermInName.getName(), fileWithTermInTitle.getName(), fileWithTermInName.getName());
     }


### PR DESCRIPTION
When testing manually, I was not able to get the expected order of results even for older versions of ACS such as `23.1.0-M4`. The expected order of results was possible after changing the values in the query.