### PR TITLE
ACS-6112: Ignoring test which fails intermittently. [skip tests]

### DIFF
--- a/tests/tas-elasticsearch/src/test/java/org/alfresco/elasticsearch/reindexing/NodesSecondaryAncestorIndexingTests.java
+++ b/tests/tas-elasticsearch/src/test/java/org/alfresco/elasticsearch/reindexing/NodesSecondaryAncestorIndexingTests.java
@@ -103,7 +103,7 @@ public class NodesSecondaryAncestorIndexingTests extends NodesSecondaryChildrenR
             fileInP.getName());
     }
 
-    @Test(groups = TestGroup.SEARCH)
+    @Test(groups = TestGroup.SEARCH, enabled = false)
     @Ignore("ACS-6112")
     public void testSecondaryAncestorWithNodeHavingComplexSecondaryRelationship()
     {

--- a/tests/tas-elasticsearch/src/test/java/org/alfresco/elasticsearch/reindexing/NodesSecondaryAncestorIndexingTests.java
+++ b/tests/tas-elasticsearch/src/test/java/org/alfresco/elasticsearch/reindexing/NodesSecondaryAncestorIndexingTests.java
@@ -7,6 +7,7 @@ import org.alfresco.rest.search.SearchRequest;
 import org.alfresco.utility.model.FileModel;
 import org.alfresco.utility.model.TestGroup;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Ignore;
 import org.testng.annotations.Test;
 
 /**
@@ -103,6 +104,7 @@ public class NodesSecondaryAncestorIndexingTests extends NodesSecondaryChildrenR
     }
 
     @Test(groups = TestGroup.SEARCH)
+    @Ignore("ACS-6112")
     public void testSecondaryAncestorWithNodeHavingComplexSecondaryRelationship()
     {
         // then


### PR DESCRIPTION
Disabling a test we already identified as intermittent failure (ACS-6112). Skipping tests as nothing but test ignore annotation has been added.