### PR TITLE
ACS-6177: [skip tests] Disabling Elasticsearch MS SQL E2E tests.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -321,6 +321,10 @@ jobs:
             profiles: all-tas-tests,elastic
             search-engine-type: elasticsearch
             db-type: mariadb
+#          - testSuite: Elasticsearch MS SQL
+#            profiles: all-tas-tests,elastic
+#            search-engine-type: elasticsearch
+#            db-type: mssql
           - testSuite: Elasticsearch Oracle 19.3.0-ee
             profiles: all-tas-tests,elastic
             search-engine-type: elasticsearch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -321,6 +321,8 @@ jobs:
             profiles: all-tas-tests,elastic
             search-engine-type: elasticsearch
             db-type: mariadb
+#          Temporarily commented out due to frequent GHA timeouts,
+#          pending further investigation as part of ACS-6177.
 #          - testSuite: Elasticsearch MS SQL
 #            profiles: all-tas-tests,elastic
 #            search-engine-type: elasticsearch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -321,10 +321,6 @@ jobs:
             profiles: all-tas-tests,elastic
             search-engine-type: elasticsearch
             db-type: mariadb
-          - testSuite: Elasticsearch MS SQL
-            profiles: all-tas-tests,elastic
-            search-engine-type: elasticsearch
-            db-type: mssql
           - testSuite: Elasticsearch Oracle 19.3.0-ee
             profiles: all-tas-tests,elastic
             search-engine-type: elasticsearch


### PR DESCRIPTION
Temporarily removing MS SQL Elasticsearch E2E suite from pipeline (as per ACS-6177).