### PR TITLE
ACS-6112: re-enable disabled test

### DIFF
--- a/tests/tas-elasticsearch/src/test/java/org/alfresco/elasticsearch/reindexing/NodesSecondaryAncestorIndexingTests.java
+++ b/tests/tas-elasticsearch/src/test/java/org/alfresco/elasticsearch/reindexing/NodesSecondaryAncestorIndexingTests.java
@@ -7,7 +7,6 @@ import org.alfresco.rest.search.SearchRequest;
 import org.alfresco.utility.model.FileModel;
 import org.alfresco.utility.model.TestGroup;
 import org.testng.annotations.BeforeClass;
-import org.testng.annotations.Ignore;
 import org.testng.annotations.Test;
 
 /**

--- a/tests/tas-elasticsearch/src/test/java/org/alfresco/elasticsearch/reindexing/NodesSecondaryAncestorIndexingTests.java
+++ b/tests/tas-elasticsearch/src/test/java/org/alfresco/elasticsearch/reindexing/NodesSecondaryAncestorIndexingTests.java
@@ -103,8 +103,7 @@ public class NodesSecondaryAncestorIndexingTests extends NodesSecondaryChildrenR
             fileInP.getName());
     }
 
-    @Test(groups = TestGroup.SEARCH, enabled = false)
-    @Ignore("ACS-6112")
+    @Test(groups = TestGroup.SEARCH)
     public void testSecondaryAncestorWithNodeHavingComplexSecondaryRelationship()
     {
         // then

--- a/tests/testcontainers-env/src/main/java/org/alfresco/tas/AlfrescoStackInitializer.java
+++ b/tests/testcontainers-env/src/main/java/org/alfresco/tas/AlfrescoStackInitializer.java
@@ -194,16 +194,18 @@ public class AlfrescoStackInitializer implements ApplicationContextInitializer<C
 
     }
 
-    protected GenericContainer createLiveIndexingContainer()
+    protected GenericContainer<?> createLiveIndexingContainer()
     {
-        return new GenericContainer(getImagesConfig().getLiveIndexingImage())
-                       .withNetwork(network)
-                       .withNetworkAliases("live-indexing")
-                       .withEnv("ELASTICSEARCH_INDEXNAME", CUSTOM_ALFRESCO_INDEX)
-                       .withEnv("SPRING_ELASTICSEARCH_REST_URIS", "http://elasticsearch:9200")
-                       .withEnv("SPRING_ACTIVEMQ_BROKERURL", "nio://activemq:61616")
-                       .withEnv("ALFRESCO_SHAREDFILESTORE_BASEURL", "http://shared-file-store:8099/alfresco/api/-default-/private/sfs/versions/1/file/")
-                       .withEnv("ALFRESCO_ACCEPTEDCONTENTMEDIATYPESCACHE_BASEURL", "http://transform-core-aio:8090/transform/config");
+        return new GenericContainer<>(getImagesConfig().getLiveIndexingImage())
+            .withNetwork(network)
+            .withNetworkAliases("live-indexing")
+            .withEnv("ELASTICSEARCH_INDEXNAME", CUSTOM_ALFRESCO_INDEX)
+            .withEnv("SPRING_ELASTICSEARCH_REST_URIS", "http://elasticsearch:9200")
+            .withEnv("SPRING_ACTIVEMQ_BROKERURL", "nio://activemq:61616")
+            .withEnv("ALFRESCO_SHAREDFILESTORE_BASEURL", "http://shared-file-store:8099/alfresco/api/-default-/private/sfs/versions/1/file/")
+            .withEnv("ALFRESCO_ACCEPTEDCONTENTMEDIATYPESCACHE_BASEURL", "http://transform-core-aio:8090/transform/config")
+            .withEnv("JAVA_TOOL_OPTIONS", "-agentlib:jdwp=transport=dt_socket,address=*:5005,server=y,suspend=n")
+            .withExposedPorts(5005);
     }
 
     protected GenericContainer createSearchEngineContainer()


### PR DESCRIPTION
Re-enable testSecondaryAncestorWithNodeHavingComplexSecondaryRelationship

- open debug port for live-indexer in E2Es