### PR TITLE
Disabling jobs requiring new license

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -381,49 +381,49 @@ jobs:
       - name: "Clean Maven cache"
         run: bash ./scripts/ci/cleanup_cache.sh
 
-  upgrade_tas_tests:
-    name: ${{ matrix.testSuite }} Upgrade TAS tests
-    runs-on: ubuntu-latest
-    if: >
-      !contains(github.event.head_commit.message, '[skip search]') &&
-      !contains(github.event.head_commit.message, '[skip tests]')
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - testSuite: Elasticsearch
-            search-engine-type: elasticsearch
-          - testSuite: Opensearch
-            search-engine-type: opensearch
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          persist-credentials: false
-      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.35.2
-      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v1.35.2
-      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.35.2
-      - name: "Build"
-        timeout-minutes: ${{ fromJSON(env.GITHUB_ACTIONS_DEPLOY_TIMEOUT) }}
-        run: |
-          bash ./scripts/ci/init.sh
-          bash ./scripts/ci/build.sh
-      - name: "Configure AWS credentials"
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_S3_ACSLICENSE_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_S3_ACSLICENSE_SECRET_ACCESS_KEY }}
-          aws-region: ${{ env.AWS_REGION }}
-      - name: "Copy Licence"
-        run: aws s3 cp ${ALF_LICENCE_S3_PATH} ${ALF_LICENCE_LOCAL_PATH}
-      - name: "Run tests"
-        id: tests
-        timeout-minutes: 30
-        run: mvn -B install -ntp -pl ":content-repository-elasticsearch-test" -am -Pall-tas-tests,elastic-upgrade -Denvironment=default -DrunBugs=false "-Dsearch.engine.type=${{ matrix.search-engine-type }}" "-Ddatabase.type=postgresql" "-Dindeximage=alfresco-es-indexing-jdbc:latest" "-Dreindeximage=alfresco-es-reindexing-jdbc:latest" "-Drepoimage=alfresco-repository-databases:latest"
-      - name: "Dump all Docker containers logs"
-        uses: Alfresco/alfresco-build-tools/.github/actions/docker-dump-containers-logs@v1.41.0
-        if: failure() && steps.tests.outcome == 'failure'
-      - name: "Clean Maven cache"
-        run: bash ./scripts/ci/cleanup_cache.sh
+#  upgrade_tas_tests:
+#    name: ${{ matrix.testSuite }} Upgrade TAS tests
+#    runs-on: ubuntu-latest
+#    if: >
+#      !contains(github.event.head_commit.message, '[skip search]') &&
+#      !contains(github.event.head_commit.message, '[skip tests]')
+#    strategy:
+#      fail-fast: false
+#      matrix:
+#        include:
+#          - testSuite: Elasticsearch
+#            search-engine-type: elasticsearch
+#          - testSuite: Opensearch
+#            search-engine-type: opensearch
+#    steps:
+#      - uses: actions/checkout@v3
+#        with:
+#          persist-credentials: false
+#      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.35.2
+#      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v1.35.2
+#      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.35.2
+#      - name: "Build"
+#        timeout-minutes: ${{ fromJSON(env.GITHUB_ACTIONS_DEPLOY_TIMEOUT) }}
+#        run: |
+#          bash ./scripts/ci/init.sh
+#          bash ./scripts/ci/build.sh
+#      - name: "Configure AWS credentials"
+#        uses: aws-actions/configure-aws-credentials@v1
+#        with:
+#          aws-access-key-id: ${{ secrets.AWS_S3_ACSLICENSE_ACCESS_KEY_ID }}
+#          aws-secret-access-key: ${{ secrets.AWS_S3_ACSLICENSE_SECRET_ACCESS_KEY }}
+#          aws-region: ${{ env.AWS_REGION }}
+#      - name: "Copy Licence"
+#        run: aws s3 cp ${ALF_LICENCE_S3_PATH} ${ALF_LICENCE_LOCAL_PATH}
+#      - name: "Run tests"
+#        id: tests
+#        timeout-minutes: 30
+#        run: mvn -B install -ntp -pl ":content-repository-elasticsearch-test" -am -Pall-tas-tests,elastic-upgrade -Denvironment=default -DrunBugs=false "-Dsearch.engine.type=${{ matrix.search-engine-type }}" "-Ddatabase.type=postgresql" "-Dindeximage=alfresco-es-indexing-jdbc:latest" "-Dreindeximage=alfresco-es-reindexing-jdbc:latest" "-Drepoimage=alfresco-repository-databases:latest"
+#      - name: "Dump all Docker containers logs"
+#        uses: Alfresco/alfresco-build-tools/.github/actions/docker-dump-containers-logs@v1.41.0
+#        if: failure() && steps.tests.outcome == 'failure'
+#      - name: "Clean Maven cache"
+#        run: bash ./scripts/ci/cleanup_cache.sh
 
   all_amps_tests:
     name: "All AMPs tests"


### PR DESCRIPTION
These jobs require real 23.2 license. Since we are not going to generate new licenses for this version (23.1 license should be used for 23.X). These jobs should be restored after introducing new versioning scheme to the repo.