### PR TITLE
ACS-6282 Switch to a disposable EC2 hosted runner for ARM64 tests

### DIFF
--- a/.github/workflows/arm64.yml
+++ b/.github/workflows/arm64.yml
@@ -108,7 +108,8 @@ jobs:
           echo "TEST_GIT_TAG=$TEST_GIT_TAG" >> $GITHUB_ENV
       - name: "Prepare test config"
         run: |
-          git checkout $TEST_GIT_TAG
+          #Temporarily test with more generous timeouts due to flaky tests
+          #git checkout $TEST_GIT_TAG
           mvn clean install -B -ntp -DskipTests -f tests/pipeline-all-amps/repo/pom.xml
           cat tests/pipeline-all-amps/repo/target/dtas/dtas-config.json
       - name: "Set up the environment"

--- a/.github/workflows/arm64.yml
+++ b/.github/workflows/arm64.yml
@@ -46,7 +46,7 @@ jobs:
           pre-runner-script: |
             set -ex
             sudo apt-get update
-            sudo apt-get install ca-certificates curl gnupg
+            sudo apt-get install ca-certificates curl gnupg -y
             sudo install -m 0755 -d /etc/apt/keyrings
             curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
             sudo chmod a+r /etc/apt/keyrings/docker.gpg
@@ -55,7 +55,7 @@ jobs:
               "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | \
               sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
             sudo apt-get update
-            sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin git unzip curl -y
+            sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin git unzip -y
 
   arm64_health_check:
     name: "ARM64 Health Check"

--- a/.github/workflows/arm64.yml
+++ b/.github/workflows/arm64.yml
@@ -43,19 +43,18 @@ jobs:
               {"Key": "Name", "Value": "arm64-acs-packaging-gh-runner"},
               {"Key": "GitHubRepository", "Value": "${{ github.repository }}"}
             ]
-          pre-runner-script: |
-            set -ex
-            sudo apt-get update
-            sudo apt-get install ca-certificates curl gnupg -y
-            sudo install -m 0755 -d /etc/apt/keyrings
-            curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
-            sudo chmod a+r /etc/apt/keyrings/docker.gpg
-            echo \
-              "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
-              "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | \
-              sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-            sudo apt-get update
-            sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin git unzip -y
+          #pre-runner-script: |
+          #  sudo apt-get update
+          #  sudo apt-get install ca-certificates curl gnupg -y
+          #  sudo install -m 0755 -d /etc/apt/keyrings
+          #  curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+          #  sudo chmod a+r /etc/apt/keyrings/docker.gpg
+          #  echo \
+          #    "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+          #    "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | \
+          #    sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+          #  sudo apt-get update
+          #  sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin git unzip -y
 
   arm64_health_check:
     name: "ARM64 Health Check"

--- a/.github/workflows/arm64.yml
+++ b/.github/workflows/arm64.yml
@@ -59,6 +59,7 @@ jobs:
       - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v3.6.0
       - name: "Install required software"
         run: |
+          # Install Docker as per https://docs.docker.com/engine/install/ubuntu/
           sudo apt-get update
           sudo apt-get install ca-certificates curl gnupg -y
           sudo install -m 0755 -d /etc/apt/keyrings
@@ -69,7 +70,9 @@ jobs:
             "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | \
             sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
           sudo apt-get update
+          # Additionally install git, zip and unzip (required by SDKMAN to install Maven), python3
           sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin git zip unzip python3 -y
+          # Workaround due to $HOME not being set causing issues with settings.xml installation in setup-build-java
           mkdir -p /root/.m2
           cp .ci.settings.xml /root/.m2/settings.xml
       - name: "Install Maven"
@@ -91,7 +94,6 @@ jobs:
           password: ${{ secrets.QUAY_PASSWORD }}
       - name: "Get latest matching tag"
         run: |
-          echo Home is: $HOME
           VERSION_NUMBER=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout | sed -E 's/([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
           TEST_GIT_TAG=$(git tag --list --sort=-taggerdate "$VERSION_NUMBER*" | head -n 1)
           if [ -z $TEST_GIT_TAG ]; then
@@ -101,7 +103,7 @@ jobs:
       - name: "Prepare test config"
         run: |
           git checkout $TEST_GIT_TAG
-          mvn -X clean install -B -ntp -DskipTests -f tests/pipeline-all-amps/repo/pom.xml
+          mvn clean install -B -ntp -DskipTests -f tests/pipeline-all-amps/repo/pom.xml
           cat tests/pipeline-all-amps/repo/target/dtas/dtas-config.json
       - name: "Set up the environment"
         id: setup-env
@@ -110,6 +112,8 @@ jobs:
           AWS_ACCESS_KEY: ${{ secrets.AWS_S3_PIPELINE_AMPS_ACCESS_KEY_ID }}
           AWS_SECRET_KEY: ${{ secrets.AWS_S3_PIPELINE_AMPS_SECRET_ACCESS_KEY }}
         run: |
+          # Adapt scripts to docker compose as a plugin rather than standalone executable
+          alias docker-compose="docker compose"
           # Make necessary env files available
           git clone --depth=1 --branch master https://${{ secrets.BOT_GITHUB_USERNAME }}:${{ secrets.BOT_GITHUB_TOKEN }}@github.com/Alfresco/alfresco-community-repo.git ../alfresco-community-repo
           # Start the environment
@@ -130,7 +134,7 @@ jobs:
           python3 -m pytest --configuration ../tests/pipeline-all-amps/repo/target/dtas/dtas-config.json tests/ -s \
             --ignore=tests/scenarios/test_sync.py
       - name: "Dump all Docker containers logs"
-        uses: Alfresco/alfresco-build-tools/.github/actions/docker-dump-containers-logs@v1.41.0
+        uses: Alfresco/alfresco-build-tools/.github/actions/docker-dump-containers-logs@v3.6.0
         if: failure() && (steps.setup-env.outcome == 'failure' || steps.run-tests.outcome == 'failure')
       - name: "Persist test failure flag"
         id: persist_test_failure_flag

--- a/.github/workflows/arm64.yml
+++ b/.github/workflows/arm64.yml
@@ -70,6 +70,8 @@ jobs:
             sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
           sudo apt-get update
           sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin git zip unzip python3 -y
+          mkdir -p /root/.m2
+          cp .ci.settings.xml /root/.m2/settings.xml
       - name: "Install Maven"
         uses: sdkman/sdkman-action@b1f9b696c79148b66d3d3a06f7ea801820318d0f
         with:

--- a/.github/workflows/arm64.yml
+++ b/.github/workflows/arm64.yml
@@ -138,7 +138,8 @@ jobs:
           pip install -r requirements.txt
           # NOTE: some tests are temporarily disabled since the related components don't provide native ARM64 images yet
           python3 -m pytest --configuration ../tests/pipeline-all-amps/repo/target/dtas/dtas-config.json tests/ -s \
-            --ignore=tests/scenarios/test_sync.py
+            --ignore=tests/scenarios/test_sync.py \
+            -k "not test_adw_reachability"
       - name: "Dump all Docker containers logs"
         uses: Alfresco/alfresco-build-tools/.github/actions/docker-dump-containers-logs@v3.6.0
         if: failure() && (steps.setup-env.outcome == 'failure' || steps.run-tests.outcome == 'failure')

--- a/.github/workflows/arm64.yml
+++ b/.github/workflows/arm64.yml
@@ -30,7 +30,7 @@ jobs:
           aws-region: eu-west-2
       - name: "Start EC2 runner"
         id: start-ec2-runner
-        uses: machulav/ec2-github-runner@4e0303de215db88e1c489e07a15ca4d867f488ea
+        uses: machulav/ec2-github-runner@2c4d1dcf2c54673ed3bfd194c4b6919ed396a209
         with:
           mode: start
           github-token: ${{ secrets.BOT_GITHUB_TOKEN }}
@@ -152,7 +152,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_EC2_GITHUB_RUNNER_SECRET_ACCESS_KEY }}
           aws-region: eu-west-2
       - name: "Stop EC2 runner"
-        uses: machulav/ec2-github-runner@4e0303de215db88e1c489e07a15ca4d867f488ea
+        uses: machulav/ec2-github-runner@2c4d1dcf2c54673ed3bfd194c4b6919ed396a209
         with:
           mode: stop
           github-token: ${{ secrets.BOT_GITHUB_TOKEN }}

--- a/.github/workflows/arm64.yml
+++ b/.github/workflows/arm64.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           mode: start
           github-token: ${{ secrets.BOT_GITHUB_TOKEN }}
-          ec2-image-id: ami-0bed444050ff5fab3
+          ec2-image-id: ami-025db40ba9581d621 #ami-0bed444050ff5fab3
           ec2-instance-type: c6g.2xlarge
           subnet-id: subnet-0777c70a4cd9ce944
           security-group-id: sg-0f89a325d9eb147cb

--- a/.github/workflows/arm64.yml
+++ b/.github/workflows/arm64.yml
@@ -109,7 +109,6 @@ jobs:
       - name: "Prepare test config"
         run: |
           git checkout $TEST_GIT_TAG
-          sed -i 's/"request_timeout_seconds": "30"/"request_timeout_seconds": "45", "wait_rendition_max_attempts": "15"/g' tests/pipeline-all-amps/repo/dtas/dtas-config.json
           mvn clean install -B -ntp -DskipTests -f tests/pipeline-all-amps/repo/pom.xml
           cat tests/pipeline-all-amps/repo/target/dtas/dtas-config.json
       - name: "Set up the environment"

--- a/.github/workflows/arm64.yml
+++ b/.github/workflows/arm64.yml
@@ -34,14 +34,18 @@ jobs:
         with:
           mode: start
           github-token: ${{ secrets.BOT_GITHUB_TOKEN }}
-          ec2-image-id: ami-0ec31c3e3b729bb6d
+          ec2-image-id: ami-0ec31c3e3b729bb6d # Ubuntu 22.04 ARM64 w/ 125GB drive
           ec2-instance-type: c6g.2xlarge
           subnet-id: subnet-0777c70a4cd9ce944
           security-group-id: sg-0f89a325d9eb147cb
           aws-resource-tags: >
             [
               {"Key": "Name", "Value": "arm64-acs-packaging-gh-runner"},
-              {"Key": "GitHubRepository", "Value": "${{ github.repository }}"}
+              {"Key": "Creator", "Value": "${{ github.repository }}"},
+              {"Key": "Owner", "Value": "ACS Feature Teams"},
+              {"Key": "Department", "Value": "Alfresco Engineering"},
+              {"Key": "Purpose", "Value": "GH runner for ARM64 acs-packaging tests"},
+              {"Key": "Production", "Value": "false"}
             ]
 
   arm64_health_check:
@@ -60,18 +64,18 @@ jobs:
       - name: "Install required software"
         run: |
           # Install Docker as per https://docs.docker.com/engine/install/ubuntu/
-          sudo apt-get update
-          sudo apt-get install ca-certificates curl gnupg -y
-          sudo install -m 0755 -d /etc/apt/keyrings
-          curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
-          sudo chmod a+r /etc/apt/keyrings/docker.gpg
+          apt-get update
+          apt-get install ca-certificates curl gnupg -y
+          install -m 0755 -d /etc/apt/keyrings
+          curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+          chmod a+r /etc/apt/keyrings/docker.gpg
           echo \
             "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
             "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | \
-            sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-          sudo apt-get update
+            tee /etc/apt/sources.list.d/docker.list > /dev/null
+          apt-get update
           # Additionally install git, zip and unzip (required by SDKMAN to install Maven), python3
-          sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin git zip unzip python3 python3-pip -y
+          apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin git zip unzip python3 python3-pip -y
           # Allow usage of "docker-compose" rather than "docker compose" in bash scripts
           ln -f -s /usr/libexec/docker/cli-plugins/docker-compose /usr/local/bin/docker-compose
           # Workaround due to $HOME not being set causing issues with settings.xml installation in setup-build-java

--- a/.github/workflows/arm64.yml
+++ b/.github/workflows/arm64.yml
@@ -108,8 +108,8 @@ jobs:
           echo "TEST_GIT_TAG=$TEST_GIT_TAG" >> $GITHUB_ENV
       - name: "Prepare test config"
         run: |
-          #Temporarily test with more generous timeouts due to flaky tests
-          #git checkout $TEST_GIT_TAG
+          git checkout $TEST_GIT_TAG
+          sed -i 's/"request_timeout_seconds": "30"/"request_timeout_seconds": "45", "wait_rendition_max_attempts": "15"/g' tests/pipeline-all-amps/repo/dtas/dtas-config.json
           mvn clean install -B -ntp -DskipTests -f tests/pipeline-all-amps/repo/pom.xml
           cat tests/pipeline-all-amps/repo/target/dtas/dtas-config.json
       - name: "Set up the environment"

--- a/.github/workflows/arm64.yml
+++ b/.github/workflows/arm64.yml
@@ -55,8 +55,8 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: 0
-      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.36.0
-      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v1.36.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v3.6.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v3.6.0
       - name: "Install required software"
         run: |
           sudo apt-get update
@@ -75,7 +75,7 @@ jobs:
         with:
           candidate: maven
           version: "3.8.8"
-      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.36.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v3.6.0
       - name: "Login to Docker Hub"
         uses: docker/login-action@v2.1.0
         with:
@@ -91,6 +91,7 @@ jobs:
         run: |
           pushd ..
           mvn help:effective-settings
+          cat $HOME/.m2/settings.xml
           popd
           VERSION_NUMBER=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout | sed -E 's/([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
           TEST_GIT_TAG=$(git tag --list --sort=-taggerdate "$VERSION_NUMBER*" | head -n 1)

--- a/.github/workflows/arm64.yml
+++ b/.github/workflows/arm64.yml
@@ -55,7 +55,7 @@ jobs:
               "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | \
               sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
             sudo apt-get update
-            sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin git unzip
+            sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin git unzip -y
 
   arm64_health_check:
     name: "ARM64 Health Check"
@@ -71,7 +71,7 @@ jobs:
       - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.36.0
       - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v1.36.0
       - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.36.0
-      - name: Install Maven
+      - name: "Install Maven"
         uses: sdkman/sdkman-action@b1f9b696c79148b66d3d3a06f7ea801820318d0f
         with:
           candidate: maven

--- a/.github/workflows/arm64.yml
+++ b/.github/workflows/arm64.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           mode: start
           github-token: ${{ secrets.BOT_GITHUB_TOKEN }}
-          ec2-image-id: ami-025db40ba9581d621 #ami-0bed444050ff5fab3
+          ec2-image-id: ami-0ec31c3e3b729bb6d
           ec2-instance-type: c6g.2xlarge
           subnet-id: subnet-0777c70a4cd9ce944
           security-group-id: sg-0f89a325d9eb147cb
@@ -57,12 +57,6 @@ jobs:
           fetch-depth: 0
       - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.36.0
       - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v1.36.0
-      - name: "Install Maven"
-        uses: sdkman/sdkman-action@b1f9b696c79148b66d3d3a06f7ea801820318d0f
-        with:
-          candidate: maven
-          version: "3.8.8"
-      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.36.0
       - name: "Install required software"
         run: |
           sudo apt-get update
@@ -76,6 +70,12 @@ jobs:
             sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
           sudo apt-get update
           sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin git zip unzip python3 -y
+      - name: "Install Maven"
+        uses: sdkman/sdkman-action@b1f9b696c79148b66d3d3a06f7ea801820318d0f
+        with:
+          candidate: maven
+          version: "3.8.8"
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.36.0
       - name: "Login to Docker Hub"
         uses: docker/login-action@v2.1.0
         with:

--- a/.github/workflows/arm64.yml
+++ b/.github/workflows/arm64.yml
@@ -55,7 +55,7 @@ jobs:
               "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | \
               sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
             sudo apt-get update
-            sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin git
+            sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin git unzip
 
   arm64_health_check:
     name: "ARM64 Health Check"

--- a/.github/workflows/arm64.yml
+++ b/.github/workflows/arm64.yml
@@ -57,6 +57,11 @@ jobs:
           fetch-depth: 0
       - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.36.0
       - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v1.36.0
+      - name: "Install Maven"
+        uses: sdkman/sdkman-action@b1f9b696c79148b66d3d3a06f7ea801820318d0f
+        with:
+          candidate: maven
+          version: "3.8.8"
       - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.36.0
       - name: "Install required software"
         run: |
@@ -71,11 +76,6 @@ jobs:
             sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
           sudo apt-get update
           sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin git zip unzip python3 -y
-      - name: "Install Maven"
-        uses: sdkman/sdkman-action@b1f9b696c79148b66d3d3a06f7ea801820318d0f
-        with:
-          candidate: maven
-          version: "3.8.8"
       - name: "Login to Docker Hub"
         uses: docker/login-action@v2.1.0
         with:

--- a/.github/workflows/arm64.yml
+++ b/.github/workflows/arm64.yml
@@ -69,12 +69,7 @@ jobs:
             "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | \
             sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
           sudo apt-get update
-          sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin git zip unzip python3 -y
-      - name: "Install Maven"
-        uses: sdkman/sdkman-action@b1f9b696c79148b66d3d3a06f7ea801820318d0f
-        with:
-          candidate: maven
-          version: "3.8.8"
+          sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin git zip unzip python3 maven -y
       - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v3.6.0
       - name: "Login to Docker Hub"
         uses: docker/login-action@v2.1.0

--- a/.github/workflows/arm64.yml
+++ b/.github/workflows/arm64.yml
@@ -15,9 +15,39 @@ env:
   DTAS_VERSION: v1.2.2
 
 jobs:
+  start-runner:
+    name: "Start self-hosted EC2 runner"
+    runs-on: ubuntu-latest
+    outputs:
+      label: ${{ steps.start-ec2-runner.outputs.label }}
+      ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
+    steps:
+      - name: "Configure AWS credentials"
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_EC2_GITHUB_RUNNER_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_EC2_GITHUB_RUNNER_SECRET_ACCESS_KEY }}
+          aws-region: eu-west-2
+      - name: "Start EC2 runner"
+        id: start-ec2-runner
+        uses: machulav/ec2-github-runner@4e0303de215db88e1c489e07a15ca4d867f488ea
+        with:
+          mode: start
+          github-token: ${{ secrets.BOT_GITHUB_TOKEN }}
+          ec2-image-id: ami-0bed444050ff5fab3
+          ec2-instance-type: c6g.2xlarge
+          subnet-id: subnet-0777c70a4cd9ce944
+          security-group-id: sg-0f89a325d9eb147cb
+          aws-resource-tags: >
+            [
+              {"Key": "Name", "Value": "arm64-acs-packaging-gh-runner"},
+              {"Key": "GitHubRepository", "Value": "${{ github.repository }}"}
+            ]
+
   arm64_health_check:
-    name: ARM64 Health Check
-    runs-on: [self-hosted, linux, arm64]
+    name: "ARM64 Health Check"
+    needs: start-runner
+    runs-on: ${{ needs.start-runner.outputs.label }}
     outputs:
       test_failure: ${{ steps.persist_test_failure_flag.outputs.test_failure }}
     steps:
@@ -39,6 +69,17 @@ jobs:
           registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}
+      - name: "Clean Maven cache"
+        run: rm -rf $HOME/.m2/repository/*
+      - name: "Clean up the environment"
+        run: |
+          rm -rf ../alfresco-community-repo
+          rm -rf dtas
+          docker container stop $(docker container ls -aq) || true
+          docker container rm $(docker container ls -aq) || true
+          docker volume rm -f $(docker volume ls -q) || true
+          docker rmi -f $(docker images -aq) || true
+          docker system prune -a -f
       - name: "Get latest matching tag"
         run: |
           VERSION_NUMBER=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout | sed -E 's/([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
@@ -85,23 +126,34 @@ jobs:
         id: persist_test_failure_flag
         run: echo "test_failure=true" >> "$GITHUB_OUTPUT"
         if: failure()
-      - name: "Clean Maven cache"
-        if: always()
-        run: rm -rf $HOME/.m2/repository/*
-      - name: "Clean up the environment"
-        if: always()
-        run: |
-          rm -rf ../alfresco-community-repo
-          rm -rf dtas
-          docker container stop $(docker container ls -aq) || true
-          docker container rm $(docker container ls -aq) || true
-          docker volume rm -f $(docker volume ls -q) || true
-          docker rmi -f $(docker images -aq) || true
-          docker system prune -a -f
+
+  stop-runner:
+    name: "Stop self-hosted EC2 runner"
+    needs:
+      - start-runner
+      - arm64_health_check
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: "Configure AWS credentials"
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_EC2_GITHUB_RUNNER_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_EC2_GITHUB_RUNNER_SECRET_ACCESS_KEY }}
+          aws-region: eu-west-2
+      - name: "Stop EC2 runner"
+        uses: machulav/ec2-github-runner@4e0303de215db88e1c489e07a15ca4d867f488ea
+        with:
+          mode: stop
+          github-token: ${{ secrets.BOT_GITHUB_TOKEN }}
+          label: ${{ needs.start-runner.outputs.label }}
+          ec2-instance-id: ${{ needs.start-runner.outputs.ec2-instance-id }}
+
   jira_integration:
     name: "JIRA integration"
     runs-on: ubuntu-latest
-    needs: [arm64_health_check]
+    needs:
+      - arm64_health_check
     if: always()
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/arm64.yml
+++ b/.github/workflows/arm64.yml
@@ -89,13 +89,7 @@ jobs:
           password: ${{ secrets.QUAY_PASSWORD }}
       - name: "Get latest matching tag"
         run: |
-          pushd ..
-          mvn help:effective-settings
-          echo $HOME
-          cat $HOME/.m2/settings.xml
-          echo "----"
-          cat /.sdkman/candidates/maven/current/conf/settings.xml
-          popd
+          echo Home is: $HOME
           VERSION_NUMBER=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout | sed -E 's/([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
           TEST_GIT_TAG=$(git tag --list --sort=-taggerdate "$VERSION_NUMBER*" | head -n 1)
           if [ -z $TEST_GIT_TAG ]; then

--- a/.github/workflows/arm64.yml
+++ b/.github/workflows/arm64.yml
@@ -43,6 +43,19 @@ jobs:
               {"Key": "Name", "Value": "arm64-acs-packaging-gh-runner"},
               {"Key": "GitHubRepository", "Value": "${{ github.repository }}"}
             ]
+          pre-runner-script: |
+            set -e
+            sudo apt-get update
+            sudo apt-get install ca-certificates curl gnupg
+            sudo install -m 0755 -d /etc/apt/keyrings
+            curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+            sudo chmod a+r /etc/apt/keyrings/docker.gpg
+            echo \
+              "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+              "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | \
+              sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+            sudo apt-get update
+            sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin git
 
   arm64_health_check:
     name: "ARM64 Health Check"
@@ -58,6 +71,14 @@ jobs:
       - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.36.0
       - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v1.36.0
       - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.36.0
+      - name: Install Maven
+        uses: sdkman/sdkman-action@b1f9b696c79148b66d3d3a06f7ea801820318d0f
+        with:
+          candidate: maven
+          version: "3.8.8"
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
       - name: "Login to Docker Hub"
         uses: docker/login-action@v2.1.0
         with:
@@ -69,17 +90,6 @@ jobs:
           registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}
-      - name: "Clean Maven cache"
-        run: rm -rf $HOME/.m2/repository/*
-      - name: "Clean up the environment"
-        run: |
-          rm -rf ../alfresco-community-repo
-          rm -rf dtas
-          docker container stop $(docker container ls -aq) || true
-          docker container rm $(docker container ls -aq) || true
-          docker volume rm -f $(docker volume ls -q) || true
-          docker rmi -f $(docker images -aq) || true
-          docker system prune -a -f
       - name: "Get latest matching tag"
         run: |
           VERSION_NUMBER=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout | sed -E 's/([0-9]+\.[0-9]+\.[0-9]+).*/\1/')

--- a/.github/workflows/arm64.yml
+++ b/.github/workflows/arm64.yml
@@ -71,7 +71,7 @@ jobs:
             "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | \
             sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
           sudo apt-get update
-          sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin git unzip -y
+          sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin git zip unzip -y
       - name: "Install Maven"
         uses: sdkman/sdkman-action@b1f9b696c79148b66d3d3a06f7ea801820318d0f
         with:

--- a/.github/workflows/arm64.yml
+++ b/.github/workflows/arm64.yml
@@ -89,7 +89,9 @@ jobs:
           password: ${{ secrets.QUAY_PASSWORD }}
       - name: "Get latest matching tag"
         run: |
+          pushd ..
           mvn help:effective-settings
+          popd
           VERSION_NUMBER=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout | sed -E 's/([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
           TEST_GIT_TAG=$(git tag --list --sort=-taggerdate "$VERSION_NUMBER*" | head -n 1)
           if [ -z $TEST_GIT_TAG ]; then

--- a/.github/workflows/arm64.yml
+++ b/.github/workflows/arm64.yml
@@ -71,7 +71,7 @@ jobs:
             sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
           sudo apt-get update
           # Additionally install git, zip and unzip (required by SDKMAN to install Maven), python3
-          sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin git zip unzip python3 -y
+          sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin git zip unzip python3 python3-pip -y
           # Workaround due to $HOME not being set causing issues with settings.xml installation in setup-build-java
           mkdir -p /root/.m2
           cp .ci.settings.xml /root/.m2/settings.xml
@@ -112,8 +112,8 @@ jobs:
           AWS_ACCESS_KEY: ${{ secrets.AWS_S3_PIPELINE_AMPS_ACCESS_KEY_ID }}
           AWS_SECRET_KEY: ${{ secrets.AWS_S3_PIPELINE_AMPS_SECRET_ACCESS_KEY }}
         run: |
-          # Adapt scripts to docker compose as a plugin rather than standalone executable
-          alias docker-compose="docker compose"
+          # Allow usage of "docker-compose" rather than "docker compose" in bash scripts
+          ln -f -s /usr/libexec/docker/cli-plugins/docker-compose /usr/local/bin/docker-compose
           # Make necessary env files available
           git clone --depth=1 --branch master https://${{ secrets.BOT_GITHUB_USERNAME }}:${{ secrets.BOT_GITHUB_TOKEN }}@github.com/Alfresco/alfresco-community-repo.git ../alfresco-community-repo
           # Start the environment
@@ -130,6 +130,7 @@ jobs:
           # Make necessary test files available
           git clone --depth 1 --branch $DTAS_VERSION https://${{ secrets.BOT_GITHUB_USERNAME }}:${{ secrets.BOT_GITHUB_TOKEN }}@github.com/Alfresco/alfresco-deployment-test-automation-scripts.git dtas
           cd dtas
+          pip install pytest
           # NOTE: some tests are temporarily disabled since the related components don't provide native ARM64 images yet
           python3 -m pytest --configuration ../tests/pipeline-all-amps/repo/target/dtas/dtas-config.json tests/ -s \
             --ignore=tests/scenarios/test_sync.py

--- a/.github/workflows/arm64.yml
+++ b/.github/workflows/arm64.yml
@@ -92,6 +92,8 @@ jobs:
           pushd ..
           mvn help:effective-settings
           cat $HOME/.m2/settings.xml
+          echo "----"
+          cat /.sdkman/candidates/maven/current/conf/settings.xml
           popd
           VERSION_NUMBER=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout | sed -E 's/([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
           TEST_GIT_TAG=$(git tag --list --sort=-taggerdate "$VERSION_NUMBER*" | head -n 1)

--- a/.github/workflows/arm64.yml
+++ b/.github/workflows/arm64.yml
@@ -58,9 +58,8 @@ jobs:
       - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.36.0
       - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v1.36.0
       - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.36.0
-      - name: "Install prerequisite software"
+      - name: "Install required software"
         run: |
-          set -ex
           sudo apt-get update
           sudo apt-get install ca-certificates curl gnupg -y
           sudo install -m 0755 -d /etc/apt/keyrings
@@ -71,15 +70,12 @@ jobs:
             "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | \
             sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
           sudo apt-get update
-          sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin git zip unzip -y
+          sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin git zip unzip python3 -y
       - name: "Install Maven"
         uses: sdkman/sdkman-action@b1f9b696c79148b66d3d3a06f7ea801820318d0f
         with:
           candidate: maven
           version: "3.8.8"
-      - uses: actions/setup-python@v4
-        with:
-          python-version: "3.10"
       - name: "Login to Docker Hub"
         uses: docker/login-action@v2.1.0
         with:

--- a/.github/workflows/arm64.yml
+++ b/.github/workflows/arm64.yml
@@ -69,7 +69,12 @@ jobs:
             "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | \
             sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
           sudo apt-get update
-          sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin git zip unzip python3 maven -y
+          sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin git zip unzip python3 -y
+      - name: "Install Maven"
+        uses: sdkman/sdkman-action@b1f9b696c79148b66d3d3a06f7ea801820318d0f
+        with:
+          candidate: maven
+          version: "3.8.8"
       - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v3.6.0
       - name: "Login to Docker Hub"
         uses: docker/login-action@v2.1.0
@@ -86,6 +91,7 @@ jobs:
         run: |
           pushd ..
           mvn help:effective-settings
+          echo $HOME
           cat $HOME/.m2/settings.xml
           echo "----"
           cat /.sdkman/candidates/maven/current/conf/settings.xml

--- a/.github/workflows/arm64.yml
+++ b/.github/workflows/arm64.yml
@@ -44,7 +44,7 @@ jobs:
               {"Key": "GitHubRepository", "Value": "${{ github.repository }}"}
             ]
           pre-runner-script: |
-            set -e
+            set -ex
             sudo apt-get update
             sudo apt-get install ca-certificates curl gnupg
             sudo install -m 0755 -d /etc/apt/keyrings
@@ -55,7 +55,7 @@ jobs:
               "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | \
               sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
             sudo apt-get update
-            sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin git unzip -y
+            sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin git unzip curl -y
 
   arm64_health_check:
     name: "ARM64 Health Check"

--- a/.github/workflows/arm64.yml
+++ b/.github/workflows/arm64.yml
@@ -72,6 +72,8 @@ jobs:
           sudo apt-get update
           # Additionally install git, zip and unzip (required by SDKMAN to install Maven), python3
           sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin git zip unzip python3 python3-pip -y
+          # Allow usage of "docker-compose" rather than "docker compose" in bash scripts
+          ln -f -s /usr/libexec/docker/cli-plugins/docker-compose /usr/local/bin/docker-compose
           # Workaround due to $HOME not being set causing issues with settings.xml installation in setup-build-java
           mkdir -p /root/.m2
           cp .ci.settings.xml /root/.m2/settings.xml
@@ -81,6 +83,10 @@ jobs:
           candidate: maven
           version: "3.8.8"
       - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v3.6.0
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: linux/amd64,linux/arm64
       - name: "Login to Docker Hub"
         uses: docker/login-action@v2.1.0
         with:
@@ -112,8 +118,6 @@ jobs:
           AWS_ACCESS_KEY: ${{ secrets.AWS_S3_PIPELINE_AMPS_ACCESS_KEY_ID }}
           AWS_SECRET_KEY: ${{ secrets.AWS_S3_PIPELINE_AMPS_SECRET_ACCESS_KEY }}
         run: |
-          # Allow usage of "docker-compose" rather than "docker compose" in bash scripts
-          ln -f -s /usr/libexec/docker/cli-plugins/docker-compose /usr/local/bin/docker-compose
           # Make necessary env files available
           git clone --depth=1 --branch master https://${{ secrets.BOT_GITHUB_USERNAME }}:${{ secrets.BOT_GITHUB_TOKEN }}@github.com/Alfresco/alfresco-community-repo.git ../alfresco-community-repo
           # Start the environment

--- a/.github/workflows/arm64.yml
+++ b/.github/workflows/arm64.yml
@@ -30,7 +30,7 @@ jobs:
           aws-region: eu-west-2
       - name: "Start EC2 runner"
         id: start-ec2-runner
-        uses: machulav/ec2-github-runner@2c4d1dcf2c54673ed3bfd194c4b6919ed396a209
+        uses: machulav/ec2-github-runner@4e0303de215db88e1c489e07a15ca4d867f488ea
         with:
           mode: start
           github-token: ${{ secrets.BOT_GITHUB_TOKEN }}
@@ -43,18 +43,6 @@ jobs:
               {"Key": "Name", "Value": "arm64-acs-packaging-gh-runner"},
               {"Key": "GitHubRepository", "Value": "${{ github.repository }}"}
             ]
-          #pre-runner-script: |
-          #  sudo apt-get update
-          #  sudo apt-get install ca-certificates curl gnupg -y
-          #  sudo install -m 0755 -d /etc/apt/keyrings
-          #  curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
-          #  sudo chmod a+r /etc/apt/keyrings/docker.gpg
-          #  echo \
-          #    "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
-          #    "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | \
-          #    sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-          #  sudo apt-get update
-          #  sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin git unzip -y
 
   arm64_health_check:
     name: "ARM64 Health Check"
@@ -70,6 +58,20 @@ jobs:
       - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.36.0
       - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v1.36.0
       - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.36.0
+      - name: "Install prerequisite software"
+        run: |
+          set -ex
+          sudo apt-get update
+          sudo apt-get install ca-certificates curl gnupg -y
+          sudo install -m 0755 -d /etc/apt/keyrings
+          curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+          sudo chmod a+r /etc/apt/keyrings/docker.gpg
+          echo \
+            "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+            "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | \
+            sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+          sudo apt-get update
+          sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin git unzip -y
       - name: "Install Maven"
         uses: sdkman/sdkman-action@b1f9b696c79148b66d3d3a06f7ea801820318d0f
         with:
@@ -151,7 +153,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_EC2_GITHUB_RUNNER_SECRET_ACCESS_KEY }}
           aws-region: eu-west-2
       - name: "Stop EC2 runner"
-        uses: machulav/ec2-github-runner@2c4d1dcf2c54673ed3bfd194c4b6919ed396a209
+        uses: machulav/ec2-github-runner@4e0303de215db88e1c489e07a15ca4d867f488ea
         with:
           mode: stop
           github-token: ${{ secrets.BOT_GITHUB_TOKEN }}

--- a/.github/workflows/arm64.yml
+++ b/.github/workflows/arm64.yml
@@ -134,7 +134,7 @@ jobs:
           # Make necessary test files available
           git clone --depth 1 --branch $DTAS_VERSION https://${{ secrets.BOT_GITHUB_USERNAME }}:${{ secrets.BOT_GITHUB_TOKEN }}@github.com/Alfresco/alfresco-deployment-test-automation-scripts.git dtas
           cd dtas
-          pip install pytest
+          pip install -r requirements.txt
           # NOTE: some tests are temporarily disabled since the related components don't provide native ARM64 images yet
           python3 -m pytest --configuration ../tests/pipeline-all-amps/repo/target/dtas/dtas-config.json tests/ -s \
             --ignore=tests/scenarios/test_sync.py

--- a/.github/workflows/arm64.yml
+++ b/.github/workflows/arm64.yml
@@ -89,6 +89,7 @@ jobs:
           password: ${{ secrets.QUAY_PASSWORD }}
       - name: "Get latest matching tag"
         run: |
+          mvn help:effective-settings
           VERSION_NUMBER=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout | sed -E 's/([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
           TEST_GIT_TAG=$(git tag --list --sort=-taggerdate "$VERSION_NUMBER*" | head -n 1)
           if [ -z $TEST_GIT_TAG ]; then
@@ -98,7 +99,7 @@ jobs:
       - name: "Prepare test config"
         run: |
           git checkout $TEST_GIT_TAG
-          mvn clean install -B -ntp -DskipTests -f tests/pipeline-all-amps/repo/pom.xml
+          mvn -X clean install -B -ntp -DskipTests -f tests/pipeline-all-amps/repo/pom.xml
           cat tests/pipeline-all-amps/repo/target/dtas/dtas-config.json
       - name: "Set up the environment"
         id: setup-env

--- a/tests/pipeline-all-amps/repo/dtas/dtas-config.json
+++ b/tests/pipeline-all-amps/repo/dtas/dtas-config.json
@@ -3,7 +3,8 @@
         "host": "http://localhost:8080",
         "username": "admin.pipeline@alfresco.com",
         "password": "admin",
-        "request_timeout_seconds": "30"
+        "request_timeout_seconds": "45",
+        "wait_rendition_max_attempts": "15"
     },
     "assertions": {
         "acs": {


### PR DESCRIPTION
Changing the approach we use to do ARM64 tests in ACS Packaging.

### **Before**
We rely on a permanently deployed EC2 runner which is easily subject to degradation over time and incurs in issues which usually result in having to reboot the runner manually or recreate it altogether. Also, this kind of runner doesn't allow parallel builds and must be cleaned thoroughly before/after the execution as it's not disposable.

### **After**
We rely on an on-demand EC2 runner that is created, set-up, used to run the tests and is finally destroyed - on the fly. This also allows parallel runs with multiple runners with no additional effort.

Also, I commented out the `test_adw_reachability` as it was failing, most likely due to the fact that ADW is emulated and therefore very slow => the test is also irrelevant, it should be enabled once again as native ARM64 ADW becomes available.

Also, I tuned some of the timeout parameters for renditions/requests as I noticed one instance of flaky rendition tests, after this change I didn't notice them anymore.

> ℹ️ **NOTE**
> _It is technically possible to shave off ~1 minute from the workflow execution by executing the "Install required software" section once and freezing it in the source AMI. At the moment I don't think it's worth it due to 1. ideally the real end-game solution for this would be https://github.com/github/roadmap/issues/836 2. it would hide all the details that are needed to make the runner work and goes against the spirit of runners being disposable machines not necessarily tailored to our purposes by default._

**Sample run:** https://github.com/Alfresco/acs-packaging/actions/runs/6828040152 ✅ 