### PR TITLE
ACS-6406 new release branch script adjusted to new ACS versioning schema

### DIFF
--- a/scripts/dev/newReleaseBranch.py
+++ b/scripts/dev/newReleaseBranch.py
@@ -170,8 +170,8 @@ def update_ci_yaml(filename, project, rel_version, dev_version):
 
     if text:
         logger.debug("Setting RELEASE_VERSION, DEVELOPMENT_VERSION (%s, %s) in %s ci.yml" % (rel_version, dev_version, project))
-        update_line(text, release_version_match, rel_version)
-        update_line(text, development_version_match, dev_version)
+        update_line(text, release_version_match, rel_version + "-A1")
+        update_line(text, development_version_match, dev_version + "-A1-SNAPSHOT")
         with open(filename, 'w') as file:
             file.writelines(text)
 

--- a/scripts/dev/newReleaseBranch.py
+++ b/scripts/dev/newReleaseBranch.py
@@ -383,7 +383,8 @@ def update_project(project, version, branch_type):
         set_ags_test_versions(project, version)
     elif project == COMMUNITY_PACKAGING:
         update_ci_yaml(YAML_DICT.get(project), project, version, next_dev_ver)
-        update_acs_comm_pck_dependencies(branch_type, project)
+        update_ci_yaml(YAML_DICT.get(project), project, version, next_dev_ver) if branch_type == SERVICE_PACK else update_ci_yaml(
+            YAML_DICT.get(project), project, version + "-A1", next_dev_ver + "-A1-SNAPSHOT")
 
 
 def log_progress(project, message):

--- a/scripts/dev/newReleaseBranch.py
+++ b/scripts/dev/newReleaseBranch.py
@@ -124,6 +124,7 @@ PROJECTS = [ACS_PACKAGING, ENTERPRISE_SHARE, ENTERPRISE_REPO, COMMUNITY_REPO, CO
 # read command line arguments
 parser = argparse.ArgumentParser(description="Create git branches after ACS release.")
 parser.add_argument('-r', '--release', metavar='x.y.z', help='release version (x.y.z format)')
+parser.add_argument('-m', '--master_skip', action='store_true', help='skip prepare master branch')
 parser.add_argument('-n', '--next_dev', metavar='x.y.z', help='next development version (x.y.z format)')
 parser.add_argument('-v', '--verbose', action='store_true', help='print out verbose processing information')
 parser.add_argument('-s', '--skip_push', action='store_true', help='skip git push')
@@ -287,8 +288,8 @@ def update_ci_yaml(filename, project, rel_version, dev_version):
     switch_dir(ci_yaml_path)
     text = read_file(filename)
 
-    release_version_match = "RELEASE_VERSION:"
-    development_version_match = "DEVELOPMENT_VERSION:"
+    release_version_match = "RELEASE_VERSION: "
+    development_version_match = "DEVELOPMENT_VERSION: "
 
     if text:
         logger.debug(f"Setting RELEASE_VERSION, DEVELOPMENT_VERSION ({rel_version}, {dev_version}) in {project} ci.yml")
@@ -612,6 +613,7 @@ if release_version:
         if is_version_bumped(release_version, next_dev_version, 0):
             create_service_pack_branches()
     # need fix as below method will cause issues when this script is run with args.ahead and subsequently without it
-    modify_master_branches()
+    if not args.master_skip:
+        modify_master_branches()
     log_progress("All projects", "Finished creating branches. Exiting.")
     sys.exit(0)

--- a/scripts/dev/newReleaseBranch.py
+++ b/scripts/dev/newReleaseBranch.py
@@ -559,7 +559,7 @@ def commit_all_and_push(project, message):
 def calculate_branch(branch_type, release_version=release_version, use_test_branches=args.test_branches):
     """Calculate the branch name
     >>> calculate_branch("master", release_version="23.2.0")
-    'release/23.2'
+    'master'
     >>> calculate_branch("service_pack", release_version="23.3.0")
     'release/23.N'
     >>> calculate_branch("service_pack", release_version="24.1.0")
@@ -573,6 +573,8 @@ def calculate_branch(branch_type, release_version=release_version, use_test_bran
     >>> calculate_branch("release", release_version="23.2.0", use_test_branches=True)
     'test/release/stabilization/23.2'
     """
+    if branch_type == MASTER:
+        return MASTER
     rel_ver = release_version.split(".")
     if branch_type == SERVICE_PACK:
         rel_ver[1] = "N"

--- a/scripts/dev/newReleaseBranch.py
+++ b/scripts/dev/newReleaseBranch.py
@@ -3,6 +3,8 @@
 # 'pip install gitpython'
 # 'pip install lxml'
 
+#!/usr/bin/env python
+
 import argparse
 import logging
 import os
@@ -70,6 +72,16 @@ logger.debug("Use test branches: %s" % args.test_branches)
 logger.debug("Cleanup test branches: %s" % args.cleanup)
 
 
+class CommentedTreeBuilder(et.TreeBuilder):
+    def __init__(self, *args, **kwargs):
+        super(CommentedTreeBuilder, self).__init__(*args, **kwargs)
+
+    def comment(self, data):
+        self.start(et.Comment, {})
+        self.data(data)
+        self.end(et.Comment)
+
+
 def get_version_number(rel_ver, index):
     return int(rel_ver.split(".")[index])
 
@@ -120,7 +132,7 @@ def update_xml_tag(xml_tree, tag_path, new_value):
 def load_xml(xml_path):
     logger.debug("Loading %s XML file" % xml_path)
     et.register_namespace("", POM_NS)
-    parser = CommentedTreeBuilder()
+    parser = et.XMLParser(target=CommentedTreeBuilder())
     xml_tree = et.parse(xml_path, parser=parser)
     xml_tree.parse(xml_path)
     return xml_tree
@@ -410,12 +422,4 @@ if release_version:
     modify_master_branches()
 
 
-class CommentedTreeBuilder(et.XMLTreeBuilder):
-    def __init__(self, html=0, target=None):
-        et.XMLTreeBuilder.__init__(self, html, target)
-        self._parser.CommentHandler = self.handle_comment
 
-    def handle_comment(self, data):
-        self._target.start(et.Comment, {})
-        self._target.data(data)
-        self._target.end(et.Comment)

--- a/scripts/dev/newReleaseBranch.py
+++ b/scripts/dev/newReleaseBranch.py
@@ -1,44 +1,72 @@
 #######################################
 # This script creates HotFix branches for repo, share and packaging projects, and updates the master branches ready for the next SP/major release.
-# To use this script you need to install lxml:
-# 'pip install lxml'
 # Run the script without passing any arguments or with -h/--help argument to get usage information.
+# When the script is run with indicating that next version is a major bump (-r/--release version major is lowera than -n/--next_dev version major)
+# then HF and SP branches get created. Otherwise (no major version bump), only HF branches are created.
+# Script can also be run ahead of release (-a/--ahead argument) and then it will only create release/X.Y.Z branches
 # See below script behaviour explained.
 #######################################
-# Create a HotFix branches for the released version (for X.Y.Z release it will be X.Y.N eg., create 23.2.N for 23.2.0 release)
+# Create a HotFix branches for the released version (for X.Y.Z release it will be release/X.Y.N eg., create release/23.2.N for 23.2.0 release)
 # 1. acs-packaging:
-# - set RELEASE_VERSION to X.Y.Z+1, DEVELOPMENT_VERSION to X.Y.Z+1-SNAPSHOT in master_release.yml
-# - set POM versions to X.Y.Z+1-SNAPSHOT
+# - set RELEASE_VERSION to X.Y.1, DEVELOPMENT_VERSION to X.Y.2-SNAPSHOT in master_release.yml
+# - set POM versions to X.Y.1-SNAPSHOT
 # - set scm-tag in main POM to HEAD
 # 2. enterprise-share
 # - set scm-tag in main POM to HEAD
-# - set ACS version properties in main POM to X.Y.Z+1
-# - set POM versions to  X.Y.Z+1.1-SNAPSHOT
+# - set ACS version properties in main POM to X.Y.1
+# - set POM versions to  X.Y.1.1-SNAPSHOT
 # 3. enterprise-repo:
-# - set POM versions to  X.Y.Z+1.1-SNAPSHOT
+# - set POM versions to  X.Y.1.1-SNAPSHOT
 # - set scm-tag in main POM to HEAD
 # - set acs.version.label to .1
 # 4. community-share
 # - set scm-tag in main POM to HEAD
-# - set ACS version properties in main POM to X.Y.Z+1
-# - set main POM versions to  X.Y.Z+1.1-SNAPSHOT
+# - set ACS version properties in main POM to X.Y.1
+# - set main POM versions to  X.Y.1.1-SNAPSHOT
 # 5. community-repo:
-# - set ACS version properties in main POM to X.Y.Z+1
-# - set POM versions to  X.Y.Z+1.1-SNAPSHOT
+# - set ACS version properties in main POM to X.Y.1
+# - set POM versions to  X.Y.1.1-SNAPSHOT
 # - set scm-tag in main POM to HEAD
-# - increment schema by 1 in repository.properties?
+# - increment schema by 1 in repository.properties
+# - set version.revision to 1 in version.properties (test resources)
+# 6. acs-community-packaging
+# - not created as we do not release hot fixes for community version
+#######################################
+# Create a HotFix branches for the released version (for X.Y.Z release it will be release/X.Y+1.0 eg., create release/23.3.0 for 23.2.0 release)
+# 1. acs-packaging:
+# - set RELEASE_VERSION to X.Y+1.0-A1, DEVELOPMENT_VERSION to X.Y+1.0-A2-SNAPSHOT in master_release.yml
+# - set POM versions to X.Y+1.0-SNAPSHOT
+# - set scm-tag in main POM to HEAD
+# 2. enterprise-share
+# - set scm-tag in main POM to HEAD
+# - set ACS version properties in main POM to X.Y+1.0
+# - set POM versions to  X.Y+1.0.1-SNAPSHOT
+# 3. enterprise-repo:
+# - set POM versions to  X.Y+1.0.1-SNAPSHOT
+# - set scm-tag in main POM to HEAD
+# - set acs.version.label comment to <!-- X.Y+1.0.<acs.version.label> -->
+# 4. community-share
+# - set scm-tag in main POM to HEAD
+# - set ACS version properties in main POM to X.Y+1.0
+# - set main POM versions to  X.Y+1.0.1-SNAPSHOT
+# 5. community-repo:
+# - set ACS version properties in main POM to X.Y+1.0
+# - set POM versions to  X.Y+1.0.1-SNAPSHOT
+# - set scm-tag in main POM to HEAD
+# - increment schema by 100 in repository.properties
 # - set version.revision to Z+1 in version.properties (test resources)
 # 6. acs-community-packaging
-# - set RELEASE_VERSION to X.Y.Z+1, DEVELOPMENT_VERSION to X.Y.Z+1-SNAPSHOT in ci.yml
-# - set POM versions to X.Y.Z+1-SNAPSHOT?
+# - set RELEASE_VERSION to X.Y+1.0-A1, DEVELOPMENT_VERSION to X.Y+1.0-A2-SNAPSHOT in ci.yml
+# - set POM versions to X.Y+1.0-SNAPSHOT
 # - set scm-tag in main POM to HEAD
-# - set comm-repo dependency in main POM to X.Y.Z+1.1
-# - set comm-share dependency in main POM to X.Y.Z+1.1
+# - set comm-repo dependency in main POM to X.Y+1.0.1
+# - set comm-share dependency in main POM to X.Y+1.0.1
 #######################################
 # Update master branch for the next SP/major release
 # 1. acs-packaging:
-# - set RELEASE_VERSION to <next_development_version> passed as script argument or X.Y+1.0-A1 (if <next_development_version> not passed), DEVELOPMENT_VERSION to <next_development_version>-SNAPSHOT or X.Y+1.0-A1-SNAPSHOT (if <next_development_version> not passed) in master_release.yml
-# - set POM versions to <next_development_version>-SNAPSHOT or X.Y+1.0-A1-SNAPSHOT (if <next_development_version> not passed)
+# - set RELEASE_VERSION to <next_development_version>-A1 passed as script argument or X.Y+1.0-A1 (if <next_development_version> not passed),
+#   DEVELOPMENT_VERSION to <next_development_version>-A2-SNAPSHOT or X.Y+1.0-A2-SNAPSHOT (if <next_development_version> not passed) in master_release.yml
+# - set POM versions to <next_development_version>-SNAPSHOT or X.Y+1.0-SNAPSHOT (if <next_development_version> not passed)
 # - set scm-tag in main POM to HEAD
 # 2. enterprise-share
 # - set scm-tag in main POM to HEAD
@@ -59,7 +87,8 @@
 # - increment schema by 100 (when next development minor version bumped) or 1000 (when next development version major bumped) in repository.properties
 # - set version.major/version.minor/version.revision to <next_development_version> or X.Y+1.0 (if <next_development_version> not passed) in version.properties (test resources)
 # 6. acs-community-packaging
-# - set RELEASE_VERSION to <next_development_version> passed as script argument or X.Y+1.0-A1 (if <next_development_version> not passed), DEVELOPMENT_VERSION to <next_development_version>-SNAPSHOT or X.Y+1.0-A1-SNAPSHOT (if <next_development_version> not passed) in master_release.yml
+# - set RELEASE_VERSION to <next_development_version>-A1 passed as script argument or X.Y+1.0-A1 (if <next_development_version> not passed),
+#   DEVELOPMENT_VERSION to <next_development_version>-A2-SNAPSHOT or X.Y+1.0-A2-SNAPSHOT (if <next_development_version> not passed) in master_release.yml
 # - set scm-tag in main POM to HEAD
 # - set comm-repo dependency in main POM to <next_development_version>.1 or X.Y+1.0.1 (if <next_development_version> not passed)
 # - set comm-share dependency in main POM to <next_development_version>.1 or X.Y+1.0.1 (if <next_development_version> not passed)
@@ -77,6 +106,7 @@ from xml.etree import ElementTree as et
 
 MASTER = 'master'
 HOTFIX = 'hotfix'
+SERVICE_PACK = 'service_pack'
 
 POM_NS = 'http://maven.apache.org/POM/4.0.0'
 COMMUNITY_PACKAGING = 'acs-community-packaging'
@@ -111,8 +141,7 @@ root_abspath = script_abspath[:root_dir_path_end]
 args = parser.parse_args()
 
 release_version = args.release if args.release else input("Enter released version (mandatory, use x.y or x.y.z format): ")
-next_dev_version = args.next_dev if args.next_dev else input(
-    "Enter next development version (optional, use x.y or x.y.z format or leave empty): ")
+next_dev_version = args.next_dev if args.next_dev else input("Enter next development version (optional, use x.y or x.y.z format or leave empty): ")
 
 # setup logging
 logger = logging.getLogger('CONSOLE')
@@ -159,9 +188,12 @@ def increment_version(rel_ver, branch_type):
     if branch_type == HOTFIX:
         incremented = get_version_number(rel_ver, 2) + 1
         versions[2] = str(incremented)
-
-    is_major_bumped = is_version_bumped(rel_ver, next_dev_version, 0)
+    if branch_type == SERVICE_PACK:
+        incremented = get_version_number(rel_ver, 1) + 1
+        versions[1] = str(incremented)
+        versions[2] = "0"
     if branch_type == MASTER:
+        is_major_bumped = is_version_bumped(rel_ver, next_dev_version, 0)
         incremented = get_version_number(rel_ver, 1) + 1
         versions[1] = str(incremented) if not is_major_bumped else next_dev_version.split(".")[1]
         versions[2] = "0" if not is_major_bumped else next_dev_version.split(".")[2]
@@ -171,13 +203,13 @@ def increment_version(rel_ver, branch_type):
     if len(versions) == 4:
         versions.pop()
         versions.append("1")
-    logger.debug("Incremented to %s" % incremented)
-    incremented = ".".join(versions)
-    return incremented
+    incremented_ver = ".".join(versions)
+    logger.debug("Incremented to %s" % incremented_ver)
+    return incremented_ver
 
 
 def get_next_dev_version(type):
-    if next_dev_version and not type == HOTFIX:
+    if next_dev_version and type == MASTER:
         logger.debug("Getting next dev version from input parameter (%s)" % next_dev_version)
         return next_dev_version
     else:
@@ -292,14 +324,14 @@ def increment_schema(project, increment):
 
 def update_acs_comm_pck_dependencies(branch_type, project):
     logger.debug("Updating comm-repo and comm-share dependencies in %s" % project)
-    comm_repo_next_ver = increment_version(calculate_hotfix_version(COMMUNITY_REPO), branch_type)
+    comm_repo_next_ver = increment_version(calculate_version(COMMUNITY_REPO), branch_type)
     logger.debug("comm-repo dependency: %s" % comm_repo_next_ver)
     switch_dir(project)
     pom_path = "pom.xml"
     text = read_file(pom_path)
     update_xml_tag(text, "<dependency.alfresco-community-repo.version>", comm_repo_next_ver)
-    update_xml_tag(text, "<version>", comm_repo_next_ver)
-    comm_share_next_ver = increment_version(calculate_hotfix_version(ENTERPRISE_SHARE), branch_type)
+    update_xml_tag(text, "<version>\d", comm_repo_next_ver)
+    comm_share_next_ver = increment_version(calculate_version(ENTERPRISE_SHARE), branch_type)
     logger.debug("comm-share dependency: %s" % comm_share_next_ver)
     switch_dir(project)
     update_xml_tag(text, "<dependency.alfresco-community-share.version>", comm_share_next_ver)
@@ -342,11 +374,17 @@ def update_ent_repo_acs_label(project, version, branch_type):
     switch_dir(project)
     filename = "pom.xml"
     text = read_file(filename)
+    versions = version.split(".")
+    if len(versions) == 4:
+        versions.pop()
+    ver = ".".join(versions)
 
     if branch_type == HOTFIX:
+        logger.debug("Setting acs.version.label to .1 in %s" % project)
         update_line(text, "<acs.version.label", ">.1</acs.version.label>")
     else:
-        update_line(text, "<acs.version.label", "/> <!-- %s.<acs.version.label> -->" % version)
+        logger.debug("Setting acs.version.label comment to %s in %s" % (ver, project))
+        update_line(text, "<acs.version.label", "/> <!-- %s.<acs.version.label> -->" % ver)
 
     save_file(filename, text)
     switch_dir('root')
@@ -418,14 +456,16 @@ def calculate_branch(type):
     rel_ver = release_version.split(".")
     if type == HOTFIX:
         rel_ver[2] = "N"
+    if type == SERVICE_PACK:
+        rel_ver[1] = int(rel_ver[1]) + 1
     prefix = "test/release/" if args.test_branches else "release/"
-    hotfix_branch = prefix + ".".join(rel_ver)
-    logger.debug("Calculated %s branch as %s " % (type, hotfix_branch))
-    return hotfix_branch
+    branch = prefix + ".".join(rel_ver) if type == HOTFIX else prefix + increment_version(release_version, type)
+    logger.debug("Calculated %s branch as %s " % (type, branch))
+    return branch
 
 
-def calculate_hotfix_version(project):
-    logger.debug("Calculating hotfix versions for %s " % project)
+def calculate_version(project):
+    logger.debug("Calculating tag version for %s " % project)
     checkout_branch(ACS_PACKAGING, MASTER if args.ahead else release_version)
     switch_dir(ACS_PACKAGING)
     ent_repo_ver = get_xml_tag_value("pom.xml",
@@ -434,13 +474,13 @@ def calculate_hotfix_version(project):
                                       "{%s}properties/{%s}dependency.alfresco-enterprise-share.version" % (POM_NS, POM_NS))
     switch_dir('root')
     if project == ACS_PACKAGING or project == COMMUNITY_PACKAGING:
-        logger.debug("Hotfix versions for %s is %s" % (project, release_version))
+        logger.debug("Tag version for %s is %s" % (project, release_version))
         return release_version
     elif project == ENTERPRISE_REPO:
-        logger.debug("Hotfix versions for %s is %s" % (project, ent_repo_ver))
+        logger.debug("Tag version for %s is %s" % (project, ent_repo_ver))
         return ent_repo_ver
     elif project == ENTERPRISE_SHARE:
-        logger.debug("Hotfix versions for %s is %s" % (project, ent_share_ver))
+        logger.debug("Tag version for %s is %s" % (project, ent_share_ver))
         return ent_share_ver
     elif project == COMMUNITY_REPO:
         checkout_branch(ENTERPRISE_REPO, ent_repo_ver)
@@ -448,7 +488,7 @@ def calculate_hotfix_version(project):
         comm_repo_ver = get_xml_tag_value("pom.xml",
                                           "{%s}properties/{%s}dependency.alfresco-community-repo.version" % (POM_NS, POM_NS))
         switch_dir('root')
-        logger.debug("Hotfix versions for %s is %s" % (project, comm_repo_ver))
+        logger.debug("Tag version for %s is %s" % (project, comm_repo_ver))
         return comm_repo_ver
 
 
@@ -458,8 +498,8 @@ def update_project(project, version, branch_type):
     update_scm_tag('HEAD', project)
     next_dev_ver = get_next_dev_version(branch_type)
     if project == ACS_PACKAGING:
-        update_ci_yaml(YAML_DICT.get(project), project, version + "-A1", next_dev_ver + "-A1-SNAPSHOT") if branch_type == MASTER else (
-            update_ci_yaml(YAML_DICT.get(project), project, version, next_dev_ver + "-SNAPSHOT"))
+        update_ci_yaml(YAML_DICT.get(project), project, version + "-A1", next_dev_ver + "-A2-SNAPSHOT") if branch_type is not HOTFIX else (
+            update_ci_yaml(YAML_DICT.get(project), project, version, increment_version(next_dev_ver, HOTFIX) + "-SNAPSHOT"))
     elif project == ENTERPRISE_SHARE:
         update_acs_ver_pom_properties(project, version)
     elif project == ENTERPRISE_REPO:
@@ -469,8 +509,8 @@ def update_project(project, version, branch_type):
         increment_schema(project, calculate_increment(release_version, next_dev_ver))
         set_ags_test_versions(project, version)
     elif project == COMMUNITY_PACKAGING:
-        update_ci_yaml(YAML_DICT.get(project), project, version + "-A1", next_dev_ver + "-A1-SNAPSHOT") if branch_type == MASTER else (
-            update_ci_yaml(YAML_DICT.get(project), project, version, next_dev_ver + "-SNAPSHOT"))
+        update_ci_yaml(YAML_DICT.get(project), project, version + "-A1", next_dev_ver + "-A2-SNAPSHOT") if branch_type is not HOTFIX else (
+            update_ci_yaml(YAML_DICT.get(project), project, version, increment_version(next_dev_ver, HOTFIX) + "-SNAPSHOT"))
         update_acs_comm_pck_dependencies(branch_type, project)
 
 
@@ -487,12 +527,25 @@ def create_hotfix_branches():
     hotfix_branch = calculate_branch(HOTFIX)
     for i in range(len(PROJECTS)):
         project = PROJECTS[i]
-        log_progress(project, "Creating hotfix branches")
-        rel_tag_version = release_version if args.ahead else calculate_hotfix_version(project)
-        create_branch(project, hotfix_branch, rel_tag_version)
-        version = increment_version(rel_tag_version, HOTFIX)
-        update_project(project, version, HOTFIX)
-        commit_and_push(project, "Creating hotfix branch %s for %s ACS release [skip ci]" % (hotfix_branch, release_version))
+        if project is not COMMUNITY_PACKAGING:
+            log_progress(project, "Creating hotfix branches")
+            rel_tag_version = calculate_version(project)
+            create_branch(project, hotfix_branch, rel_tag_version)
+            version = increment_version(rel_tag_version, HOTFIX)
+            update_project(project, version, HOTFIX)
+            commit_and_push(project, "Creating hotfix branch %s for %s ACS release [skip ci]" % (hotfix_branch, release_version))
+
+
+def create_service_pack_branches():
+    sp_branch = calculate_branch(SERVICE_PACK)
+    for i in range(len(PROJECTS)):
+        project = PROJECTS[i]
+        log_progress(project, "Creating service pack branches")
+        rel_tag_version = calculate_version(project)
+        create_branch(project, sp_branch, rel_tag_version)
+        version = increment_version(rel_tag_version, SERVICE_PACK)
+        update_project(project, version, SERVICE_PACK)
+        commit_and_push(project, "Creating service pack branch %s after %s ACS release [skip ci]" % (sp_branch, release_version))
 
 
 def modify_master_branches():
@@ -543,7 +596,9 @@ if release_version:
         create_release_branches()
     else:
         create_hotfix_branches()
-    # needs a small rework as below method will cause issues when this script is run with args.ahead and subsequently without it
+        if is_version_bumped(release_version, next_dev_version, 0):
+            create_service_pack_branches()
+    # need fix as below method will cause issues when this script is run with args.ahead and subsequently without it
     modify_master_branches()
     log_progress("All projects", "Finished creating branches. Exiting.")
     sys.exit(0)

--- a/scripts/dev/newReleaseBranch.py
+++ b/scripts/dev/newReleaseBranch.py
@@ -1,0 +1,283 @@
+# This script creates HotFix branches for repo, share and packaging projects, and updates the master branches ready for the next SP/major release.
+# To use this script you need to install gitpython and lxml:
+# 'pip install gitpython'
+# 'pip install lxml'
+
+import argparse
+import sys
+import os
+import logging
+from xml.etree import ElementTree as et
+import re
+import subprocess
+
+POM_NS = "http://maven.apache.org/POM/4.0.0"
+PROJECTS = ["acs-packaging", "enterprise-share", "enterprise-repo", "community-repo", "acs-community-packaging"]
+YAML_DICT = {"acs-packaging": "master_release.yml", "acs-community-packaging": "ci.yml"}
+
+# read command line arguments
+parser = argparse.ArgumentParser(description='Create git branches after ACS release.')
+parser.add_argument('-r', '--release', metavar='x.y.z', help='release version (x.y.z format)')
+parser.add_argument('-n', '--next_dev', metavar='x.y.z', help='next development version (x.y.z format)')
+parser.add_argument('-v', '--verbose', action='store_true', help='Print out verbose processing information')
+parser.add_argument('-s', '--skip_push', action='store_true', help='skip git push')
+parser.add_argument('-t', '--test_branches', action='store_true', help='use test branches')
+parser.add_argument('-c', '--cleanup', action='store_true', help='cleanup test branches')
+
+if len(sys.argv) == 1:
+    parser.print_help()
+    parser.exit()
+
+# set global variables
+script_path = os.path.dirname(sys.argv[0])
+script_abspath = os.path.abspath(script_path)
+root_dir_path_end = script_abspath.find("acs-packaging")
+root_abspath = script_abspath[:root_dir_path_end]
+
+args = parser.parse_args()
+
+release_version = args.release if args.release else input("Enter released version (mandatory, use x.y or x.y.z format): ")
+next_dev_version = args.next_dev if args.next_dev else input(
+    "Enter next development version (optional, use x.y or x.y.z format or leave empty): ")
+
+# setup logging
+logger = logging.getLogger("CONSOLE")
+console_handler = logging.StreamHandler()
+if args.verbose:
+    logger.setLevel(logging.DEBUG)
+    console_handler.setLevel(logging.DEBUG)
+else:
+    logger.setLevel(logging.INFO)
+    console_handler.setLevel(logging.INFO)
+formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+console_handler.setFormatter(formatter)
+logger.addHandler(console_handler)
+
+logger.debug("Released version: %s" % release_version)
+logger.debug("Next development version: %s" % next_dev_version)
+logger.debug("Skip push: %s" % args.skip_push)
+logger.debug("Use test branches: %s" % args.test_branches)
+logger.debug("Cleanup test branches: %s" % args.cleanup)
+
+
+def get_version_number(rel_ver, index):
+    return int(rel_ver.split(".")[index])
+
+
+def increment_version(rel_ver, branch_type):
+    if branch_type == "hotfix":
+        incremented = get_version_number(rel_ver, 2) + 1
+        versions = rel_ver.split(".")
+        versions[2] = string(incremented)
+        return ".".join(versions)
+    if branch_type == "servicepack":
+        incremented = get_version_number(rel_ver, 1) + 1
+        versions = rel_ver.split(".")
+        versions[1] = string(incremented)
+        versions[2] = "0"
+        return ".".join(versions)
+
+
+def get_next_dev_version(type):
+    if next_dev_version is None:
+        return increment_version(release_version, type)
+    else:
+        return next_dev_version
+
+
+def switch_dir(project):
+    logger.debug("Current dir: %s" % os.getcwd())
+    os.chdir(os.path.dirname(root_abspath))
+    if project != "root":
+        os.chdir(project)
+    logger.debug("Switched dir to: %s" % os.getcwd())
+
+
+def get_xml_tag_value(xml_path, tag_path):
+    xml_tree = load_xml(xml_path)
+    return xml_tree.getroot().find(tag_path).text
+
+
+def update_xml_tag(xml_tree, tag_path, new_value):
+    xml_tag = xml_tree.getroot().find(tag_path)
+    xml_tag.text = new_value
+    return xml_tree
+
+
+def load_xml(xml_path):
+    logger.debug("Loading %s XML file" % xml_path)
+    et.register_namespace("", POM_NS)
+    xml_tree = et.ElementTree()
+    xml_tree.parse(xml_path)
+    return xml_tree
+
+
+def update_acs_ver_pom_properties(version, project):
+    if project == "alfresco-community-repo":
+        prefix = "acs."
+    switch_dir(project)
+    pom_path = "pom.xml"
+    pom_tree = load_xml(pom_path)
+    split_version = version.split(".")
+    logger.debug("Setting ACS versions (%s) in %s pom.xml" % (split_version, project))
+    update_xml_tag(pom_tree, "{%s}properties/{%s}%sversion.major" % (POM_NS, POM_NS, prefix), split_version[0])
+    update_xml_tag(pom_tree, "{%s}properties/{%s}%sversion.minor" % (POM_NS, POM_NS, prefix), split_version[1])
+    update_xml_tag(pom_tree, "{%s}properties/{%s}%sversion.revision" % (POM_NS, POM_NS, prefix), split_version[2])
+    pom_tree.write(pom_path)
+    switch_dir("root")
+
+
+def update_scm_tag(tag, project):
+    switch_dir(project)
+    pom_path = "pom.xml"
+    pom_tree = load_xml(pom_path)
+    logger.debug("Setting scm tag to %s in %s pom.xml" % (tag, project))
+    update_xml_tag(pom_tree, "{%s}scm/{%s}tag" % (POM_NS, POM_NS), tag)
+    pom_tree.write(pom_path)
+    switch_dir("root")
+
+
+def update_ci_yaml(filename, project, release_version, next_dev_version):
+    ci_yaml_path = os.path.join(project, ".github", "workflows")
+    switch_dir(ci_yaml_path)
+    rel_regex = re.compile("RELEASE_VERSION:.*", re.IGNORECASE)
+    dev_regex = re.compile("DEVELOPMENT_VERSION:.*", re.IGNORECASE)
+    with open(filename, "r") as file:
+        text = file.readlines()
+
+    for i in range(len(text)):
+        if "RELEASE_VERSION:" in text[i]:
+            rel_line = i
+        if "DEVELOPMENT_VERSION:" in text[i]:
+            dev_line = i
+
+    logger.debug("Setting RELEASE_VERSION, DEVELOPMENT_VERSION (%s, %s) in %s ci.yml" % (release_version, next_dev_version, project))
+    text[rel_line] = rel_regex.sub("RELEASE_VERSION: %s" % release_version, text[rel_line])
+    text[dev_line] = dev_regex.sub("DEVELOPMENT_VERSION: %s" % next_dev_version, text[dev_line])
+
+    with open(filename, "w") as file:
+        file.writelines(text)
+
+    switch_dir("root")
+
+
+def increment_schema(increment):
+    project = "alfresco-community-repo"
+    properties_path = os.path.join(project, "repository", "src", "main", "resources", "alfresco")
+    filename = "repository.properties"
+    switch_dir(properties_path)
+    key = "version.schema="
+    regex = re.compile(key + ".*", re.IGNORECASE)
+    with open(filename, "r") as file:
+        text = file.readlines()
+
+    for i in range(len(text)):
+        if key in text[i]:
+            line_no = i
+
+    schema = text[line_no].split("=")[1]
+    new_schema = int(schema) + increment
+
+    logger.debug("Updating property version.schema from %s to %s in %s" % (schema, new_schema, project))
+    text[line_no] = regex.sub(key + str(new_schema), text[line_no])
+
+    with open(filename, "w") as file:
+        file.writelines(text)
+
+    switch_dir("root")
+
+
+def exec_cmd(cmd_args):
+    logger.debug("Executing command line of %s" % " ".join(cmd_args))
+    subprocess.run(cmd_args, shell=True) if logging.DEBUG == logger.level else subprocess.run(cmd_args, shell=True,
+                                                                                              stdout=subprocess.DEVNULL)
+
+
+def set_versions(project, version, profiles: list[str]):
+    switch_dir(project)
+    arguments = ["mvn", "versions:set", "-DgenerateBackupPoms=false", "-DnewVersion=%s" % version, "-P%s" % ",".join(profiles)]
+    logger.debug("Updating versions to %s in pom of %s" % (version, project))
+
+    exec_cmd(arguments)
+    switch_dir("root")
+
+
+def checkout_branch(project, branch):
+    switch_dir(project)
+    logger.debug("Checking out %s branch in %s" % (branch, project))
+    exec_cmd(["git", "fetch"])
+    exec_cmd(["git", "checkout", branch])
+    switch_dir("root")
+
+
+def create_branch(project, branch, tag):
+    switch_dir(project)
+    logger.debug("Creating %s branch in %s from %s tag" % (branch, project, tag))
+    checkout_branch(project, tag)
+    exec_cmd(["git", "switch", "-c", branch])
+    switch_dir("root")
+
+
+def commit_and_push(project, message):
+    logger.debug("Committing changes in %s. Commit message: %s" % (project, message))
+    switch_dir(project)
+    exec_cmd(["git", "commit", "--all", "-m", message])
+    if args.skip_push:
+        logger.debug("Pushing changes in %s to remote." % project)
+        exec_cmd(["git", "push"])
+    switch_dir("root")
+
+def calculate_hotfix_branch():
+    rel_ver = release_version.split(".")
+    rel_ver[2] = "N"
+    prefix = "test/release/" if args.test_branches else "release/"
+    return prefix + ".".join(rel_ver)
+
+def calculate_hotfix_version(project):
+    match project:
+        case "acs-packaging" | "acs-community-packaging":
+            return release_version
+        case "alfresco-enterprise-repo":
+            switch_dir("acs-packaging")
+            ent_repo_ver = get_xml_tag_value("pom.xml", "{%s}properties/{%s}dependency.alfresco-enterprise-repo.version" % (POM_NS, POM_NS))
+            switch_dir("root")
+            return ent_repo_ver
+        case "alfresco-enterprise-share":
+            switch_dir("acs-packaging")
+            ent_share_ver = get_xml_tag_value("pom.xml", "{%s}properties/{%s}dependency.alfresco-enterprise-share.version" % (POM_NS, POM_NS))
+            switch_dir("root")
+            return ent_share_ver
+        case "alfresco-community-repo":
+            switch_dir("alfresco-enterprise-repo")
+            comm_repo_ver = get_xml_tag_value("pom.xml", "{%s}properties/{%s}dependency.alfresco-community-repo.version" % (POM_NS, POM_NS))
+            switch_dir("root")
+            return comm_repo_ver
+
+
+def update_project(project, version, branch_type):
+    set_versions(project, version, ["dev"])
+    update_scm_tag("HEAD", project)
+    if project.endswith("packaging"):
+        update_ci_yaml(YAML_DICT.get(project), project, version, get_next_dev_version(branch_type))
+    if project == "alfresco-community-repo":
+        update_acs_ver_pom_properties(version, project)
+        increment_schema(1)
+    if project == "alfresco-enterprise-share":
+        update_acs_ver_pom_properties(version, project)
+    if project == "alfresco-enterprise-repo":
+        switch_dir(project)
+        xml_tree = load_xml("pom.xml")
+        update_xml_tag(xml_tree, "{%s}properties/{%s}acs.version.label" % (POM_NS, POM_NS), ".1")
+
+def create_hotfix_branches():
+    hotfix_branch = calculate_hotfix_branch()
+    branch_type = "hotfix"
+    for i in range(len(PROJECTS)):
+        project = PROJECTS[i]
+        tag_version = calculate_hotfix_version(project)
+        create_branch(project, hotfix_branch, tag_version)
+        version = increment_version(tag_version, branch_type) + "-SNAPSHOT"
+        update_project(project, version, branch_type)
+
+
+create_hotfix_branches()

--- a/scripts/dev/newReleaseBranch.py
+++ b/scripts/dev/newReleaseBranch.py
@@ -284,8 +284,9 @@ def set_versions(project, version, profiles: list[str]):
         snapshot_ver = version + "-SNAPSHOT"
     else:
         ver = version.split(".")
-        ver[3] = "1"
-        snapshot_ver = ".".join(ver) + "-SNAPSHOT"
+        if len(ver) == 4:
+            ver.pop()
+        snapshot_ver = ".".join(ver) + ".1-SNAPSHOT"
 
     arguments = ["mvn", "versions:set", "-DgenerateBackupPoms=false", "-DnewVersion=%s" % snapshot_ver, "-P%s" % ",".join(profiles)]
     logger.debug("Updating versions to %s in pom of %s" % (snapshot_ver, project))
@@ -354,7 +355,7 @@ def calculate_hotfix_version(project):
 
 def update_project(project, version, branch_type):
     profiles = ["dev"] if "packaging" in project else ["ags"]
-    set_versions(project, version + "-SNAPSHOT", profiles)
+    set_versions(project, version, profiles)
     update_scm_tag('HEAD', project)
     next_dev_ver = get_next_dev_version(branch_type)
     if project == ACS_PACKAGING:

--- a/scripts/dev/newReleaseBranch.py
+++ b/scripts/dev/newReleaseBranch.py
@@ -120,7 +120,8 @@ def update_xml_tag(xml_tree, tag_path, new_value):
 def load_xml(xml_path):
     logger.debug("Loading %s XML file" % xml_path)
     et.register_namespace("", POM_NS)
-    xml_tree = et.ElementTree()
+    parser = et.XMLParser(target=et.TreeBuilder(insert_comments=True))
+    xml_tree = et.parse(xml_path, parser=parser)
     xml_tree.parse(xml_path)
     return xml_tree
 
@@ -135,7 +136,7 @@ def update_acs_ver_pom_properties(project, version):
     update_xml_tag(pom_tree, "{%s}properties/{%s}%sversion.major" % (POM_NS, POM_NS, prefix), split_version[0])
     update_xml_tag(pom_tree, "{%s}properties/{%s}%sversion.minor" % (POM_NS, POM_NS, prefix), split_version[1])
     update_xml_tag(pom_tree, "{%s}properties/{%s}%sversion.revision" % (POM_NS, POM_NS, prefix), split_version[2])
-    pom_tree.write(pom_path)
+    pom_tree.write(pom_path, encoding='utf-8', xml_declaration=True)
     switch_dir("root")
 
 
@@ -145,7 +146,7 @@ def update_scm_tag(tag, project):
     pom_tree = load_xml(pom_path)
     logger.debug("Setting scm tag to %s in %s pom.xml" % (tag, project))
     update_xml_tag(pom_tree, "{%s}scm/{%s}tag" % (POM_NS, POM_NS), tag)
-    pom_tree.write(pom_path)
+    pom_tree.write(pom_path, encoding='utf-8', xml_declaration=True)
     switch_dir('root')
 
 

--- a/scripts/dev/newReleaseBranch.py
+++ b/scripts/dev/newReleaseBranch.py
@@ -273,7 +273,7 @@ def exec_cmd(cmd_args):
         ret = subprocess.run(cmd_args, shell=True) if args.trace else subprocess.run(cmd_args, shell=True, stdout=subprocess.DEVNULL)
         ret.check_returncode()
     except subprocess.CalledProcessError as e:
-        logger.ERROR("Error:\nreturn code: %s\nOutput: %s" % (e.returncode, e.stderr.decode("utf-8")))
+        logger.error("Error:\nreturn code: %s\nOutput: %s" % (e.returncode, e.stderr.decode("utf-8")))
         raise
 
 

--- a/scripts/dev/newReleaseBranch.py
+++ b/scripts/dev/newReleaseBranch.py
@@ -32,6 +32,7 @@ parser.add_argument('-s', '--skip_push', action='store_true', help='skip git pus
 parser.add_argument('-t', '--test_branches', action='store_true', help='use test branches')
 parser.add_argument('-c', '--cleanup', action='store_true', help='cleanup test branches')
 parser.add_argument('-a', '--ahead', action='store_true', help='create branches ahead of release')
+parser.add_argument('-z', '--trace', action='store_true', help='trace command line')
 
 if len(sys.argv) == 1:
     parser.print_help()
@@ -268,8 +269,7 @@ def update_ent_repo_acs_label(project, version, branch_type):
 
 def exec_cmd(cmd_args):
     logger.debug("Executing command line of %s" % " ".join(cmd_args))
-    subprocess.run(cmd_args, shell=True) if logging.DEBUG == logger.level else subprocess.run(cmd_args, shell=True,
-                                                                                              stdout=subprocess.DEVNULL)
+    subprocess.run(cmd_args, shell=True) if args.trace else subprocess.run(cmd_args, shell=True, stdout=subprocess.DEVNULL)
 
 
 def set_versions(project, version, profiles: list[str]):

--- a/scripts/dev/newReleaseBranch.py
+++ b/scripts/dev/newReleaseBranch.py
@@ -269,7 +269,13 @@ def update_ent_repo_acs_label(project, version, branch_type):
 
 def exec_cmd(cmd_args):
     logger.debug("Executing command line of %s" % " ".join(cmd_args))
-    subprocess.run(cmd_args, shell=True) if args.trace else subprocess.run(cmd_args, shell=True, stdout=subprocess.DEVNULL)
+    try:
+        ret = subprocess.run(cmd_args, shell=True) if args.trace else subprocess.run(cmd_args, shell=True, stdout=subprocess.DEVNULL)
+        ret.check_returncode()
+    except subprocess.CalledProcessError as e:
+        logger.ERROR("Error:\nreturn code: %s\nOutput: %s" % (e.returncode, e.stderr.decode("utf-8")))
+        raise
+
 
 
 def set_versions(project, version, profiles: list[str]):

--- a/scripts/dev/newReleaseBranch.py
+++ b/scripts/dev/newReleaseBranch.py
@@ -5,7 +5,7 @@
 # then HF and SP branches get created. Otherwise (no major version bump), only HF branches are created.
 # See below script behaviour explained.
 #######################################
-# Create a HotFix branches for the released version (for X.Y.Z release it will be release/X.Y.N eg., create release/23.2.N for 23.2.0 release)
+# Create HotFix branches for the released version (for X.Y.Z release it will be release/X.Y.N eg., create release/23.2.N for 23.2.0 release)
 # 1. acs-packaging:
 # - set RELEASE_VERSION to X.Y.1, DEVELOPMENT_VERSION to X.Y.2-SNAPSHOT in master_release.yml
 # - set POM versions to X.Y.1-SNAPSHOT
@@ -31,7 +31,7 @@
 # 6. acs-community-packaging
 # - not created as we do not release hot fixes for community version
 #######################################
-# Create a HotFix branches for the released version (for X.Y.Z release it will be release/X.Y+1.0 eg., create release/23.3.0 for 23.2.0 release)
+# Create ServicePack branches for the released version (for X.Y.Z release it will be release/X.Y+1 eg., create release/23.3 for 23.2.0 release)
 # 1. acs-packaging:
 # - set RELEASE_VERSION to X.Y+1.0-A1, DEVELOPMENT_VERSION to X.Y+1.0-A2-SNAPSHOT in master_release.yml
 # - set POM versions to X.Y+1.0-SNAPSHOT
@@ -460,7 +460,7 @@ def calculate_branch(type):
     if type == HOTFIX:
         rel_ver[2] = "N"
     elif type == SERVICE_PACK:
-        rel_ver[1] = int(rel_ver[1]) + 1
+        rel_ver[1] = str(int(rel_ver[1]) + 1)
         rel_ver.pop(2)
     else:
         rel_ver.pop(2)

--- a/scripts/dev/newReleaseBranch.py
+++ b/scripts/dev/newReleaseBranch.py
@@ -21,16 +21,12 @@
 # - set POM versions to  X.Y.1.1-SNAPSHOT
 # - set scm-tag in main POM to HEAD
 # - set acs.version.label to .1
-# 4. community-share
-# - set scm-tag in main POM to HEAD
-# - set ACS version properties in main POM to X.Y.1
-# - set main POM versions to  X.Y.1.1-SNAPSHOT
-# 5. community-repo:
+# 4. community-repo:
 # - set ACS version properties in main POM to X.Y.1
 # - set POM versions to  X.Y.1.1-SNAPSHOT
 # - set scm-tag in main POM to HEAD
 # - set version.revision to 1 in version.properties (test resources)
-# 6. acs-community-packaging
+# 5. acs-community-packaging
 # - not created as we do not release hot fixes for community version
 #######################################
 # Create ServicePack branches for the released version (for X.Y.Z release it will be release/X.N eg., create release/23.N for 23.3.0 release)
@@ -46,17 +42,13 @@
 # - set POM versions to  X.Y+1.0.1-SNAPSHOT
 # - set scm-tag in main POM to HEAD
 # - set acs.version.label comment to <!-- X.Y+1.0.<acs.version.label> -->
-# 4. community-share
-# - set scm-tag in main POM to HEAD
-# - set ACS version properties in main POM to X.Y+1.0
-# - set main POM versions to  X.Y+1.0.1-SNAPSHOT
-# 5. community-repo:
+# 4. community-repo:
 # - set ACS version properties in main POM to X.Y+1.0
 # - set POM versions to  X.Y+1.0.1-SNAPSHOT
 # - set scm-tag in main POM to HEAD
 # - increment schema by 100 in repository.properties
 # - set version.revision to Z+1 in version.properties (test resources)
-# 6. acs-community-packaging
+# 5. acs-community-packaging
 # - set RELEASE_VERSION to X.Y+1.0-A1, DEVELOPMENT_VERSION to X.Y+1.0-A2-SNAPSHOT in ci.yml
 # - set POM versions to X.Y+1.0-A1-SNAPSHOT
 # - set scm-tag in main POM to HEAD
@@ -77,17 +69,13 @@
 # - set POM versions to <next_development_version>.1-SNAPSHOT or X.Y+1.0.1-SNAPSHOT (if <next_development_version> not passed)
 # - set scm-tag in main POM to HEAD
 # - set acs.version.label comment to <!-- X.Y+1.0.<acs.version.label> -->
-# 4. community-share
-# - set scm-tag in main POM to HEAD
-# - set ACS version properties in main POM to <next_development_version> or X.Y+1.0 (if <next_development_version> not passed)
-# - set POM versions to <next_development_version>.1-SNAPSHOT or X.Y+1.0.1-SNAPSHOT (if <next_development_version> not passed)
-# 5. community-repo:
+# 4. community-repo:
 # - set ACS version properties in main POM to <next_development_version> or X.Y+1.0 (if <next_development_version> not passed)
 # - set POM versions to <next_development_version>.1-SNAPSHOT or X.Y+1.0.1-SNAPSHOT (if <next_development_version> not passed)
 # - set scm-tag in main POM to HEAD
 # - increment schema by 100 (when next development minor version bumped) or 1000 (when next development version major bumped) in repository.properties
 # - set version.major/version.minor/version.revision to <next_development_version> or X.Y+1.0 (if <next_development_version> not passed) in version.properties (test resources)
-# 6. acs-community-packaging
+# 5. acs-community-packaging
 # - set RELEASE_VERSION to <next_development_version>-A1 passed as script argument or X.Y+1.0-A1 (if <next_development_version> not passed),
 #   DEVELOPMENT_VERSION to <next_development_version>-A2-SNAPSHOT or X.Y+1.0-A2-SNAPSHOT (if <next_development_version> not passed) in master_release.yml
 # - set POM versions to <next_development_version>-A1-SNAPSHOT or X.Y+1.0-A1-SNAPSHOT (if <next_development_version> not passed)
@@ -483,7 +471,7 @@ def update_ent_repo_acs_label(project, version, branch_type):
         update_line(text, "<acs.version.label", ">.1</acs.version.label>")
     else:
         logger.debug(f"Setting acs.version.label comment to {ver} in {project}")
-        update_line(text, f"<acs.version.label", "/> <!-- {ver}.<acs.version.label> -->")
+        update_line(text, "<acs.version.label", f"/> <!-- {ver}.<acs.version.label> -->")
 
     save_file(filename, text)
     switch_dir('root')

--- a/scripts/dev/newReleaseBranch.py
+++ b/scripts/dev/newReleaseBranch.py
@@ -3,6 +3,7 @@
 # Run the script without passing any arguments or with -h/--help argument to get usage information.
 # When the script is run with indicating that next version is a major bump (-r/--release version major is lowera than -n/--next_dev version major)
 # then HF and SP branches get created. Otherwise (no major version bump), only HF branches are created.
+# Script can also create release branches ahead of release so that master/main branches do not need to get the code frozem (-a/--ahead argument is passed)
 # See below script behaviour explained.
 #######################################
 # Create HotFix branches for the released version (for X.Y.Z release it will be release/X.Y.N eg., create release/23.2.N for 23.2.0 release)
@@ -91,6 +92,10 @@
 # - set scm-tag in main POM to HEAD
 # - set comm-repo dependency in main POM to <next_development_version>.1 or X.Y+1.0.1 (if <next_development_version> not passed)
 # - set comm-share dependency in main POM to <next_development_version>.1 or X.Y+1.0.1 (if <next_development_version> not passed)
+#######################################
+# In case when release branches are to be created ahead of release (for X.Y.Z release it will be release/X.Y eg., create release/23.2 for 23.2.0 release)
+# In all 6 projects, branches are created from master branch without any additional changes.
+# Master branches are updated for the next SP/major release in a same way as in case of post release script execution (see above).
 #######################################
 
 # !/usr/bin/env python

--- a/scripts/dev/newReleaseBranch.py
+++ b/scripts/dev/newReleaseBranch.py
@@ -507,8 +507,10 @@ def update_project(project, version, branch_type):
     update_scm_tag('HEAD', project)
     next_dev_ver = get_next_dev_version(branch_type)
     if project == ACS_PACKAGING:
-        update_ci_yaml('master_release.yml', project, version + "-A1", next_dev_ver + "-A2-SNAPSHOT") if branch_type is not HOTFIX else (
-            update_ci_yaml('master_release.yml', project, version, increment_version(next_dev_ver, HOTFIX) + "-SNAPSHOT"))
+        if branch_type is not HOTFIX:
+            update_ci_yaml('master_release.yml', project, version + "-A1", next_dev_ver + "-A2-SNAPSHOT")
+        else:
+            update_ci_yaml('master_release.yml', project, version, increment_version(next_dev_ver, HOTFIX) + "-SNAPSHOT")
     elif project == ENTERPRISE_SHARE:
         update_acs_ver_pom_properties(project, version)
     elif project == ENTERPRISE_REPO:
@@ -518,8 +520,10 @@ def update_project(project, version, branch_type):
         increment_schema(project, calculate_increment(release_version, next_dev_ver))
         set_ags_test_versions(project, version)
     elif project == COMMUNITY_PACKAGING:
-        update_ci_yaml('ci.yml', project, version + "-A1", next_dev_ver + "-A2-SNAPSHOT") if branch_type is not HOTFIX else (
-            update_ci_yaml('ci.yml', project, version, increment_version(next_dev_ver, HOTFIX) + "-SNAPSHOT"))
+        if branch_type is not HOTFIX:
+            update_ci_yaml('ci.yml', project, version + "-A1", next_dev_ver + "-A2-SNAPSHOT")
+        else:
+            update_ci_yaml('ci.yml', project, version, increment_version(next_dev_ver, HOTFIX) + "-SNAPSHOT")
         update_acs_comm_pck_dependencies(branch_type, project)
 
 

--- a/scripts/dev/newReleaseBranch.py
+++ b/scripts/dev/newReleaseBranch.py
@@ -243,7 +243,7 @@ def set_ags_test_versions(project, version):
 
     logger.debug("Updating versions to %s in version.properties file in %s" % (version, project))
     major_key = "version.major="
-    update_line(text, major_key, version.spli(".")[0])
+    update_line(text, major_key, version.split(".")[0])
     minor_key = "version.minor="
     update_line(text, minor_key, version.split(".")[1])
     revision_key = "version.revision="

--- a/scripts/dev/newReleaseBranch.py
+++ b/scripts/dev/newReleaseBranch.py
@@ -89,12 +89,12 @@ def increment_version(rel_ver, branch_type):
 
 
 def get_next_dev_version(type):
-    if next_dev_version is None:
-        logger.debug("Getting next dev version. Incrementing released %s for %s" % (release_version, type))
-        return increment_version(release_version, type)
-    else:
+    if next_dev_version:
         logger.debug("Getting next dev version from input parameter (%s)" % next_dev_version)
         return next_dev_version
+    else:
+        logger.debug("Getting next dev version. Incrementing released %s for %s" % (release_version, type))
+        return increment_version(release_version, type)
 
 
 def switch_dir(project):

--- a/scripts/dev/newReleaseBranch.py
+++ b/scripts/dev/newReleaseBranch.py
@@ -383,9 +383,8 @@ def modify_master_branches():
         project = PROJECTS[i]
         log_progress(project, "Updating master for next release")
         next_dev_ver = get_next_dev_version(SERVICE_PACK)
-        version = increment_version(next_dev_ver, SERVICE_PACK)
         checkout_branch(project, 'master')
-        update_project(project, version, SERVICE_PACK)
+        update_project(project, next_dev_ver, SERVICE_PACK)
         commit_and_push(project, "Updating master branch to %s after %s ACS release [skip ci]" % (next_dev_ver, release_version))
 
 

--- a/scripts/dev/newReleaseBranch.py
+++ b/scripts/dev/newReleaseBranch.py
@@ -170,8 +170,8 @@ def update_ci_yaml(filename, project, rel_version, dev_version):
 
     if text:
         logger.debug("Setting RELEASE_VERSION, DEVELOPMENT_VERSION (%s, %s) in %s ci.yml" % (rel_version, dev_version, project))
-        update_line(text, release_version_match, rel_version + "-A1")
-        update_line(text, development_version_match, dev_version + "-A1-SNAPSHOT")
+        update_line(text, release_version_match, rel_version)
+        update_line(text, development_version_match, dev_version)
         with open(filename, 'w') as file:
             file.writelines(text)
 
@@ -344,7 +344,8 @@ def update_project(project, version, branch_type):
     update_scm_tag('HEAD', project)
     next_dev_ver = get_next_dev_version(branch_type)
     if project == ACS_PACKAGING:
-        update_ci_yaml(YAML_DICT.get(project), project, version, next_dev_ver)
+        update_ci_yaml(YAML_DICT.get(project), project, version, next_dev_ver) if branch_type == SERVICE_PACK else update_ci_yaml(
+            YAML_DICT.get(project), project, version + "-A1", next_dev_ver + "-A1-SNAPSHOT")
     elif project == ENTERPRISE_SHARE:
         update_acs_ver_pom_properties(project, version)
     elif project == ENTERPRISE_REPO:

--- a/scripts/dev/newReleaseBranch.py
+++ b/scripts/dev/newReleaseBranch.py
@@ -382,9 +382,9 @@ def update_project(project, version, branch_type):
         increment_schema(project, calculate_increment(version, next_dev_ver))
         set_ags_test_versions(project, version)
     elif project == COMMUNITY_PACKAGING:
-        update_ci_yaml(YAML_DICT.get(project), project, version, next_dev_ver)
         update_ci_yaml(YAML_DICT.get(project), project, version, next_dev_ver) if branch_type == SERVICE_PACK else update_ci_yaml(
             YAML_DICT.get(project), project, version + "-A1", next_dev_ver + "-A1-SNAPSHOT")
+        update_acs_comm_pck_dependencies(branch_type, project)
 
 
 def log_progress(project, message):


### PR DESCRIPTION
This python script mimics the behavior of the shell script we used for new branch creation after ACS release but it is adjusted to new ACS versioning schema. 
Additionally, script gives opportunity to create release branches before the release is done so that we don't need to freeze the code. 
It is written in python mostly because it gives more control of processing output and error handling.
As I have revisited python after many years, I am open to any suggestions.