### PR TITLE
ACS-6650 Avoid running SAST scan on DependaBot PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,7 @@ jobs:
     runs-on: ubuntu-latest
     if: >
       (github.ref_name == 'master' || startsWith(github.ref_name, 'release/') || github.event_name == 'pull_request') &&
+      github.actor != 'dependabot[bot]' &&
       !contains(github.event.head_commit.message, '[skip tests]')
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Skipping SAST scan on DependaBot PRs as it won't provide any additional insights and requires sharing more secrets with DependaBot than we're willing to.