### PR TITLE
Fix JIRA integration unable to identify current train

### DIFF
--- a/scripts/ci/jira/jira_integration.py
+++ b/scripts/ci/jira/jira_integration.py
@@ -171,7 +171,7 @@ def whether_create_issue():
 
 def set_current_release():
     """Set current release name. """
-    sql_query = 'project = "OPSEXP" AND type = "Epic" AND status IN ("Open","In Progress") ORDER BY created DESC'
+    sql_query = 'project = "OPSEXP" AND status IN ("Open","In Progress") ORDER BY created DESC'
     output = jira.jql(sql_query)
     epics = output['issues']
     release_trains = []


### PR DESCRIPTION
Relaxing the filter to guess the current train as sometimes there are no Epics to pick from, but Stories/Tasks/Sub-tasks instead may be available.

**Tested here:** https://github.com/Alfresco/acs-packaging/actions/runs/8111459674/job/22171289846 ✅ 