### PR TITLE
ACS-7513 Increase CMIS (BROWSER binding) / CMIS (ATOM binding) TAS tests timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,17 +155,17 @@ jobs:
             pom-dir: tests/tas-cmis
             profiles: all-tas-tests,run-cmis-browser
             compose-file: docker-compose-cmis-tests.yml
-            deploy-timeout: 40
+            deploy-timeout: 60
           - testSuite: CMIS (ATOM binding)
             pom-dir: tests/tas-cmis
             profiles: all-tas-tests,run-cmis-atom
             compose-file: docker-compose-cmis-tests.yml
-            deploy-timeout: 40
+            deploy-timeout: 60
           - testSuite: CMIS (WEBSERVICES binding)
             pom-dir: tests/tas-cmis
             profiles: all-tas-tests,run-cmis-webservices
             compose-file: docker-compose-cmis-tests.yml
-            deploy-timeout: 40
+            deploy-timeout: 60
           - testSuite: Email
             pom-dir: tests/tas-email
             profiles: all-tas-tests


### PR DESCRIPTION
To avoid CMIS (BROWSER binding) / CMIS (ATOM binding) TAS tests timeouts there is a need to increate timeout to 1h. 