### PR TITLE
ACS-7712 Bump S3 connector to 5.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
         <alfresco.rm-enterprise-rest-api-explorer.version>3.0.2</alfresco.rm-enterprise-rest-api-explorer.version>
 
-        <alfresco.s3connector.version>5.0.0</alfresco.s3connector.version>
+        <alfresco.s3connector.version>5.1.0</alfresco.s3connector.version>
         <alfresco.azure-connector.version>3.0.0</alfresco.azure-connector.version>
 
         <alfresco.salesforce-connector.version>2.3.4</alfresco.salesforce-connector.version>


### PR DESCRIPTION
As per title, bumping the S3 connector version for tests so that we can better guarantee compatibility with 5.1.0.

Also verified compatibility in the S3 connector repository via https://github.com/Alfresco/alfresco-s3-connector/actions/runs/8986658359 ✅ 