### PR TITLE
ACS-8279 Add a temporary fix for unsupported Docker Image Format/Manifest/Schema combinations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -299,6 +299,12 @@ jobs:
           persist-credentials: false
       - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.35.2
       - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.35.2
+      - name: "Re-enable support for legacy image formats in the daemon" # Temporary fix for unsupported Docker Image Format/Manifest Version/Schema combinations
+        run: |
+          sudo mkdir -p /etc/systemd/system/docker.service.d
+          sudo bash -c 'echo -e "[Service]\nEnvironment=\"DOCKER_ENABLE_DEPRECATED_PULL_SCHEMA_1_IMAGE=1\"" >> /etc/systemd/system/docker.service.d/deprecated-schema.conf'       
+          sudo systemctl daemon-reload
+          sudo systemctl restart docker
       - name: "Build"
         timeout-minutes: ${{ fromJSON(env.GITHUB_ACTIONS_DEPLOY_TIMEOUT) }}
         run: |
@@ -423,6 +429,12 @@ jobs:
           persist-credentials: false
       - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.35.2
       - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.35.2
+      - name: "Re-enable support for legacy image formats in the daemon" # Temporary fix for unsupported Docker Image Format/Manifest Version/Schema combinations
+        run: |
+          sudo mkdir -p /etc/systemd/system/docker.service.d
+          sudo bash -c 'echo -e "[Service]\nEnvironment=\"DOCKER_ENABLE_DEPRECATED_PULL_SCHEMA_1_IMAGE=1\"" >> /etc/systemd/system/docker.service.d/deprecated-schema.conf'       
+          sudo systemctl daemon-reload
+          sudo systemctl restart docker
       - name: "Build"
         timeout-minutes: ${{ fromJSON(env.GITHUB_ACTIONS_DEPLOY_TIMEOUT) }}
         run: |
@@ -459,6 +471,12 @@ jobs:
           persist-credentials: false
       - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.35.2
       - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.35.2
+      - name: "Re-enable support for legacy image formats in the daemon" # Temporary fix for unsupported Docker Image Format/Manifest Version/Schema combinations
+        run: |
+          sudo mkdir -p /etc/systemd/system/docker.service.d
+          sudo bash -c 'echo -e "[Service]\nEnvironment=\"DOCKER_ENABLE_DEPRECATED_PULL_SCHEMA_1_IMAGE=1\"" >> /etc/systemd/system/docker.service.d/deprecated-schema.conf'       
+          sudo systemctl daemon-reload
+          sudo systemctl restart docker
       - name: "Build"
         timeout-minutes: ${{ fromJSON(env.GITHUB_ACTIONS_DEPLOY_TIMEOUT) }}
         run: |


### PR DESCRIPTION
With the latest Docker 26.x, certain combinations of Docker Image Format/Manifest/Schema version have been deprecated: [Deprecated Engine Features](https://docs.docker.com/engine/deprecated/#pushing-and-pulling-with-image-manifest-v2-schema-1).
This PR is to add a temporary fix.