### PR TITLE
ACS-8360 Remove workaround for old docker images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -299,12 +299,6 @@ jobs:
           persist-credentials: false
       - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.35.2
       - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.35.2
-      - name: "Re-enable support for legacy image formats in the daemon" # Temporary fix for unsupported Docker Image Format/Manifest Version/Schema combinations
-        run: |
-          sudo mkdir -p /etc/systemd/system/docker.service.d
-          sudo bash -c 'echo -e "[Service]\nEnvironment=\"DOCKER_ENABLE_DEPRECATED_PULL_SCHEMA_1_IMAGE=1\"" >> /etc/systemd/system/docker.service.d/deprecated-schema.conf'       
-          sudo systemctl daemon-reload
-          sudo systemctl restart docker
       - name: "Build"
         timeout-minutes: ${{ fromJSON(env.GITHUB_ACTIONS_DEPLOY_TIMEOUT) }}
         run: |
@@ -429,12 +423,6 @@ jobs:
           persist-credentials: false
       - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.35.2
       - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.35.2
-      - name: "Re-enable support for legacy image formats in the daemon" # Temporary fix for unsupported Docker Image Format/Manifest Version/Schema combinations
-        run: |
-          sudo mkdir -p /etc/systemd/system/docker.service.d
-          sudo bash -c 'echo -e "[Service]\nEnvironment=\"DOCKER_ENABLE_DEPRECATED_PULL_SCHEMA_1_IMAGE=1\"" >> /etc/systemd/system/docker.service.d/deprecated-schema.conf'       
-          sudo systemctl daemon-reload
-          sudo systemctl restart docker
       - name: "Build"
         timeout-minutes: ${{ fromJSON(env.GITHUB_ACTIONS_DEPLOY_TIMEOUT) }}
         run: |
@@ -471,12 +459,6 @@ jobs:
           persist-credentials: false
       - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.35.2
       - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.35.2
-      - name: "Re-enable support for legacy image formats in the daemon" # Temporary fix for unsupported Docker Image Format/Manifest Version/Schema combinations
-        run: |
-          sudo mkdir -p /etc/systemd/system/docker.service.d
-          sudo bash -c 'echo -e "[Service]\nEnvironment=\"DOCKER_ENABLE_DEPRECATED_PULL_SCHEMA_1_IMAGE=1\"" >> /etc/systemd/system/docker.service.d/deprecated-schema.conf'       
-          sudo systemctl daemon-reload
-          sudo systemctl restart docker
       - name: "Build"
         timeout-minutes: ${{ fromJSON(env.GITHUB_ACTIONS_DEPLOY_TIMEOUT) }}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -459,6 +459,12 @@ jobs:
           persist-credentials: false
       - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.35.2
       - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.35.2
+      - name: "Re-enable support for legacy image formats in the daemon" # Temporary fix for unsupported Docker Image Format/Manifest Version/Schema combinations
+        run: |
+          sudo mkdir -p /etc/systemd/system/docker.service.d
+          sudo bash -c 'echo -e "[Service]\nEnvironment=\"DOCKER_ENABLE_DEPRECATED_PULL_SCHEMA_1_IMAGE=1\"" >> /etc/systemd/system/docker.service.d/deprecated-schema.conf'       
+          sudo systemctl daemon-reload
+          sudo systemctl restart docker
       - name: "Build"
         timeout-minutes: ${{ fromJSON(env.GITHUB_ACTIONS_DEPLOY_TIMEOUT) }}
         run: |


### PR DESCRIPTION
As the images for oracle-database have been rebuilt, we can remove the workaround that allowed to use old images