### PR TITLE
OPSEXP-2757 Fix AIMS tests after base Docker image bump

### DIFF
--- a/tests/environment/alfresco-with-jolokia/Dockerfile
+++ b/tests/environment/alfresco-with-jolokia/Dockerfile
@@ -5,7 +5,7 @@ ARG JOLOKIA_VER=1.6.2
 ARG TOMCAT_DIR=/usr/local/tomcat
 
 USER root
-RUN yum install -y curl unzip && \
+RUN yum install -y curl-minimal unzip && \
     mkdir -p /build/jolokia && \
     curl -o /build/jolokia-jee.war https://repo1.maven.org/maven2/org/jolokia/jolokia-war-unsecured/${JOLOKIA_VER}/jolokia-war-unsecured-${JOLOKIA_VER}.war && \
     ${TOMCAT_DIR}/bin/migrate.sh /build/jolokia-jee.war /build/jolokia.war && \


### PR DESCRIPTION
As per title, ref: https://github.com/Alfresco/alfresco-enterprise-repo/commit/6507a92f571d340a4cc43fa3caa294fc7a6df021

Failure on master: https://github.com/Alfresco/acs-packaging/actions/runs/10147799486/job/28059066955#step:8:605