### PR TITLE
ACS-8490 [release] ACS 23.3.0-A31 [skip tests]

### DIFF
--- a/.github/workflows/master_release.yml
+++ b/.github/workflows/master_release.yml
@@ -22,8 +22,8 @@ env:
   GITHUB_ACTIONS_DEPLOY_TIMEOUT: 60
   BASE_BUILD_NUMBER: 10000
     # Release version has to start with real version (23.2.0-....) for the docker image to build successfully.
-  RELEASE_VERSION: 23.3.0-A30
-  DEVELOPMENT_VERSION: 23.3.0-A31-SNAPSHOT
+  RELEASE_VERSION: 23.3.0-A31
+  DEVELOPMENT_VERSION: 23.3.0-A32-SNAPSHOT
 
 jobs:
   run_ci:


### PR DESCRIPTION
As per title, waiting for https://github.com/Alfresco/alfresco-enterprise-share/actions/runs/10181534940/job/28163060119 to complete before merging.