### PR TITLE
[ACS-9108] Bumped python version 3.7.15 -> 3.8.12 due to https://github.com/onnx/tensorflow-onnx/pull/2376 (#3014)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ env:
   TAS_SCRIPTS: ../alfresco-community-repo/packaging/tests/scripts
   ALF_LICENCE_S3_PATH: s3://acs-license/acs/alf23-allenabled.lic
   ALF_LICENCE_LOCAL_PATH: /tmp/licence.lic
-  PYTHON_VERSION: 3.7.15
+  PYTHON_VERSION: 3.8.12
   DTAS_VERSION: v1.5.5
 
 jobs:


### PR DESCRIPTION
(cherry picked from commit 846a176bca5c3b99e7030a1bee430f810dc6c443)