### PR TITLE
PRODSEC-10029 - to bumping apache camel and netty to latest safe compatible version

### DIFF
--- a/.ci.settings.xml
+++ b/.ci.settings.xml
@@ -7,6 +7,14 @@
             </activation>
             <repositories>
                 <repository>
+                    <releases>
+                        <enabled>true</enabled>
+                    </releases>
+                    <id>central</id>
+                    <name>Maven Central</name>
+                    <url>https://repo.maven.apache.org/maven2</url>
+                </repository>
+                <repository>
                     <id>alfresco-internal</id>
                     <releases>
                         <enabled>true</enabled>

--- a/pom.xml
+++ b/pom.xml
@@ -10,11 +10,11 @@
         <groupId>org.alfresco</groupId>
         <artifactId>alfresco-enterprise-repo</artifactId>
         <relativePath>../alfresco-enterprise-repo/pom.xml</relativePath>
-        <version>23.4.1.5</version>
+        <version>23.4.1.6-SNAPSHOT</version>
     </parent>
 
     <properties>
-        <dependency.alfresco-enterprise-repo.version>23.4.1.5</dependency.alfresco-enterprise-repo.version>
+        <dependency.alfresco-enterprise-repo.version>23.4.1.6-SNAPSHOT</dependency.alfresco-enterprise-repo.version>
         <dependency.alfresco-enterprise-share.version>23.4.1.2</dependency.alfresco-enterprise-share.version>
 
         <alfresco.rm-enterprise-rest-api-explorer.version>3.0.2</alfresco.rm-enterprise-rest-api-explorer.version>


### PR DESCRIPTION
Bumps dependency.camel.version from 4.6.0 to 4.10.2
Bumps dependency.netty.version from 4.1.117.Final to 4.1.118.Final