### PR TITLE
[MNT-24358] removing check of deleted files in test

### DIFF
--- a/tests/tas-distribution-zip/src/test/java/org/alfresco/distribution/CheckDistributionZipContents.java
+++ b/tests/tas-distribution-zip/src/test/java/org/alfresco/distribution/CheckDistributionZipContents.java
@@ -61,8 +61,6 @@ public class CheckDistributionZipContents
             assertThat(zipEntries).contains(
                     "keystore/metadata-keystore/keystore-passwords.properties",
                     "keystore/metadata-keystore/keystore",
-                    "keystore/generate_keystores.bat",
-                    "keystore/generate_keystores.sh",
                     "bin/alfresco-mmt.jar",
                     "bin/apply_amps.bat",
                     "bin/apply_amps.sh",


### PR DESCRIPTION
As part of [MNT-24358], generate_keystores.bat and generate_keystores.sh were deleted because they were outdated config. Hence removing checks of both file from CheckDistributionZipContents.java which is leading to failure in CI.

[MNT-24358]: https://hyland.atlassian.net/browse/MNT-24358?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ