### PR TITLE
ACS-9459 Bump ES Connector to 5.1.0-A.1

### DIFF
--- a/tests/tas-elasticsearch/pom.xml
+++ b/tests/tas-elasticsearch/pom.xml
@@ -99,6 +99,7 @@
       <groupId>org.opensearch.client</groupId>
       <artifactId>opensearch-java</artifactId>
       <version>${dependency.opensearch.version}</version>
+      <scope>test</scope>
       <exclusions>
         <exclusion>
           <groupId>org.eclipse</groupId>

--- a/tests/tas-elasticsearch/pom.xml
+++ b/tests/tas-elasticsearch/pom.xml
@@ -96,14 +96,13 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.alfresco</groupId>
-      <artifactId>alfresco-elasticsearch-shared</artifactId>
-      <version>${dependency.elasticsearch-shared.version}</version>
-      <scope>test</scope>
+      <groupId>org.opensearch.client</groupId>
+      <artifactId>opensearch-java</artifactId>
+      <version>${dependency.opensearch.version}</version>
       <exclusions>
         <exclusion>
-            <groupId>org.eclipse</groupId>
-            <artifactId>yasson</artifactId>
+          <groupId>org.eclipse</groupId>
+          <artifactId>yasson</artifactId>
         </exclusion>
       </exclusions>
     </dependency>


### PR DESCRIPTION
Fixed dependencies related to elasticsearch-shared library changes. 
More information in ticket: https://hyland.atlassian.net/browse/ACS-9621