### PR TITLE
MNT-25349 : Update test case to support async update for repositoryNodesCount

### DIFF
--- a/tests/environment/ldap-container/Dockerfile
+++ b/tests/environment/ldap-container/Dockerfile
@@ -1,4 +1,4 @@
-FROM osixia/openldap:1.1.5
+FROM osixia/openldap:1.5.0
 
 ADD importData.ldif /importData.ldif
 ADD startup.sh /container/service/slapd/startup.sh

--- a/tests/environment/ldap-container/default.yaml.startup
+++ b/tests/environment/ldap-container/default.yaml.startup
@@ -19,7 +19,7 @@ LDAP_READONLY_USER_USERNAME: readonly
 LDAP_READONLY_USER_PASSWORD: readonly
 
 # Backend
-LDAP_BACKEND: hdb
+LDAP_BACKEND: mdb
 
 # Tls
 LDAP_TLS: true

--- a/tests/tas-elasticsearch/src/test/java/org/alfresco/elasticsearch/ElasticsearchAdminConsoleTests.java
+++ b/tests/tas-elasticsearch/src/test/java/org/alfresco/elasticsearch/ElasticsearchAdminConsoleTests.java
@@ -5,6 +5,7 @@ import static java.util.Arrays.asList;
 import static org.springframework.http.HttpMethod.GET;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 
 import java.util.List;
 import java.util.UUID;
@@ -47,6 +48,8 @@ public class ElasticsearchAdminConsoleTests extends AbstractTestNGSpringContextT
 {
     private static final String ADMIN_CONSOLE_URL = "/alfresco/s/enterprise/admin/admin-searchservice";
     private static final String FILE_NAME = "ElasticsearchAdminConsoleTests_" + UUID.randomUUID() + ".txt";
+    private static final String UNAVAILABLE = "Unavailable";
+    private static final long CACHE_EXPIRY_MS = 65000;
 
     @Autowired
     public DataUser dataUser;
@@ -82,6 +85,14 @@ public class ElasticsearchAdminConsoleTests extends AbstractTestNGSpringContextT
 
     /**
      * Check the "elasticsearch" subsystem is selected and that the creation of a new document is reflected in the document counts.
+     * <p>
+     * The repository nodes count (indexable documents) is computed asynchronously:
+     * <ul>
+     * <li>First page load returns "Unavailable" and triggers a background DB query.</li>
+     * <li>Subsequent refresh shows the computed count (cached for ~60 seconds).</li>
+     * <li>After cache expiry, the next refresh serves the stale cached value and triggers a new background DB query.</li>
+     * <li>The following refresh shows the updated count.</li>
+     * </ul>
      */
     @TestRail(section = TestGroup.SEARCH,
             executionType = ExecutionType.REGRESSION,
@@ -97,22 +108,105 @@ public class ElasticsearchAdminConsoleTests extends AbstractTestNGSpringContextT
                 "Expected elasticsearch subsystem to be shown as selected.");
         assertFalse(document.select("#elasticsearchSearch").hasClass("hidden"), "Expected elasticsearch section to be displayed.");
 
-        Step.STEP("Get the number of indexed and indexable documents.");
-        int indexedDocs = Integer.valueOf(document.select("#elasticsearchDocumentCount span.value").text());
-        int indexableDocs = Integer.valueOf(document.select("#repositoryNodesCount span.value").text());
+        Step.STEP("Verify that repository nodes count is 'Unavailable' or numeric on first load.");
+        String initialRepoNodesText = document.select("#repositoryNodesCount span.value").text();
+        assertTrue(UNAVAILABLE.equals(initialRepoNodesText) || isNumeric(initialRepoNodesText),
+                "Expected repository nodes count to be '" + UNAVAILABLE + "' or a number, but got: '" + initialRepoNodesText + "'");
+
+        Step.STEP("Wait for repository nodes count to become available (async DB query).");
+        int indexableDocs = waitForNumericRepositoryNodesCount();
+
+        Step.STEP("Get the number of indexed documents (synchronous).");
+        document = loadSearchAdminPage();
+        int indexedDocs = parseCount(document.select("#elasticsearchDocumentCount span.value").text());
 
         Step.STEP("Create a document and wait for it to be indexed.");
         createDocumentAndEnsureIndexed(FILE_NAME);
 
-        Step.STEP("Refresh the admin console.");
+        Step.STEP("Wait for the cache to expire before refreshing.");
+        Thread.sleep(CACHE_EXPIRY_MS);
+
+        Step.STEP("Refresh page to trigger a new background DB query (still shows old cached value).");
+        loadSearchAdminPage();
+
+        Step.STEP("Wait for the updated repository nodes count to appear.");
+        int newIndexableDocs = waitForRepositoryNodesCountGreaterThan(indexableDocs);
+
+        Step.STEP("Get the new indexed document count (synchronous).");
         document = loadSearchAdminPage();
-        Step.STEP("Get the new number of indexed and indexable documents.");
-        int newIndexedDocs = Integer.valueOf(document.select("#elasticsearchDocumentCount span.value").text());
-        int newIndexableDocs = Integer.valueOf(document.select("#repositoryNodesCount span.value").text());
+        int newIndexedDocs = parseCount(document.select("#elasticsearchDocumentCount span.value").text());
 
         Step.STEP("Check the document counts have each been increased by one.");
         assertEquals(newIndexedDocs, indexedDocs + 1, "Expected the number of indexed documents to increase by one.");
         assertEquals(newIndexableDocs, indexableDocs + 1, "Expected the number of indexable documents to increase by one.");
+    }
+
+    /**
+     * Poll the admin console until the repository nodes count becomes a numeric value.
+     */
+    private int waitForNumericRepositoryNodesCount() throws Exception
+    {
+        final int[] result = new int[1];
+        Utility.sleep(1000, 60000, () -> {
+            Document doc = loadSearchAdminPage();
+            String text = doc.select("#repositoryNodesCount span.value").text();
+            if (!isNumeric(text))
+            {
+                throw new AssertionError("Repository nodes count is not yet available: '" + text + "'");
+            }
+            result[0] = parseCount(text);
+        });
+        return result[0];
+    }
+
+    /**
+     * Poll the admin console until the repository nodes count is greater than the given baseline.
+     */
+    private int waitForRepositoryNodesCountGreaterThan(int baseline) throws Exception
+    {
+        final int[] result = new int[1];
+        Utility.sleep(1000, 60000, () -> {
+            Document doc = loadSearchAdminPage();
+            String text = doc.select("#repositoryNodesCount span.value").text();
+            if (!isNumeric(text))
+            {
+                throw new AssertionError("Repository nodes count is not yet available: '" + text + "'");
+            }
+            int count = parseCount(text);
+            if (count <= baseline)
+            {
+                throw new AssertionError("Repository nodes count has not yet updated: " + count + " (baseline: " + baseline + ")");
+            }
+            result[0] = count;
+        });
+        return result[0];
+    }
+
+    private boolean isNumeric(String text)
+    {
+        String normalized = text.replace("\u00A0", "").replaceAll("[,\\s]", "").trim();
+        if (normalized.isEmpty())
+        {
+            return false;
+        }
+        return normalized.chars().allMatch(Character::isDigit);
+    }
+
+    private int parseCount(String text)
+    {
+        String normalized = text.replace("\u00A0", "").replaceAll("[,\\s]", "").trim();
+        if (normalized.isEmpty())
+        {
+            throw new AssertionError("Expected a numeric count but got empty/blank text: '" + text + "'");
+        }
+        try
+        {
+            return Integer.parseInt(normalized);
+        }
+        catch (NumberFormatException e)
+        {
+            throw new AssertionError("Expected a numeric count but got: '" + text + "'", e);
+        }
     }
 
     /**

--- a/tests/tas-elasticsearch/src/test/java/org/alfresco/elasticsearch/ElasticsearchAdminConsoleTests.java
+++ b/tests/tas-elasticsearch/src/test/java/org/alfresco/elasticsearch/ElasticsearchAdminConsoleTests.java
@@ -109,7 +109,7 @@ public class ElasticsearchAdminConsoleTests extends AbstractTestNGSpringContextT
         assertFalse(document.select("#elasticsearchSearch").hasClass("hidden"), "Expected elasticsearch section to be displayed.");
 
         Step.STEP("Verify that repository nodes count is 'Unavailable' or numeric on first load.");
-        String initialRepoNodesText = document.select("#repositoryNodesCount span.value").text().replace("\u00A0", "").trim();
+        String initialRepoNodesText = document.select("#repositoryNodesCount span.value").text();
         assertTrue(UNAVAILABLE.equals(initialRepoNodesText) || isNumeric(initialRepoNodesText),
                 "Expected repository nodes count to be '" + UNAVAILABLE + "' or a number, but got: '" + initialRepoNodesText + "'");
 
@@ -187,7 +187,7 @@ public class ElasticsearchAdminConsoleTests extends AbstractTestNGSpringContextT
     private boolean isNumeric(String text)
     {
         String normalized = text.replace("\u00A0", "").replaceAll("[,\\s]", "").trim();
-        return !normalized.isEmpty() && normalized.chars().allMatch(Character::isDigit);
+        return !normalized.isEmpty() && normalized.chars().allMatch(ch -> ch >= '0' && ch <= '9');
     }
 
     private int parseCount(String text)

--- a/tests/tas-elasticsearch/src/test/java/org/alfresco/elasticsearch/ElasticsearchAdminConsoleTests.java
+++ b/tests/tas-elasticsearch/src/test/java/org/alfresco/elasticsearch/ElasticsearchAdminConsoleTests.java
@@ -49,7 +49,7 @@ public class ElasticsearchAdminConsoleTests extends AbstractTestNGSpringContextT
     private static final String ADMIN_CONSOLE_URL = "/alfresco/s/enterprise/admin/admin-searchservice";
     private static final String FILE_NAME = "ElasticsearchAdminConsoleTests_" + UUID.randomUUID() + ".txt";
     private static final String UNAVAILABLE = "Unavailable";
-    private static final long CACHE_EXPIRY_MS = 65000;
+    private static final long CACHE_EXPIRY_MS = 60000;
 
     @Autowired
     public DataUser dataUser;
@@ -109,7 +109,7 @@ public class ElasticsearchAdminConsoleTests extends AbstractTestNGSpringContextT
         assertFalse(document.select("#elasticsearchSearch").hasClass("hidden"), "Expected elasticsearch section to be displayed.");
 
         Step.STEP("Verify that repository nodes count is 'Unavailable' or numeric on first load.");
-        String initialRepoNodesText = document.select("#repositoryNodesCount span.value").text();
+        String initialRepoNodesText = document.select("#repositoryNodesCount span.value").text().replace("\u00A0", "").trim();
         assertTrue(UNAVAILABLE.equals(initialRepoNodesText) || isNumeric(initialRepoNodesText),
                 "Expected repository nodes count to be '" + UNAVAILABLE + "' or a number, but got: '" + initialRepoNodesText + "'");
 

--- a/tests/tas-elasticsearch/src/test/java/org/alfresco/elasticsearch/ElasticsearchAdminConsoleTests.java
+++ b/tests/tas-elasticsearch/src/test/java/org/alfresco/elasticsearch/ElasticsearchAdminConsoleTests.java
@@ -109,7 +109,7 @@ public class ElasticsearchAdminConsoleTests extends AbstractTestNGSpringContextT
         assertFalse(document.select("#elasticsearchSearch").hasClass("hidden"), "Expected elasticsearch section to be displayed.");
 
         Step.STEP("Verify that repository nodes count is 'Unavailable' or numeric on first load.");
-        String initialRepoNodesText = document.select("#repositoryNodesCount span.value").text();
+        String initialRepoNodesText = document.select("#repositoryNodesCount span.value").text().replace("\u00A0", " ").trim();
         assertTrue(UNAVAILABLE.equals(initialRepoNodesText) || isNumeric(initialRepoNodesText),
                 "Expected repository nodes count to be '" + UNAVAILABLE + "' or a number, but got: '" + initialRepoNodesText + "'");
 

--- a/tests/tas-elasticsearch/src/test/java/org/alfresco/elasticsearch/ElasticsearchAdminConsoleTests.java
+++ b/tests/tas-elasticsearch/src/test/java/org/alfresco/elasticsearch/ElasticsearchAdminConsoleTests.java
@@ -144,6 +144,7 @@ public class ElasticsearchAdminConsoleTests extends AbstractTestNGSpringContextT
     /**
      * Poll the admin console until the repository nodes count becomes a numeric value.
      */
+    @SuppressWarnings("PMD.SignatureDeclareThrowsException")
     private int waitForNumericRepositoryNodesCount() throws Exception
     {
         final int[] result = new int[1];
@@ -162,6 +163,7 @@ public class ElasticsearchAdminConsoleTests extends AbstractTestNGSpringContextT
     /**
      * Poll the admin console until the repository nodes count is greater than the given baseline.
      */
+    @SuppressWarnings("PMD.SignatureDeclareThrowsException")
     private int waitForRepositoryNodesCountGreaterThan(int baseline) throws Exception
     {
         final int[] result = new int[1];
@@ -185,11 +187,7 @@ public class ElasticsearchAdminConsoleTests extends AbstractTestNGSpringContextT
     private boolean isNumeric(String text)
     {
         String normalized = text.replace("\u00A0", "").replaceAll("[,\\s]", "").trim();
-        if (normalized.isEmpty())
-        {
-            return false;
-        }
-        return normalized.chars().allMatch(Character::isDigit);
+        return !normalized.isEmpty() && normalized.chars().allMatch(Character::isDigit);
     }
 
     private int parseCount(String text)
@@ -212,6 +210,7 @@ public class ElasticsearchAdminConsoleTests extends AbstractTestNGSpringContextT
     /**
      * Create a text document with the given file name and wait until we can query for it.
      */
+    @SuppressWarnings("PMD.SignatureDeclareThrowsException")
     private void createDocumentAndEnsureIndexed(String fileName) throws Exception
     {
         dataContent.usingUser(user).usingSite(siteModel)


### PR DESCRIPTION

# Update ElasticsearchAdminConsoleTests for async repository nodes count

## Summary

Updates `ElasticsearchAdminConsoleTests` to handle the asynchronous computation of `repositoryNodesCount` introduced in [alfresco-enterprise-repo#2926](https://github.com/Alfresco/alfresco-enterprise-repo/pull/2926).

## Background

The `repository.nodesCount` metric on the Admin Console Search Service page is now computed asynchronously via a background-refreshing cache (default TTL: 60 seconds). The previous test assumed this value was available synchronously on page load, causing a `NumberFormatException` when parsing the initial `"Unavailable"` string.

## Changes

- **Handle initial "Unavailable" state**: On first page load, the test now accepts either `"Unavailable"` or a numeric value for `repositoryNodesCount` (the cache may already be warm from `@BeforeClass` setup).
- **Poll until count becomes available**: Added `waitForNumericRepositoryNodesCount()` which retries page loads until the async DB query populates the cache.
- **Respect cache lifecycle for count updates**: After creating a new document, the test waits for the cache to expire (~60s), refreshes the page to trigger a new background DB query, then polls until the updated count appears.
- **Poll for count increase**: Added `waitForRepositoryNodesCountGreaterThan(baseline)` which retries until the repository nodes count exceeds the previously captured baseline.
- **Robust number parsing**: Added `parseCount()` and `isNumeric()` helpers that handle formatted numbers (commas, non-breaking spaces) and provide clear assertion messages on failure.
- **`elasticsearchDocumentCount` unchanged**: This value remains synchronous and is parsed immediately on page load as before.

## Test flow

```
1. Load admin page → assert elasticsearch subsystem selected
2. Assert repositoryNodesCount is "Unavailable" or numeric (tolerant)
3. Poll until repositoryNodesCount becomes numeric → capture baseline (indexableDocs)
4. Get elasticsearchDocumentCount immediately (sync) → capture baseline (indexedDocs)
5. Create document, wait for ES indexing
6. Thread.sleep(60s) — wait for cache to expire
7. Refresh page → triggers new background DB query (serves stale cached value)
8. Poll until repositoryNodesCount > baseline → capture newIndexableDocs
9. Get elasticsearchDocumentCount (sync) → capture newIndexedDocs
10. Assert both counts increased by 1
```

## Related

- alfresco-enterprise-repo#2926 — Admin search service: async node count, query optimisation and deleted nodes count fix
