### PR TITLE
ACS-11434 Elasticsearch Support for community

### DIFF
--- a/tests/environment/.env
+++ b/tests/environment/.env
@@ -22,7 +22,7 @@ SHARE_TAG=26.2.0-A.4
 DIGITAL_WORKSPACE_TAG=7.3.0
 #By default the connector tag is set to the value of `dependency.elasticsearch-shared.version` maven property.
 #Following env variable allow you to override this value. It is useful for testing. It should be left blank on the main branch.
-ES_CONNECTOR_TAG=
+ES_CONNECTOR_TAG=5.7.0-A.1
 #For CMIS Elastic docker-compose - it is default value - it should be changed in before_script for different databases.
 CMIS_ALFRESCO_IMAGE=alfresco/alfresco-content-repository:${ALFRESCO_TAG}
 DATABASE_ENV_PROPERTIES="-Ddb.driver=org.postgresql.Driver -Ddb.username=alfresco -Ddb.password=alfresco -Ddb.url=jdbc:postgresql://database:5432/alfresco "


### PR DESCRIPTION
See https://github.com/Alfresco/alfresco-enterprise-repo/pull/2972

* Updated `ES_CONNECTOR_TAG` to `5.7.0-A.1` in `tests/environment/.env` to match the latest connector
For now, overriding `ES_CONNECTOR_TAG` , will revert it when `alfresco-elasticsearch-shared` module is public