### PR TITLE
ACS-11940 move help links to docs.hyland.com

### DIFF
--- a/distribution/src/main/resources/VERSIONS.md
+++ b/distribution/src/main/resources/VERSIONS.md
@@ -1,6 +1,6 @@
 # Component Versions
 
-This file lists the recommended components for this Service Pack. Use it along with the [Supported Platforms Matrix](https://support.hyland.com/access?dita:id=baq1719482911154&vrm_version=26.1) and the [Alfresco Documentation](https://support.hyland.com/access?dita:id=kho1719590768396&vrm_version=26.1) to apply selective component upgrades.
+This file lists the recommended components for this Service Pack. Use it along with the [Supported Platforms Matrix](https://docs.hyland.com/access?dita:id=baq1719482911154&vrm_version=26.1) and the [Alfresco Documentation](https://docs.hyland.com/access?dita:id=kho1719590768396&vrm_version=26.1) to apply selective component upgrades.
 
 #### Alfresco Content Services @project.version@
 

--- a/docs/create-custom-image-using-existing-docker-image.md
+++ b/docs/create-custom-image-using-existing-docker-image.md
@@ -126,7 +126,7 @@ alfresco-custom-image                            (Dir)
     │
     └───Dockerfile                              (File)
 ```
-* Generate keystore and truststore required for ssl and SAML. Additional information can be found under [alfresco documentation](https://docs.hyland.com/p/alfresco).
+* Generate keystore and truststore required for SSL and SAML. Additional information can be found under [Alfresco documentation](https://docs.hyland.com/p/alfresco).
 
 * Append the content of "share-config-custom.xml" from saml-distribution to the one used in the alfresco-share docker image (We append content manually because it is to big for a SED command).
 

--- a/docs/create-custom-image-using-existing-docker-image.md
+++ b/docs/create-custom-image-using-existing-docker-image.md
@@ -88,7 +88,7 @@ docker push customrepository/alfresco-custom-image:customTag
 ### Applying AMPs that require additional configuration (advanced)
 
 **Note:** We are going to use the alfresco-saml-distribution in order to install Alfresco-SAML-Module. This example is for testing purposes only! we are going to configure ssl using Tomcat on Linux. The recommended ways for a production environment are:
-- usage of a proxy see [Official Alfresco Documentation](https://docs.alfresco.com/5.2/tasks/configure-ssl-prod.html). 
+- usage of a proxy see [Official Alfresco Documentation](https://docs.hyland.com/r/Alfresco/Alfresco-Content-Services/26.1/Alfresco-Content-Services/Configure/Repository/Secure-Sockets-Layer-SSL-and-the-Repository/Configure-SSL-for-a-Production-Environment). 
 - using SSL termination at the K8s Ingress. 
 
 ### Steps:
@@ -126,7 +126,7 @@ alfresco-custom-image                            (Dir)
     │
     └───Dockerfile                              (File)
 ```
-* Generate keystore and truststore required for ssl and SAML. Additional information can be found under [alfresco documentation](https://docs.alfresco.com/).
+* Generate keystore and truststore required for ssl and SAML. Additional information can be found under [alfresco documentation](https://docs.hyland.com/p/alfresco).
 
 * Append the content of "share-config-custom.xml" from saml-distribution to the one used in the alfresco-share docker image (We append content manually because it is to big for a SED command).
 

--- a/docs/create-custom-image-using-existing-docker-image.md
+++ b/docs/create-custom-image-using-existing-docker-image.md
@@ -88,8 +88,8 @@ docker push customrepository/alfresco-custom-image:customTag
 ### Applying AMPs that require additional configuration (advanced)
 
 **Note:** We are going to use the alfresco-saml-distribution in order to install Alfresco-SAML-Module. This example is for testing purposes only! we are going to configure ssl using Tomcat on Linux. The recommended ways for a production environment are:
-- usage of a proxy see [Official Alfresco Documentation](https://docs.hyland.com/r/Alfresco/Alfresco-Content-Services/26.1/Alfresco-Content-Services/Configure/Repository/Secure-Sockets-Layer-SSL-and-the-Repository/Configure-SSL-for-a-Production-Environment). 
-- using SSL termination at the K8s Ingress. 
+- Use a proxy. See [Official Alfresco documentation](https://docs.hyland.com/r/Alfresco/Alfresco-Content-Services/26.1/Alfresco-Content-Services/Configure/Repository/Secure-Sockets-Layer-SSL-and-the-Repository/Configure-SSL-for-a-Production-Environment).
+- Use SSL termination at the K8s Ingress.
 
 ### Steps:
 * We are going to use the following folder and file structure:


### PR DESCRIPTION
This change depends on 

https://github.com/Alfresco/alfresco-server-root/pull/8  
https://github.com/Alfresco/alfresco-community-repo/pull/4220 
https://github.com/Alfresco/alfresco-enterprise-repo/pull/3075 
https://github.com/Alfresco/alfresco-enterprise-share/pull/1394  