### PR TITLE
Replace alfrescoPub-ubuntu2204-16G-4CPU runners with ubuntu-latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -351,7 +351,7 @@ jobs:
 
   tas_tests_search_api:
     name: ${{ matrix.testSuite }} | TAS tests (Search API)
-    runs-on: alfrescoPub-ubuntu2204-16G-4CPU
+    runs-on: ubuntu-latest
     needs: 
       - test_run_check
     if: needs.test_run_check.outputs.tests == 'true'
@@ -424,7 +424,7 @@ jobs:
 
   upgrade_tas_tests:
     name: ${{ matrix.testSuite }} Upgrade TAS tests
-    runs-on: alfrescoPub-ubuntu2204-16G-4CPU
+    runs-on: ubuntu-latest
     needs: 
       - test_run_check
     if: needs.test_run_check.outputs.tests == 'true'


### PR DESCRIPTION
Swaps out the custom `alfrescoPub-ubuntu2204-16G-4CPU` self-hosted runners for the standard `ubuntu-latest` GitHub-hosted runners in the CI workflow, they are equivalent and they are free for public repos.

## Changes

- `.github/workflows/ci.yml`: updated `runs-on` for `tas_tests_search_api` and `upgrade_tas_tests` jobs

Reopened from a `fix/*` branch, replacing #3529.