### PR TITLE
ACS-11940 bump documentation links to 26.2

### DIFF
--- a/distribution/src/main/resources/VERSIONS.md
+++ b/distribution/src/main/resources/VERSIONS.md
@@ -1,6 +1,6 @@
 # Component Versions
 
-This file lists the recommended components for this Service Pack. Use it along with the [Supported Platforms Matrix](https://docs.hyland.com/access?dita:id=baq1719482911154&vrm_version=26.1) and the [Alfresco Documentation](https://docs.hyland.com/access?dita:id=kho1719590768396&vrm_version=26.1) to apply selective component upgrades.
+This file lists the recommended components for this Service Pack. Use it along with the [Supported Platforms Matrix](https://docs.hyland.com/access?dita:id=baq1719482911154&vrm_version=26.2) and the [Alfresco Documentation](https://docs.hyland.com/access?dita:id=kho1719590768396&vrm_version=26.2) to apply selective component upgrades.
 
 #### Alfresco Content Services @project.version@
 

--- a/docs/create-custom-image-using-existing-docker-image.md
+++ b/docs/create-custom-image-using-existing-docker-image.md
@@ -88,7 +88,7 @@ docker push customrepository/alfresco-custom-image:customTag
 ### Applying AMPs that require additional configuration (advanced)
 
 **Note:** We are going to use the alfresco-saml-distribution in order to install Alfresco-SAML-Module. This example is for testing purposes only! we are going to configure ssl using Tomcat on Linux. The recommended ways for a production environment are:
-- Use a proxy. See [Official Alfresco documentation](https://docs.hyland.com/r/Alfresco/Alfresco-Content-Services/26.1/Alfresco-Content-Services/Configure/Repository/Secure-Sockets-Layer-SSL-and-the-Repository/Configure-SSL-for-a-Production-Environment).
+- Use a proxy. See [Official Alfresco documentation](https://docs.hyland.com/r/Alfresco/Alfresco-Content-Services/26.2/Alfresco-Content-Services/Configure/Repository/Secure-Sockets-Layer-SSL-and-the-Repository/Configure-SSL-for-a-Production-Environment).
 - Use SSL termination at the K8s Ingress.
 
 ### Steps:


### PR DESCRIPTION
Updates stale version to latest available on docs.hyland. See similar https://github.com/Alfresco/alfresco-community-repo/pull/4248