### PR TITLE
Please [skip tests] and [release] ACS 26.3.0-A.4

### DIFF
--- a/.github/workflows/master_release.yml
+++ b/.github/workflows/master_release.yml
@@ -21,8 +21,8 @@ env:
   GITHUB_ACTIONS_DEPLOY_TIMEOUT: 60
   BASE_BUILD_NUMBER: 10000
     # Release version has to start with real version (23.2.0-....) for the docker image to build successfully.
-  RELEASE_VERSION: 26.3.0-A.3
-  DEVELOPMENT_VERSION: 26.3.0-A.4-SNAPSHOT
+  RELEASE_VERSION: 26.3.0-A.4
+  DEVELOPMENT_VERSION: 26.3.0-A.5-SNAPSHOT
 
 jobs:
   commit_parser:


### PR DESCRIPTION
To release Alpha with documentation URL change and version bump to 26.2