### PR TITLE
[ACS-12297] Fix false positive conflict between com.google.android:annotations and software.amazon.awssdk:annotations

### DIFF
--- a/tests/scripts/checkLibraryDuplicates.sh
+++ b/tests/scripts/checkLibraryDuplicates.sh
@@ -22,10 +22,13 @@ fi
 for current_lib in $(ls "$lib_dir"); do
    if [[ "$current_lib" =~ [0-9]+.[0-9] ]]; then
        noversion_lib="${current_lib%%"$BASH_REMATCH"*}"
+       # Exact de-versioned library name (drop the trailing '-'/'_' separator before the version),
+       # so the whitelist matches a whole artifactId and not any name that merely contains it
+       lib_name="${noversion_lib%[-_]}"
 
        skip=false
        for exclude_lib in $WHITELIST; do
-           if [[ "$noversion_lib" =~ "$exclude_lib" ]]; then
+           if [[ "$lib_name" == "$exclude_lib" ]]; then
                skip=true
                break
            fi

--- a/tests/scripts/checkLibraryDuplicates.sh
+++ b/tests/scripts/checkLibraryDuplicates.sh
@@ -6,7 +6,10 @@
 # usually libraries with versions that don't follow naming/versioning standards.
 # e.g. geronimo-jms_2.0_spec-1.0-alpha-2.jar
 #      geronimo-jms_1.1_spec-1.1.1.jar
-WHITELIST="geronimo-jta netty-tcnative-boringssl-static"
+# 'annotations' is a false positive: this check compares file names only, so distinct artifacts that share the
+# same artifactId collide. software.amazon.awssdk:annotations (AWS SDK) and com.google.android:annotations
+# (transitive of google-cloud-storage) are different libraries, not two versions of the same one.
+WHITELIST="geronimo-jta netty-tcnative-boringssl-static annotations"
 
 lib_dir=$1
 multiple_version_lib_list=""


### PR DESCRIPTION
The duplicate-library check compares file names only, so distinct artifacts that share an artifactId collide. After moving the cloud SDKs from the connector AMPs into ACS, the platform WAR ships both **software.amazon.awssdk**:annotations:2.46.17 and **com.google.android**:annotations:4.1.1.4

https://github.com/Alfresco/acs-packaging/actions/runs/31386591194/job/93448349583
<img width="964" height="284" alt="Screenshot 2026-08-10 at 15 05 51" src="https://github.com/user-attachments/assets/fd100114-167a-4bba-8d94-9a946e00e5ed" />
