### PR TITLE
[ACS-11962]-Fix TAS aims failure

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,11 +10,11 @@
         <groupId>org.alfresco</groupId>
         <artifactId>alfresco-enterprise-repo</artifactId>
         <relativePath>../alfresco-enterprise-repo/pom.xml</relativePath>
-        <version>26.3.0.21</version>
+        <version>26.3.0.22-SNAPSHOT</version>
     </parent>
 
     <properties>
-        <dependency.alfresco-enterprise-repo.version>26.3.0.21</dependency.alfresco-enterprise-repo.version>
+        <dependency.alfresco-enterprise-repo.version>26.3.0.22-SNAPSHOT</dependency.alfresco-enterprise-repo.version>
         <dependency.alfresco-enterprise-share.version>26.3.0.20</dependency.alfresco-enterprise-share.version>
 
         <alfresco.rm-enterprise-rest-api-explorer.version>3.0.2</alfresco.rm-enterprise-rest-api-explorer.version>

--- a/pom.xml
+++ b/pom.xml
@@ -10,11 +10,11 @@
         <groupId>org.alfresco</groupId>
         <artifactId>alfresco-enterprise-repo</artifactId>
         <relativePath>../alfresco-enterprise-repo/pom.xml</relativePath>
-        <version>26.3.0.22-SNAPSHOT</version>
+        <version>26.3.0.21</version>
     </parent>
 
     <properties>
-        <dependency.alfresco-enterprise-repo.version>26.3.0.22-SNAPSHOT</dependency.alfresco-enterprise-repo.version>
+        <dependency.alfresco-enterprise-repo.version>26.3.0.21</dependency.alfresco-enterprise-repo.version>
         <dependency.alfresco-enterprise-share.version>26.3.0.20</dependency.alfresco-enterprise-share.version>
 
         <alfresco.rm-enterprise-rest-api-explorer.version>3.0.2</alfresco.rm-enterprise-rest-api-explorer.version>

--- a/tests/tas-restapi/src/test/resources/restapi-aims-suite.xml
+++ b/tests/tas-restapi/src/test/resources/restapi-aims-suite.xml
@@ -24,6 +24,13 @@
         <packages>
             <package name="org.alfresco.rest.*">
                 <exclude name="org.alfresco.rest.people.deauthorization.community.*"/>
+                <!-- ACS-11962: search tests migrated from Search Services require dedicated
+                     search backend env (Solr/ES) and are not tagged as sanity, so they are
+                     out of scope for the AIMS smoke suite -->
+                <exclude name="org.alfresco.rest.search"/>
+                <exclude name="org.alfresco.rest.search.crosslocale"/>
+                <exclude name="org.alfresco.rest.search.fingerprint"/>
+                <exclude name="org.alfresco.rest.search.tracker"/>
             </package>
         </packages>
 	</test>

--- a/tests/tas-restapi/src/test/resources/restapi-aims-suite.xml
+++ b/tests/tas-restapi/src/test/resources/restapi-aims-suite.xml
@@ -24,13 +24,10 @@
         <packages>
             <package name="org.alfresco.rest.*">
                 <exclude name="org.alfresco.rest.people.deauthorization.community.*"/>
-                <!-- ACS-11962: search tests migrated from Search Services require dedicated
+                <!-- ACS-11962: search tests migrated from Search Services require a dedicated
                      search backend env (Solr/ES) and are not tagged as sanity, so they are
-                     out of scope for the AIMS smoke suite -->
-                <exclude name="org.alfresco.rest.search"/>
-                <exclude name="org.alfresco.rest.search.crosslocale"/>
-                <exclude name="org.alfresco.rest.search.fingerprint"/>
-                <exclude name="org.alfresco.rest.search.tracker"/>
+                     out of scope for the AIMS sanity suite -->
+                <exclude name="org.alfresco.rest.search.*"/>
             </package>
         </packages>
 	</test>


### PR DESCRIPTION
This pull request makes a targeted update to the test suite configuration by excluding certain search-related test packages from the AIMS smoke suite. This ensures that only relevant tests are included in the suite, as the excluded tests require a dedicated search backend environment and are not tagged as sanity tests.

Test suite configuration updates:

* Excluded the following search-related packages from the `restapi-aims-suite.xml` test suite: `org.alfresco.rest.search`, `org.alfresco.rest.search.crosslocale`, `org.alfresco.rest.search.fingerprint`, and `org.alfresco.rest.search.tracker`, to align with environment requirements and suite scope.