### PR TITLE
Normalize line-ending checkout to LF instead of CRLF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,11 +1,2 @@
-.* eol=crlf
-*.html eol=crlf
-*.java eol=crlf
-*.txt eol=crlf
-*.css eol=crlf
-*.xml eol=crlf
-*.js eol=crlf
-*.properties eol=crlf
-# Shell scripts require LF
 *.sh text eol=lf
 Dockerfile text eol=lf


### PR DESCRIPTION
Started from https://github.com/Alfresco/alfresco-build-tools/pull/1512/changes#r3796545898

## Summary
- `.gitattributes` previously forced `eol=crlf` on most text files (dotfiles, `.html`, `.java`, `.txt`, `.css`, `.xml`, `.js`, `.properties`), a legacy convention from when contributors and CI mostly ran on Windows.
- The blobs stored in git are already LF-only (no CRLF ever actually made it into the repository content), so this only affected local checkout formatting.
- Reduced `.gitattributes` to just the two rules that actually matter: forcing `eol=lf` for `*.sh` and `Dockerfile`, since CRLF in either breaks execution on Linux/Docker regardless of the committer's local git config. Everything else now follows each contributor's local `core.autocrlf`/`core.eol`, which already resolves to LF on Linux/Mac (our CI and current dev environments) and native CRLF on Windows if desired.

## Test plan
- [x] Confirm CI passes with no change in build/test behavior
- [x] Confirm shell scripts and Dockerfiles still check out with LF endings