### PR TITLE
ACS-12103 - Add GCS sanity tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
 
         <alfresco.s3connector.version>8.0.1-A.7</alfresco.s3connector.version>
         <alfresco.azure-connector.version>6.0.0-A.1</alfresco.azure-connector.version>
+        <alfresco.gcsconnector.version>1.0.0-A.3</alfresco.gcsconnector.version>
         <alfresco.salesforce-connector.version>4.1.0</alfresco.salesforce-connector.version>
         <alfresco.outlook.version>3.1.0</alfresco.outlook.version>
         <alfresco.desktop-sync.version>5.3.6-A.1</alfresco.desktop-sync.version>

--- a/tests/pipeline-all-amps/repo/dtas/dtas-config.json
+++ b/tests/pipeline-all-amps/repo/dtas/dtas-config.json
@@ -52,6 +52,11 @@
                     "installed": true
                 },
                 {
+                    "id": "org_alfresco_integrations_GCSConnector",
+                    "version": "${alfresco.gcsconnector.version}",
+                    "installed": true
+                },
+                {
                     "id": "alfresco-ai-repo",
                     "version": "${alfresco.ais.version}",
                     "installed": true

--- a/tests/pipeline-all-amps/repo/pom.xml
+++ b/tests/pipeline-all-amps/repo/pom.xml
@@ -74,6 +74,14 @@
                                     <outputDirectory>${project.build.directory}/amps</outputDirectory>
                                 </artifactItem>
                                 <artifactItem>
+                                    <groupId>org.alfresco.integrations</groupId>
+                                    <artifactId>alfresco-gcs-connector</artifactId>
+                                    <version>${alfresco.gcsconnector.version}</version>
+                                    <type>amp</type>
+                                    <overWrite>false</overWrite>
+                                    <outputDirectory>${project.build.directory}/amps</outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
                                     <groupId>org.alfresco</groupId>
                                     <artifactId>alfresco-share-services</artifactId>
                                     <version>${dependency.alfresco-community-repo.version}</version>

--- a/tests/tas-all-amps/pom.xml
+++ b/tests/tas-all-amps/pom.xml
@@ -198,6 +198,14 @@
                                             <outputDirectory>${project.build.directory}/amps</outputDirectory>
                                         </artifactItem>
                                         <artifactItem>
+                                            <groupId>org.alfresco.integrations</groupId>
+                                            <artifactId>alfresco-gcs-connector</artifactId>
+                                            <version>${alfresco.gcsconnector.version}</version>
+                                            <type>amp</type>
+                                            <overWrite>false</overWrite>
+                                            <outputDirectory>${project.build.directory}/amps</outputDirectory>
+                                        </artifactItem>
+                                        <artifactItem>
                                             <groupId>org.alfresco</groupId>
                                             <artifactId>alfresco-ai-repo</artifactId>
                                             <version>${alfresco.ais.version}</version>

--- a/tests/tas-all-amps/src/test/java/org/alfresco/rest/discovery/DiscoveryTests.java
+++ b/tests/tas-all-amps/src/test/java/org/alfresco/rest/discovery/DiscoveryTests.java
@@ -74,6 +74,7 @@ public class DiscoveryTests extends RestTest
                 "alfresco-trashcan-cleaner",
                 "org_alfresco_integrations_S3Connector",
                 "org_alfresco_integrations_AzureConnector",
+                "org_alfresco_integrations_GCSConnector",
                 "alfresco-content-connector-for-salesforce-repo",
                 "alfresco-share-services",
                 "org_alfresco_device_sync_repo",


### PR DESCRIPTION
https://hyland.atlassian.net/browse/ACS-12103

### Implementation details:
Sanity tests have been added for the GCS connector to the packaging pipeline. The scope is - GCS AMP is bundled, installs, and coexists with all other AMPs without breaking startup. There is no functional tests (upload/download/DAU) were added, as those belong to the alfresco-gcs-connector project's Integration tests.

### Validation:
"All AMPs tests" is green (Tests run: 2, Failures: 0) with the alfresco-gcs-connector (1.0.0-A.3) (latest as of now). The package is downloaded from Nexus, installs, coexists, and is reported INSTALLED via the Discovery API.

Duplicate jar check was performed by `checkLibraryDuplicates.sh`:
```
2026-08-19T11:40:19.7564558Z Scanning libraries from ./tests/tas-all-amps/target/war/alfresco/WEB-INF/lib
2026-08-19T11:40:19.7565427Z Skipping libraries which match the whitelist, check for false positives:
2026-08-19T11:40:19.9218395Z Skip annotations-2.46.17.jar
2026-08-19T11:40:19.9219158Z Skip annotations-4.1.1.4.jar
2026-08-19T11:40:20.8191008Z Skip netty-tcnative-boringssl-static-2.0.81.Final-linux-aarch_64.jar
2026-08-19T11:40:20.8191916Z Skip netty-tcnative-boringssl-static-2.0.81.Final-linux-x86_64.jar
2026-08-19T11:40:20.8192491Z Skip netty-tcnative-boringssl-static-2.0.81.Final-osx-aarch_64.jar
2026-08-19T11:40:20.8193201Z Skip netty-tcnative-boringssl-static-2.0.81.Final-osx-x86_64.jar
2026-08-19T11:40:20.8193789Z Skip netty-tcnative-boringssl-static-2.0.81.Final-windows-x86_64.jar
2026-08-19T11:40:20.8194330Z Skip netty-tcnative-boringssl-static-2.0.81.Final.jar
2026-08-19T11:40:21.2349541Z [INFO] There are no duplicated libraries.
```
It has final result: “There are no duplicated libraries”.